### PR TITLE
Investigate DllImport usage and patterns

### DIFF
--- a/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml
+++ b/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml
@@ -13,7 +13,7 @@
                          Width="600"
                          MinWidth="500"
                          MinHeight="450"
-                         ResizeMode="CanResizeWithGrip"
+                         ResizeMode="CanResize"
                          Style="{DynamicResource DynamoWindowStyle}"
                          AllowsTransparency="True"
                          Background="Transparent"
@@ -457,6 +457,12 @@
                         </Grid>
                     </Border>
                 </Grid>
+                <ResizeGrip  x:Name="WindowResizeGrip"
+                            Grid.Row="4"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Bottom"
+                            Margin="0, 0, 2, 2"
+                            Cursor="SizeNWSE" PreviewMouseLeftButtonDown="WindowResizeGrip_OnPreviewMouseLeftButtonDown" />                
             </Grid>
         </Border>
     </Grid>

--- a/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml
+++ b/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml
@@ -457,12 +457,22 @@
                         </Grid>
                     </Border>
                 </Grid>
-                <ResizeGrip  x:Name="WindowResizeGrip"
-                            Grid.Row="4"
-                            HorizontalAlignment="Right"
-                            VerticalAlignment="Bottom"
-                            Margin="0, 0, 2, 2"
-                            Cursor="SizeNWSE" PreviewMouseLeftButtonDown="WindowResizeGrip_OnPreviewMouseLeftButtonDown" />                
+                <Border x:Name="WindowResizeGrip"
+                        Grid.Row="4"
+                        Width="18"
+                        Height="18"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Bottom"
+                        Margin="0,0,2,2"
+                        Background="Transparent"
+                        Cursor="SizeNWSE"
+                        PreviewMouseLeftButtonDown="WindowResizeGrip_OnPreviewMouseLeftButtonDown">
+                    <Canvas Width="18" Height="18">
+                        <Line X1="3" Y1="15" X2="15" Y2="3" Stroke="#747474" StrokeThickness="1" />
+                        <Line X1="7" Y1="17" X2="17" Y2="7" Stroke="#8C8C8C" StrokeThickness="1" />
+                        <Line X1="1" Y1="11" X2="11" Y2="1" Stroke="#5E5E5E" StrokeThickness="1" />
+                    </Canvas>
+                </Border>                
             </Grid>
         </Border>
     </Grid>

--- a/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml.cs
+++ b/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml.cs
+++ b/src/Libraries/PythonNodeModelsWpf/ScriptEditorWindow.xaml.cs
@@ -50,6 +50,12 @@ namespace PythonNodeModelsWpf
         // Reasonable max and min font size values for zooming limits
         private const double FONT_MAX_SIZE = 60d;
         private const double FONT_MIN_SIZE = 5d;
+        private const int WM_SYSCOMMAND = 0x0112;
+        private const int SC_SIZE = 0xF000;
+        private const int HTBOTTOMRIGHT = 0x0008;
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
 
         private const double pythonZoomScalingSliderMaximum = 300d;
         private const double pythonZoomScalingSliderMinimum = 25d;
@@ -798,5 +804,15 @@ namespace PythonNodeModelsWpf
             }
         }
         #endregion
+
+        private void WindowResizeGrip_OnPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (WindowState != WindowState.Normal)
+                return;
+
+            var helper = new WindowInteropHelper(this);
+            SendMessage(helper.Handle, WM_SYSCOMMAND, (IntPtr)(SC_SIZE + HTBOTTOMRIGHT), IntPtr.Zero);
+            e.Handled = true;
+        }
     }
 }


### PR DESCRIPTION
### Purpose

This PR addresses two issues:
1.  Resolves a compilation error where `DllImportAttribute` was not found by adding the necessary `using System.Runtime.InteropServices;` directive.
2.  Fixes a crash that occurred when maximizing the `ScriptEditorWindow`. The built-in `ResizeGrip` was causing a `System.Windows.Media.Visual.TrySimpleTransformToAncestor` exception in borderless windows. This has been replaced with a custom `Border` and `Canvas` implementation for the resize handle, which avoids the crash while maintaining functionality and visual style.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed a crash that occurred when maximizing the Python Script Editor window.

### Reviewers

(FILL ME IN)

### FYIs

The conversation leading to this fix also clarified the purpose of `[DllImport("user32.dll")]` and the `NoStyleWindowBorderStyle` style, confirming their appropriate usage within the Dynamo codebase.

---
<a href="https://cursor.com/background-agent?bcId=bc-252f038c-5182-4eb7-9893-a66cc31cd58a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-252f038c-5182-4eb7-9893-a66cc31cd58a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

