### PR TITLE
Package manager version compatibility

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageViewModel.cs
@@ -12,6 +12,7 @@ using Dynamo.Models;
 using Dynamo.PackageManager;
 using Dynamo.Wpf.Properties;
 using Dynamo.Wpf.Utilities;
+using Greg.Requests;
 using Prism.Commands;
 using NotificationObject = Dynamo.Core.NotificationObject;
 
@@ -453,6 +454,14 @@ namespace Dynamo.ViewModels
             var vm = PublishPackageViewModel.FromLocalPackage(dynamoViewModel, Model, true);
             vm.IsNewVersion = true;
 
+            // Auto-populate compatibility from the latest published version (server-cached),
+            // falling back to local package data if unavailable.
+            var latestPublishedCompatibility = TryGetLatestPublishedCompatibilityMatrix(Model.Name);
+            if (latestPublishedCompatibility != null && latestPublishedCompatibility.Any())
+            {
+                vm.CompatibilityMatrix = latestPublishedCompatibility.ToList();
+            }
+
             dynamoViewModel.OnRequestPackagePublishDialog(vm);
         }
 
@@ -487,6 +496,60 @@ namespace Dynamo.ViewModels
             var package = this.packageManagerClientViewModel.CachedPackageList.FirstOrDefault(x => x.Name == packageName);
 
             return package;
+        }
+
+        /// <summary>
+        /// Returns the compatibility matrix from the latest published package version
+        /// available in the cached package list (downloaded from the package manager).
+        /// </summary>
+        private IEnumerable<PackageCompatibility> TryGetLatestPublishedCompatibilityMatrix(string packageName)
+        {
+            var cached = GetPackageVersionInformationFromCached(packageName);
+            var versions = cached?.Header?.versions;
+            if (versions == null || versions.Count == 0) return null;
+
+            // Prefer the highest semantic version (major.minor.patch). If parsing fails, fall back to list order.
+            var latest = versions
+                .Select(v => new { Version = v, Parsed = TryParseThreePartVersion(v.version) })
+                .OrderByDescending(x => x.Parsed != null) // parsed versions first
+                .ThenByDescending(x => x.Parsed)          // then by numeric order
+                .Select(x => x.Version)
+                .FirstOrDefault();
+
+            var matrix = latest?.compatibility_matrix;
+            if (matrix == null) return null;
+
+            return matrix.Select(entry => new PackageCompatibility(
+                entry.name,
+                entry.versions != null ? new List<string>(entry.versions) : null,
+                entry.min,
+                entry.max));
+        }
+
+        /// <summary>
+        /// Parses a semantic-like "major.minor.patch" version string into System.Version.
+        /// Strips any pre-release/build metadata (e.g. "1.2.3-alpha+1" -> "1.2.3").
+        /// </summary>
+        private static Version TryParseThreePartVersion(string version)
+        {
+            if (string.IsNullOrWhiteSpace(version)) return null;
+            var cleaned = version.Split('-', '+')[0];
+            var parts = cleaned.Split('.');
+            if (parts.Length < 3) return null;
+
+            // System.Version allows 2-4 components; use first 3 to avoid surprises.
+            if (!int.TryParse(parts[0], out var major)) return null;
+            if (!int.TryParse(parts[1], out var minor)) return null;
+            if (!int.TryParse(parts[2], out var patch)) return null;
+
+            try
+            {
+                return new Version(major, minor, patch);
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         private bool IsPackageDeprecated(string packageName)

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -24,6 +24,7 @@ using Greg.Requests;
 using Newtonsoft.Json.Linq;
 using Dynamo.Models;
 using System.Globalization;
+using Greg.Responses; // ADDED: to access PackageHeader/versions when building previous version list
 
 namespace Dynamo.UI.Views
 {
@@ -206,6 +207,10 @@ namespace Dynamo.UI.Views
                 if (publishPackageViewModel.PreviewPackageContents?.Count > 0) UpdatePreviewPackageContents();
                 if (publishPackageViewModel.CompatibilityMatrix?.Count > 0) SendCompatibilityMatrix(publishPackageViewModel.CompatibilityMatrix);
                 if (publishPackageViewModel.RetainFolderStructureOverride) UpdateRetainFolderStructureFlag(publishPackageViewModel.RetainFolderStructureOverride);
+
+                // ADDED: send previous published versions so the wizard can show/hide "Copy from"
+                var previousVersions = GetPublishedPackageVersions(publishPackageViewModel);
+                SendPublishedPackageVersions(previousVersions);
             }
         }
 
@@ -415,6 +420,58 @@ namespace Dynamo.UI.Views
                     await dynWebView.CoreWebView2.ExecuteScriptAsync($"window.receiveCompatibilityMatrix({jsonPayload})");
                 }
             }
