### PR TITLE
Fix nested python migration

### DIFF
--- a/src/DynamoCore/Migration/PythonEngineUpgradeService.cs
+++ b/src/DynamoCore/Migration/PythonEngineUpgradeService.cs
@@ -58,6 +58,85 @@ namespace Dynamo.Models.Migration.Python
             }
         }
 
+        private sealed class CustomNodeTraversalResult
+        {
+            internal HashSet<Guid> Reachable { get; } = new HashSet<Guid>();
+            internal HashSet<Guid> WithPython { get; } = new HashSet<Guid>();
+        }
+
+        private CustomNodeTraversalResult TraverseCustomNodeDependencies(
+            IEnumerable<Guid> rootDefIds,
+            Func<NodeModel, bool> isPythonNode)
+        {
+            var result = new CustomNodeTraversalResult();
+            var memo = new Dictionary<Guid, bool>();
+            var visiting = new HashSet<Guid>();
+
+            if (rootDefIds == null) return result;
+
+            foreach (var defId in rootDefIds)
+            {
+                TraverseCustomNode(defId, isPythonNode, result, memo, visiting);
+            }
+
+            return result;
+        }
+
+        private bool TraverseCustomNode(
+            Guid defId,
+            Func<NodeModel, bool> isPythonNode,
+            CustomNodeTraversalResult result,
+            IDictionary<Guid, bool> memo,
+            ISet<Guid> visiting)
+        {
+            if (defId == Guid.Empty) return false;
+
+            result.Reachable.Add(defId);
+
+            if (memo.TryGetValue(defId, out var cached))
+            {
+                return cached;
+            }
+
+            if (!visiting.Add(defId))
+            {
+                return false;
+            }
+
+            var workspace = workspaceResolver?.Invoke(defId) as WorkspaceModel;
+            if (workspace == null)
+            {
+                visiting.Remove(defId);
+                memo[defId] = false;
+                return false;
+            }
+
+            bool hasPython = workspace.Nodes?.Any(isPythonNode) == true;
+
+            var nestedIds = workspace.Nodes?
+                .OfType<Dynamo.Graph.Nodes.CustomNodes.Function>()
+                .Select(func => func.Definition?.FunctionId ?? Guid.Empty)
+                .Where(id => id != Guid.Empty)
+                .ToList() ?? new List<Guid>();
+
+            foreach (var nestedId in nestedIds)
+            {
+                if (TraverseCustomNode(nestedId, isPythonNode, result, memo, visiting))
+                {
+                    hasPython = true;
+                }
+            }
+
+            if (hasPython)
+            {
+                result.WithPython.Add(defId);
+            }
+
+            visiting.Remove(defId);
+            memo[defId] = hasPython;
+            return hasPython;
+        }
+
         /// <summary>
         /// Attempts to retrieve the custom node workspace associated with the specified function identifier from the
         /// given Dynamo model.
@@ -84,19 +163,22 @@ namespace Dynamo.Models.Migration.Python
             if (isPythonNode == null) throw new ArgumentNullException(nameof(isPythonNode));
 
             // Direct python nodes
-            var directNodes = workspace.Nodes.Where(isPythonNode).ToList();            
+            var directNodes = workspace.Nodes.Where(isPythonNode).ToList();
 
-            // Custom nodes that contain python
-            var customDefIds = new HashSet<Guid>();
-            foreach (var func in workspace.Nodes.OfType<Dynamo.Graph.Nodes.CustomNodes.Function>())
+            // Custom nodes that contain python (directly or through nesting)
+            var rootCustomNodeIds = workspace.Nodes
+                .OfType<Dynamo.Graph.Nodes.CustomNodes.Function>()
+                .Select(func => func.Definition?.FunctionId ?? Guid.Empty)
+                .Where(id => id != Guid.Empty)
+                .ToList();
+
+            var traversal = TraverseCustomNodeDependencies(rootCustomNodeIds, isPythonNode);
+
+            var customDefIds = new HashSet<Guid>(traversal.WithPython);
+
+            foreach (var migratedId in TempMigratedCustomDefs.Where(traversal.Reachable.Contains))
             {
-                var defId = func.Definition?.FunctionId ?? Guid.Empty;
-                if (defId == Guid.Empty) continue;
-
-                if (CustomNodeHasPython(defId, isPythonNode) || TempMigratedCustomDefs.Contains(defId))
-                {
-                    customDefIds.Add(defId);
-                }
+                customDefIds.Add(migratedId);
             }
 
             return new Usage(workspace, directNodes, customDefIds.ToList());
