### PR TITLE
Dynamo setup and build

### DIFF
--- a/src/setnpmreg.ps1
+++ b/src/setnpmreg.ps1
@@ -17,9 +17,15 @@ try {
     $response = Invoke-WebRequest -Uri $adskNpmRegistry -TimeoutSec 20 -ErrorAction Stop
 
     if ($response.StatusCode -eq 200) {
-        Write-Host "adsk npm registry is reachable" -ForegroundColor Green
-        createNpmrcFile -registry $adskNpmRegistry
-        Write-Output "//npm.autodesk.com/artifactory/api/npm/:_authToken=`${NPM_TOKEN}" | Out-File -FilePath .npmrc -Encoding UTF8 -Append
+        if ([string]::IsNullOrWhiteSpace($env:NPM_TOKEN)) {
+            Write-Host "adsk npm registry is reachable, but NPM_TOKEN is not set; using public npm registry" -ForegroundColor Yellow
+            createNpmrcFile -registry $npmRegistry
+        }
+        else {
+            Write-Host "adsk npm registry is reachable" -ForegroundColor Green
+            createNpmrcFile -registry $adskNpmRegistry
+            Write-Output "//npm.autodesk.com/artifactory/api/npm/:_authToken=`${NPM_TOKEN}" | Out-File -FilePath .npmrc -Encoding UTF8 -Append
+        }
     }
     else {
         Write-Host "adsk npm registry is not reachable" -ForegroundColor Red


### PR DESCRIPTION
### Purpose

This PR addresses a common build failure (`npm pack ... exited with code 1`) encountered when setting up Dynamo on new machines or outside the Autodesk network. The `src/setnpmreg.ps1` script previously attempted to use Autodesk's internal npm registry if reachable, even when `NPM_TOKEN` was not set, leading to 401 Unauthorized errors during `npm pack` operations. This change modifies the script to only use the internal registry when `NPM_TOKEN` is explicitly set, otherwise falling back to the public npm registry.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixes an issue where Dynamo builds would fail with "npm pack ... exited with code 1" if `NPM_TOKEN` was not set, by ensuring the build system correctly falls back to the public npm registry in such cases.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of

---
<a href="https://cursor.com/background-agent?bcId=bc-87b42115-911a-4ba7-ad6d-29ad8cd7924d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87b42115-911a-4ba7-ad6d-29ad8cd7924d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