+        }
+
+        // ADDED: send list of published versions for the selected package
+        private async void SendPublishedPackageVersions(IEnumerable<string> versions)
+        {
+            var safeVersions = versions?.Where(v => !string.IsNullOrWhiteSpace(v)).Distinct().ToList() ?? new List<string>();
+            var payload = new { versions = safeVersions };
+
+            string jsonPayload = JsonSerializer.Serialize(payload);
+
+            if (dynWebView?.CoreWebView2 != null)
+            {
+                // Wizard front-end should implement: window.receivePublishedPackageVersions({ versions: [...] })
+                await dynWebView.CoreWebView2.ExecuteScriptAsync($"window.receivePublishedPackageVersions({jsonPayload});");
+            }
+        }
+
+        // ADDED: gather published versions from the cached package list (server data)
+        private static IEnumerable<string> GetPublishedPackageVersions(PublishPackageViewModel vm)
+        {
+            if (vm?.DynamoViewModel?.PackageManagerClientViewModel?.CachedPackageList == null) return Enumerable.Empty<string>();
+            if (string.IsNullOrWhiteSpace(vm.Name)) return Enumerable.Empty<string>();
+
+            // Find the package header from the package manager cache.
+            var cached = vm.DynamoViewModel.PackageManagerClientViewModel.CachedPackageList
+                .FirstOrDefault(x => string.Equals(x?.Name, vm.Name, StringComparison.OrdinalIgnoreCase));
+
+            var versions = cached?.Header?.versions;
+            if (versions == null || versions.Count == 0) return Enumerable.Empty<string>();
+
+            // Return all published version strings (sorted best-effort).
+            return versions
+                .Select(v => v?.version)
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .OrderByDescending(TryParseThreePartVersionForSort)
+                .ThenByDescending(v => v);
+        }
+
+        // ADDED: best-effort semantic-ish sort key; unparsable versions sort last.
+        private static Version TryParseThreePartVersionForSort(string version)
+        {
+            if (string.IsNullOrWhiteSpace(version)) return new Version(0, 0, 0);
+            var cleaned = version.Split('-', '+')[0];
+            var parts = cleaned.Split('.');
+            if (parts.Length < 3) return new Version(0, 0, 0);
+
+            if (!int.TryParse(parts[0], out var major)) return new Version(0, 0, 0);
+            if (!int.TryParse(parts[1], out var minor)) return new Version(0, 0, 0);
+            if (!int.TryParse(parts[2], out var patch)) return new Version(0, 0, 0);
+
+            try { return new Version(major, minor, patch); }
+            catch { return new Version(0, 0, 0); }
         }
 
         private async void SendUpdatedPackageContents(object frontendData, string type)

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -59,6 +59,7 @@ namespace Dynamo.UI.Views
         internal Action<string> RequestToggleNodeLibraryOnItem;
         internal Action<string> RequestOpenFolder;
         internal Action<string> RequestUpdateCompatibilityMatrix;
+        internal Action<string> RequestCopyCompatibilityFromVersion; // ADDED
         internal Action RequestLoadMarkdownContent;
         internal Action RequestClearMarkdownContent;
         internal Action<string> RequestLogMessage;
@@ -100,6 +101,7 @@ namespace Dynamo.UI.Views
             RequestToggleNodeLibraryOnItem = ToggleNodeLibraryOnItem;
             RequestOpenFolder = OpenFolder;
             RequestUpdateCompatibilityMatrix = UpdateCompatibilityMatrix;
+            RequestCopyCompatibilityFromVersion = CopyCompatibilityFromVersion; // ADDED
             RequestLoadMarkdownContent = LoadMarkdownContent;
             RequestClearMarkdownContent = ClearMarkdownContent;
             RequestLogMessage = LogMessage;
@@ -269,6 +271,7 @@ namespace Dynamo.UI.Views
                             RequestToggleNodeLibraryOnItem,
                             RequestOpenFolder,
                             RequestUpdateCompatibilityMatrix,
+                            RequestCopyCompatibilityFromVersion, // ADDED
                             RequestLoadMarkdownContent,
                             RequestClearMarkdownContent,
                             RequestLogMessage,
@@ -871,6 +874,48 @@ namespace Dynamo.UI.Views
             }
         }
 
