### PR TITLE
Workspace GUID and filename check

### DIFF
--- a/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
+++ b/src/PythonMigrationViewExtension/PythonMigrationViewExtension.cs
@@ -28,6 +28,7 @@ namespace Dynamo.PythonMigration
         private bool hasCPython3Engine;
         private bool enginesSubscribed;
         private Guid lastWorkspaceGuid = Guid.Empty;
+        private string lastWorkspaceFileName = string.Empty;
         private PythonEngineUpgradeService upgradeService;
 
         internal ViewLoadedParams LoadedParams { get; set; }
@@ -287,9 +288,13 @@ namespace Dynamo.PythonMigration
                     // In test mode, do not toggle RunType or we’ll break auto-run expectations
                     MigrateCPythonNodesForWorkspace();
                 }
-                else if (lastWorkspaceGuid != hws.Guid)
+                else if (lastWorkspaceGuid != hws.Guid
+                    || !string.Equals(lastWorkspaceFileName ?? string.Empty,
+                        hws.FileName ?? string.Empty,
+                        StringComparison.OrdinalIgnoreCase))
                 {
                     lastWorkspaceGuid = hws.Guid;
+                    lastWorkspaceFileName = hws.FileName;
 
                     // Temporarily switch to Manual to avoid mutating during evaluation
                     var oldRunType = hws.RunSettings.RunType;
@@ -343,6 +348,7 @@ namespace Dynamo.PythonMigration
             // Close the CPython toast notification when workspace is cleared/closed
             DynamoViewModel.ToastManager?.CloseRealTimeInfoWindow();
             lastWorkspaceGuid = Guid.Empty;
+            lastWorkspaceFileName = string.Empty;
             CurrentWorkspace.ShowPythonAutoMigrationNotifications = false;
         }
 


### PR DESCRIPTION
<!--
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.
-->

### Purpose

This PR addresses an issue in `PythonMigrationViewExtension.OnCurrentWorkspaceChanged()` where CPython nodes would not migrate to PythonNet3 if a new graph was opened that happened to share the same GUID as a previously opened graph.

Previously, the migration check relied solely on `lastWorkspaceGuid`. This change updates the check to use a composite identity of both `lastWorkspaceGuid` and `lastWorkspaceFileName` (full file path, case-insensitive) to accurately track the last migrated Home workspace. This ensures that different graphs, even with identical GUIDs, are correctly identified and migrated.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixes an issue where CPython nodes would not migrate to PythonNet3 if a new graph was loaded that had the same GUID as a previously opened graph. The migration now correctly identifies unique graphs using both GUID and file path.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

### FYIs

N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-a558f471-392a-4fb6-a976-6f5aee85fcc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a558f471-392a-4fb6-a976-6f5aee85fcc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