@@ -135,8 +217,10 @@ namespace Dynamo.Models.Migration.Python
 
             if (activeDefIds.Count == 0) return;
 
+            var reachableDefs = TraverseCustomNodeDependencies(activeDefIds, _ => false).Reachable;
+
             var defToCommit = TempMigratedCustomDefs
-                .Where(id => activeDefIds.Contains(id))
+                .Where(reachableDefs.Contains)
                 .ToList();
 
             if (defToCommit.Count == 0) return;
@@ -276,12 +360,5 @@ namespace Dynamo.Models.Migration.Python
             return new string(name.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray());
         }
 
-        private bool CustomNodeHasPython(Guid defId, Func<NodeModel, bool> isPythonNode)
-        {
-            if (dynamoModel?.CustomNodeManager == null) return false;
-
-            var cws = this.TryGetFunctionWorkspace(dynamoModel, defId) as CustomNodeWorkspaceModel;
-            return cws?.Nodes != null && cws.Nodes.Any(isPythonNode) == true;
-        }
     }
 }

--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -178,17 +178,30 @@ namespace Dynamo.PythonMigration
                     {
                         var usageInside = upgradeService.DetectPythonUsage(workspace, IsCPythonNode);
 
+                        var upgradedDefs = new HashSet<Guid>();
+                        var visitedDefs = new HashSet<Guid> { defId };
+
                         if (usageInside.DirectPythonNodes.Any())
                         {
                             // Track this def as temp-migrated for the session
                             upgradeService.TempMigratedCustomDefs.Add(defId);
 
-                            var count = upgradeService.UpgradeNodesInMemory(
+                            upgradeService.UpgradeNodesInMemory(
                                 usageInside.DirectPythonNodes,
                                 workspace,
                                 SetEngine);
 
-                            ShowPythonEngineUpgradeToast(0, count);
+                            upgradedDefs.Add(defId);
+                        }
+
+                        UpgradeCustomNodeDefinitions(
+                            usageInside.CustomNodeDefIdsWithPython,
+                            visitedDefs,
+                            upgradedDefs);
+
+                        if (upgradedDefs.Count > 0)
+                        {
+                            ShowPythonEngineUpgradeToast(0, upgradedDefs.Count);
                         }
                     }
                 }
@@ -487,23 +500,11 @@ namespace Dynamo.PythonMigration
             }
 
             // Prepare custom node definitions that contain CPython nodes
-            foreach (var defId in usage.CustomNodeDefIdsWithPython)
-            {
-                var workspace = upgradeService.TryGetFunctionWorkspace(DynamoViewModel.Model, defId) as WorkspaceModel;
-                if (workspace != null)
-                {
-                    var inner = upgradeService.DetectPythonUsage(workspace, IsCPythonNode);
-
-                    if (inner.DirectPythonNodes.Any())
-                    {
-                        upgradeService.TempMigratedCustomDefs.Add(defId);
-                        upgradeService.UpgradeNodesInMemory(
-                        inner.DirectPythonNodes,
-                        workspace,
-                        SetEngine);
-                    }
-                }
-            }
+            var upgradedCustomDefs = new HashSet<Guid>();
+            UpgradeCustomNodeDefinitions(
+                usage.CustomNodeDefIdsWithPython,
+                new HashSet<Guid>(),
+                upgradedCustomDefs);
 
             var directCount = usage.DirectPythonNodes.Count();
             var customCount = usage.CustomNodeDefIdsWithPython.Count();
@@ -541,6 +542,49 @@ namespace Dynamo.PythonMigration
                     py.ShowAutoUpgradedBar = workspace is HomeWorkspaceModel;
                 }
             }