+        // ADDED: Wizard requested to copy compatibility from a previously published version.
+        // This updates the Dynamo-side PublishPackageViewModel AND pushes the matrix back to the wizard UI.
+        internal void CopyCompatibilityFromVersion(string version)
+        {
+            if (publishPackageViewModel == null) return;
+            if (string.IsNullOrWhiteSpace(version)) return;
+
+            try
+            {
+                var pkgName = publishPackageViewModel.Name;
+                if (string.IsNullOrWhiteSpace(pkgName)) return;
+
+                var cachedPackage = publishPackageViewModel.DynamoViewModel?.PackageManagerClientViewModel?.CachedPackageList
+                    ?.FirstOrDefault(x => string.Equals(x?.Name, pkgName, StringComparison.OrdinalIgnoreCase));
+
+                var selectedVersion = cachedPackage?.Header?.versions?
+                    .FirstOrDefault(v => string.Equals(v?.version, version, StringComparison.OrdinalIgnoreCase));
+
+                var matrix = selectedVersion?.compatibility_matrix?
+                    .Select(entry => new PackageCompatibility(
+                        entry.name,
+                        entry.versions != null ? new List<string>(entry.versions) : null,
+                        entry.min,
+                        entry.max))
+                    .ToList();
+
+                if (matrix == null || matrix.Count == 0)
+                {
+                    LogMessage($"No compatibility matrix found for '{pkgName}' version '{version}'.");
+                    return;
+                }
+
+                publishPackageViewModel.CompatibilityMatrix = matrix;
+                SendCompatibilityMatrix(publishPackageViewModel.CompatibilityMatrix);
+                LogMessage($"Copied compatibility matrix from '{pkgName}' version '{version}'.");
+            }
+            catch (Exception ex)
+            {
+                LogMessage(ex);
+            }
+        }
+
         internal void LoadMarkdownContent()
         {
             if (publishPackageViewModel == null)
@@ -1246,6 +1291,7 @@ namespace Dynamo.UI.Views
         readonly Action<string> RequestToggleNodeLibraryOnItem;
         readonly Action<string> RequestOpenFolder;
         readonly Action<string> RequestUpdateCompatibilityMatrix;
+        readonly Action<string> RequestCopyCompatibilityFromVersion; // ADDED
         readonly Action RequestLoadMarkdownContent;
         readonly Action RequestClearMarkdownContent;
         readonly Action<string> RequestLogMessage;
@@ -1265,6 +1311,7 @@ namespace Dynamo.UI.Views
             Action<string> requestToggleNodeLibraryOnItem,
             Action<string> requestOpenFolder,
             Action<string> requestUpdateCompatibilityMatrix,
+            Action<string> requestCopyCompatibilityFromVersion, // ADDED
             Action requestLoadMarkdownContent,
             Action requestClearMarkdownContent,
             Action<string> requestLogMessage,
@@ -1283,6 +1330,7 @@ namespace Dynamo.UI.Views
             RequestToggleNodeLibraryOnItem = requestToggleNodeLibraryOnItem;
             RequestOpenFolder = requestOpenFolder;
             RequestUpdateCompatibilityMatrix = requestUpdateCompatibilityMatrix;
+            RequestCopyCompatibilityFromVersion = requestCopyCompatibilityFromVersion; // ADDED
             RequestLoadMarkdownContent = requestLoadMarkdownContent;
             RequestClearMarkdownContent = requestClearMarkdownContent;
             RequestLogMessage = requestLogMessage;
@@ -1328,6 +1376,13 @@ namespace Dynamo.UI.Views
         public void UpdateCompatibilityMatrix(string jsonPayload)
         {
             RequestUpdateCompatibilityMatrix(jsonPayload);
+        }
+
+        // ADDED: Called by the wizard when user selects "Copy from" version.
+        [DynamoJSInvokable]
+        public void CopyCompatibilityFromVersion(string version)
+        {
+            RequestCopyCompatibilityFromVersion(version);
         }
 
         [DynamoJSInvokable]


### PR DESCRIPTION
### Purpose

This PR introduces functionality to automatically pre-populate the package compatibility matrix when publishing a new version of an existing package. It copies the compatibility information from the latest published version of that package, improving the user experience by reducing manual data entry.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Publishing a new package version now auto-fills the compatibility matrix with settings from the latest published version of the package.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

---
<a href="https://cursor.com/background-agent?bcId=bc-a94ab4e1-c212-4e6c-b130-db576132e563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a94ab4e1-c212-4e6c-b130-db576132e563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