+        }
+
+        private void UpgradeCustomNodeDefinitions(
+            IEnumerable<Guid> defIds,
+            HashSet<Guid> visited,
+            HashSet<Guid> upgraded)
+        {
+            if (upgradeService == null || defIds == null) return;
+            visited ??= new HashSet<Guid>();
+            upgraded ??= new HashSet<Guid>();
+
+            foreach (var defId in defIds.Where(id => id != Guid.Empty))
+            {
+                UpgradeCustomNodeDefinition(defId, visited, upgraded);
+            }
+        }
+
+        private void UpgradeCustomNodeDefinition(
+            Guid defId,
+            HashSet<Guid> visited,
+            HashSet<Guid> upgraded)
+        {
+            if (upgradeService == null || defId == Guid.Empty) return;
+            if (!visited.Add(defId)) return;
+
+            var workspace = upgradeService.TryGetFunctionWorkspace(DynamoViewModel.Model, defId) as WorkspaceModel;
+            if (workspace == null) return;
+
+            var usage = upgradeService.DetectPythonUsage(workspace, IsCPythonNode);
+
+            if (usage.DirectPythonNodes.Any())
+            {
+                upgradeService.TempMigratedCustomDefs.Add(defId);
+
+                upgradeService.UpgradeNodesInMemory(
+                    usage.DirectPythonNodes,
+                    workspace,
+                    SetEngine);
+
+                upgraded.Add(defId);
+            }
+
+            UpgradeCustomNodeDefinitions(usage.CustomNodeDefIdsWithPython, visited, upgraded);
         }
 
         #endregion

--- a/test/Libraries/DynamoPythonTests/PythonEngineUpgradeServiceTests.cs
+++ b/test/Libraries/DynamoPythonTests/PythonEngineUpgradeServiceTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dynamo.Engine;
+using Dynamo.Graph.Annotations;
+using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Nodes.CustomNodes;
+using Dynamo.Graph.Nodes.NodeLoaders;
+using Dynamo.Graph.Notes;
+using Dynamo.Graph.Presets;
+using Dynamo.Graph.Workspaces;
+using Dynamo.Models;
+using Dynamo.Models.Migration.Python;
+using Dynamo.PythonServices;
+using NUnit.Framework;
+using PythonNodeModels;
+
+namespace DynamoPythonTests
+{
+    [TestFixture]
+    public class PythonEngineUpgradeServiceTests
+    {
+        [Test]
+        public void DetectPythonUsage_FindsNestedCustomNodes()
+        {
+            var scenario = CreateNestedScenario();
+
+            var usage = scenario.Service.DetectPythonUsage(scenario.HostWorkspace, IsCPythonNode);
+
+            CollectionAssert.Contains(usage.CustomNodeDefIdsWithPython, scenario.InnerDefinitionId);
+            CollectionAssert.Contains(usage.CustomNodeDefIdsWithPython, scenario.OuterDefinitionId);
+            Assert.AreEqual(0, usage.DirectPythonNodes.Count());
+        }
+
+        [Test]
+        public void NestedCustomNodes_AreUpgraded()
+        {
+            var scenario = CreateNestedScenario();
+
+            var usage = scenario.Service.DetectPythonUsage(scenario.HostWorkspace, IsCPythonNode);
+
+            var visited = new HashSet<Guid>();
+            foreach (var defId in usage.CustomNodeDefIdsWithPython)
+            {
+                UpgradeCustomNodeGraph(defId, scenario, visited);
+            }
+
+            Assert.AreEqual(PythonEngineManager.PythonNet3EngineName, scenario.InnerPythonNode.EngineName);
+            CollectionAssert.Contains(scenario.Service.TempMigratedCustomDefs, scenario.InnerDefinitionId);
+        }
+
+        private static void UpgradeCustomNodeGraph(Guid defId, NestedScenario scenario, HashSet<Guid> visited)
+        {
+            if (!visited.Add(defId)) return;
+            if (!scenario.WorkspaceLookup.TryGetValue(defId, out var workspace)) return;
+
+            var usage = scenario.Service.DetectPythonUsage(workspace, IsCPythonNode);
+
+            if (usage.DirectPythonNodes.Any())
+            {
+                scenario.Service.TempMigratedCustomDefs.Add(defId);
+                scenario.Service.UpgradeNodesInMemory(
+                    usage.DirectPythonNodes,
+                    workspace,
+                    SimpleSetEngine);
+            }
+
+            foreach (var nested in usage.CustomNodeDefIdsWithPython)
+            {
+                UpgradeCustomNodeGraph(nested, scenario, visited);
+            }
+        }
+
+        private static void SimpleSetEngine(NodeModel node, WorkspaceModel workspace)
+        {
+            if (node is PythonNodeBase py && py.EngineName == PythonEngineManager.CPython3EngineName)
+            {
+                py.EngineName = PythonEngineManager.PythonNet3EngineName;
+            }
+        }
+
+        private static bool IsCPythonNode(NodeModel node)
+        {
+            return node is PythonNodeBase py &&
+                   py.EngineName == PythonEngineManager.CPython3EngineName;
+        }
+
+        private static NestedScenario CreateNestedScenario()
+        {
+            var innerDefId = Guid.NewGuid();
+            var innerPythonNode = new PythonNode
+            {
+                EngineName = PythonEngineManager.CPython3EngineName
+            };
+            var innerWorkspace = CreateWorkspace(innerDefId, "Inner", new NodeModel[] { innerPythonNode });
+            var innerDefinition = new CustomNodeDefinition(innerDefId, "Inner", innerWorkspace.Nodes);
+
+            var outerDefId = Guid.NewGuid();
+            var nestedFunction = new Function(innerDefinition, "Inner", string.Empty, string.Empty);
+            var outerWorkspace = CreateWorkspace(outerDefId, "Outer", new NodeModel[] { nestedFunction });
+            var outerDefinition = new CustomNodeDefinition(outerDefId, "Outer", outerWorkspace.Nodes);
+
+            var hostFunction = new Function(outerDefinition, "Outer", string.Empty, string.Empty);
+            var hostWorkspace = CreateWorkspace(Guid.NewGuid(), "Host", new NodeModel[] { hostFunction });
+
+            var lookup = new Dictionary<Guid, CustomNodeWorkspaceModel>
+            {
+                { innerDefId, innerWorkspace },
+                { outerDefId, outerWorkspace }
+            };
+
+            var service = new PythonEngineUpgradeService(
+                dynamoModel: null,
+                pathManager: null,
+                functionWorkspaceResolver: guid =>
+                {
+                    lookup.TryGetValue(guid, out var workspace);
+                    return workspace;
+                });
+
+            return new NestedScenario
+            {
+                HostWorkspace = hostWorkspace,
+                InnerPythonNode = innerPythonNode,
+                InnerDefinitionId = innerDefId,
+                OuterDefinitionId = outerDefId,
+                Service = service,
+                WorkspaceLookup = lookup
+            };
+        }
+
+        private static CustomNodeWorkspaceModel CreateWorkspace(
+            Guid id,
+            string name,
+            IEnumerable<NodeModel> nodes)
+        {
+            var info = new WorkspaceInfo(id.ToString(), name, string.Empty, RunType.Manual);
+            return new CustomNodeWorkspaceModel(
+                new NodeFactory(),
+                nodes,
+                Enumerable.Empty<NoteModel>(),
+                Enumerable.Empty<AnnotationModel>(),
+                Enumerable.Empty<PresetModel>(),
+                new ElementResolver(),
+                info);
+        }
+
+        private sealed class NestedScenario
+        {
+            internal WorkspaceModel HostWorkspace { get; init; }
+            internal PythonNode InnerPythonNode { get; init; }
+            internal Guid InnerDefinitionId { get; init; }
+            internal Guid OuterDefinitionId { get; init; }
+            internal PythonEngineUpgradeService Service { get; init; }
+            internal Dictionary<Guid, CustomNodeWorkspaceModel> WorkspaceLookup { get; init; }
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

This PR addresses a limitation in the CPython to PythonNet3 migration logic where CPython nodes nested within multiple layers of Custom Nodes were not being detected or migrated. The changes introduce a recursive traversal mechanism to correctly identify and upgrade CPython nodes in deeply nested Custom Node definitions.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed an issue where CPython nodes located within nested Custom Node definitions were not automatically migrated to PythonNet3. The migration service now correctly traverses and upgrades Python nodes in all levels of Custom Node nesting.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of

---
<a href="https://cursor.com/background-agent?bcId=bc-8fbf817d-15bb-441e-bbcb-44ab072bb9b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8fbf817d-15bb-441e-bbcb-44ab072bb9b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

