### PR TITLE
Package manager DynamoTeam icon

### DIFF
--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -660,6 +660,60 @@ namespace Dynamo.Controls
         }
     }
 
+    /// <summary>
+    /// Subtracts a numeric parameter from a numeric binding value.
+    /// Useful for computing MaxWidth/MinWidth values in XAML.
+    /// </summary>
+    public class SubtractDoubleConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null) return 0d;
+
+            if (!TryGetDouble(value, culture, out var baseValue))
+                return 0d;
+
+            if (parameter == null)
+                return baseValue;
+
+            if (!TryGetDouble(parameter, CultureInfo.InvariantCulture, out var subtractValue) &&
+                !TryGetDouble(parameter, culture, out subtractValue))
+            {
+                return baseValue;
+            }
+
+            var result = baseValue - subtractValue;
+            return result < 0 ? 0d : result;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+
+        private static bool TryGetDouble(object value, CultureInfo culture, out double result)
+        {
+            switch (value)
+            {
+                case double d:
+                    result = d;
+                    return true;
+                case float f:
+                    result = f;
+                    return true;
+                case int i:
+                    result = i;
+                    return true;
+                case string s when double.TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, culture, out var parsed):
+                    result = parsed;
+                    return true;
+                default:
+                    result = 0d;
+                    return false;
+            }
+        }
+    }
+
     public class PathToFileNameConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -660,60 +660,6 @@ namespace Dynamo.Controls
         }
     }
 
-    /// <summary>
-    /// Subtracts a numeric parameter from a numeric binding value.
-    /// Useful for computing MaxWidth/MinWidth values in XAML.
-    /// </summary>
-    public class SubtractDoubleConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (value == null) return 0d;
-
-            if (!TryGetDouble(value, culture, out var baseValue))
-                return 0d;
-
-            if (parameter == null)
-                return baseValue;
-
-            if (!TryGetDouble(parameter, CultureInfo.InvariantCulture, out var subtractValue) &&
-                !TryGetDouble(parameter, culture, out subtractValue))
-            {
-                return baseValue;
-            }
-
-            var result = baseValue - subtractValue;
-            return result < 0 ? 0d : result;
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotSupportedException();
-        }
-
-        private static bool TryGetDouble(object value, CultureInfo culture, out double result)
-        {
-            switch (value)
-            {
-                case double d:
-                    result = d;
-                    return true;
-                case float f:
-                    result = f;
-                    return true;
-                case int i:
-                    result = i;
-                    return true;
-                case string s when double.TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, culture, out var parsed):
-                    result = parsed;
-                    return true;
-                default:
-                    result = 0d;
-                    return false;
-            }
-        }
-    }
-
     public class PathToFileNameConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -1533,8 +1533,14 @@ namespace Dynamo.Controls
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if ((bool)value)
-                return Visibility.Visible;
+            // Be defensive: bindings can yield null/UnsetValue during template load.
+            // Returning Collapsed avoids repeated exceptions that can degrade UI performance.
+            if (value is bool b)
+                return b ? Visibility.Visible : Visibility.Collapsed;
+
+            if (value is bool? nb)
+                return nb.GetValueOrDefault(false) ? Visibility.Visible : Visibility.Collapsed;
+
             return Visibility.Collapsed;
         }
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
@@ -15,6 +15,8 @@ namespace Dynamo.PackageManager.ViewModels
 {
     public class PackageManagerSearchElementViewModel : BrowserItemViewModel, IEquatable<PackageManagerSearchElementViewModel>
     {
+        private const string DynamoTeamPublisherName = "DynamoTeam";
+
         public ICommand DownloadLatestCommand { get; set; }
         public ICommand UpvoteCommand { get; set; }
         public ICommand VisitSiteCommand { get; set; }
@@ -53,6 +55,19 @@ namespace Dynamo.PackageManager.ViewModels
         /// VM Maintainers property
         /// </summary>
         public string Maintainers { get { return this.SearchElementModel.Maintainers; } }
+
+        /// <summary>
+        /// True when the package is published/maintained by DynamoTeam.
+        /// Used by the Package Manager UI to display a logo badge.
+        /// </summary>
+        public bool IsPublishedByDynamoTeam
+        {
+            get
+            {
+                return SearchElementModel?.Header?.maintainers?.Any(m =>
+                    string.Equals(m?.username, DynamoTeamPublisherName, StringComparison.OrdinalIgnoreCase)) == true;
+            }
+        }
         /// <summary>
         /// VM LatestVersion property
         /// </summary>

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
@@ -23,7 +23,6 @@
             <controls:DependencyListToStringConverter x:Key="DependencyListToStringConverter" />
             <controls:ListHasMoreThanNItemsToVisibilityConverter x:Key="ListHasMoreThanNItemsToVisibilityConverter" />
             <controls:BoolToVisibilityCollapsedConverter x:Key="BoolToVisibilityCollapsedConverter" />
-            <controls:SubtractDoubleConverter x:Key="SubtractDoubleConverter" />
             <Style BasedOn="{StaticResource GenericToolTipLight}" TargetType="ToolTip" />
             <Style x:Key="RectangleStyle" TargetType="Rectangle">
                 <Setter Property="Opacity" Value="0" />
@@ -487,58 +486,57 @@
                                 </Grid.ColumnDefinitions>
 
                                 <!--  Package Name + DynamoTeam badge  -->
-                                <Grid x:Name="packageNameArea" Grid.Column="0" HorizontalAlignment="Stretch">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="*" />
-                                    </Grid.ColumnDefinitions>
-
-                                    <!--  Package Name  -->
-                                    <TextBlock Name="packageName"
-                                               Grid.Column="0"
-                                               VerticalAlignment="Center"
-                                               FontFamily="{StaticResource ArtifaktElementRegular}"
-                                               FontSize="14"
-                                               FontWeight="SemiBold"
-                                               MaxWidth="{Binding ActualWidth, ElementName=packageNameArea, Converter={StaticResource SubtractDoubleConverter}, ConverterParameter=22}"
-                                               MouseDown="PackageName_MouseDown"
-                                               Text="{Binding Path=Name}"
-                                               TextTrimming="CharacterEllipsis"
-                                               TextWrapping="NoWrap">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="True">
-                                                        <Setter Property="Foreground" Value="#999999" />
-                                                    </DataTrigger>
-                                                    <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="False">
-                                                        <Setter Property="Foreground" Value="{StaticResource PMForegroundColorBrush}" />
-                                                    </DataTrigger>
-                                                    <Trigger Property="IsMouseOver" Value="True">
-                                                        <Setter Property="TextDecorations" Value="Underline" />
-                                                    </Trigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                        <TextBlock.ToolTip>
-                                            <ToolTip Content="{Binding Path=Name}" Style="{StaticResource GenericToolTipLight}" />
-                                        </TextBlock.ToolTip>
-                                    </TextBlock>
-
-                                    <!--  DynamoTeam badge icon (right after package name)  -->
-                                    <Image Grid.Column="1"
-                                           Width="14"
-                                           Height="14"
-                                           Margin="6,0,0,0"
+                                <TextBlock Name="packageName"
+                                           Grid.Column="0"
                                            VerticalAlignment="Center"
-                                           Source="/DynamoCoreWpf;component/UI/Images/dynamonotext.png"
-                                           Visibility="{Binding IsPublishedByDynamoTeam, Converter={StaticResource BoolToVisibilityCollapsedConverter}}">
-                                        <Image.ToolTip>
-                                            <ToolTip Content="Published by DynamoTeam" Style="{StaticResource GenericToolTipLight}" />
-                                        </Image.ToolTip>
-                                    </Image>
-                                </Grid>
+                                           FontFamily="{StaticResource ArtifaktElementRegular}"
+                                           FontSize="14"
+                                           FontWeight="SemiBold"
+                                           MouseDown="PackageName_MouseDown"
+                                           TextTrimming="CharacterEllipsis"
+                                           TextWrapping="NoWrap">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="True">
+                                                    <Setter Property="Foreground" Value="#999999" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="False">
+                                                    <Setter Property="Foreground" Value="{StaticResource PMForegroundColorBrush}" />
+                                                </DataTrigger>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter Property="TextDecorations" Value="Underline" />
+                                                </Trigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                    <TextBlock.ToolTip>
+                                        <ToolTip Content="{Binding Path=Name}" Style="{StaticResource GenericToolTipLight}" />
+                                    </TextBlock.ToolTip>
+                                    <Run Text="{Binding Path=Name}" />
+                                    <InlineUIContainer>
+                                        <!--  DynamoTeam badge icon (right after package name)  -->
+                                        <Image Width="14"
+                                               Height="14"
+                                               Margin="6,0,0,0"
+                                               VerticalAlignment="Center"
+                                               Source="/DynamoCoreWpf;component/UI/Images/dynamonotext.png"
+                                               Visibility="Collapsed">
+                                            <Image.Style>
+                                                <Style TargetType="Image">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsPublishedByDynamoTeam}" Value="True">
+                                                            <Setter Property="Visibility" Value="Visible" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Image.Style>
+                                            <Image.ToolTip>
+                                                <ToolTip Content="Published by DynamoTeam" Style="{StaticResource GenericToolTipLight}" />
+                                            </Image.ToolTip>
+                                        </Image>
+                                    </InlineUIContainer>
+                                </TextBlock>
 
                                 <!--  Tag Bubble  -->
                                 <Border Name="newPackageLabel"

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
@@ -486,57 +486,56 @@
                                 </Grid.ColumnDefinitions>
 
                                 <!--  Package Name + DynamoTeam badge  -->
-                                <TextBlock Name="packageName"
-                                           Grid.Column="0"
-                                           VerticalAlignment="Center"
-                                           FontFamily="{StaticResource ArtifaktElementRegular}"
-                                           FontSize="14"
-                                           FontWeight="SemiBold"
-                                           MouseDown="PackageName_MouseDown"
-                                           TextTrimming="CharacterEllipsis"
-                                           TextWrapping="NoWrap">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="True">
-                                                    <Setter Property="Foreground" Value="#999999" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="False">
-                                                    <Setter Property="Foreground" Value="{StaticResource PMForegroundColorBrush}" />
-                                                </DataTrigger>
-                                                <Trigger Property="IsMouseOver" Value="True">
-                                                    <Setter Property="TextDecorations" Value="Underline" />
-                                                </Trigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                    <TextBlock.ToolTip>
-                                        <ToolTip Content="{Binding Path=Name}" Style="{StaticResource GenericToolTipLight}" />
-                                    </TextBlock.ToolTip>
-                                    <Run Text="{Binding Path=Name}" />
-                                    <InlineUIContainer>
-                                        <!--  DynamoTeam badge icon (right after package name)  -->
-                                        <Image Width="14"
-                                               Height="14"
-                                               Margin="6,0,0,0"
+                                <Grid x:Name="packageNameArea" Grid.Column="0" HorizontalAlignment="Stretch">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <!--  Package Name  -->
+                                    <TextBlock Name="packageName"
+                                               Grid.Column="0"
                                                VerticalAlignment="Center"
-                                               Source="/DynamoCoreWpf;component/UI/Images/dynamonotext.png"
-                                               Visibility="Collapsed">
-                                            <Image.Style>
-                                                <Style TargetType="Image">
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding IsPublishedByDynamoTeam}" Value="True">
-                                                            <Setter Property="Visibility" Value="Visible" />
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </Image.Style>
-                                            <Image.ToolTip>
-                                                <ToolTip Content="Published by DynamoTeam" Style="{StaticResource GenericToolTipLight}" />
-                                            </Image.ToolTip>
-                                        </Image>
-                                    </InlineUIContainer>
-                                </TextBlock>
+                                               FontFamily="{StaticResource ArtifaktElementRegular}"
+                                               FontSize="14"
+                                               FontWeight="SemiBold"
+                                               MouseDown="PackageName_MouseDown"
+                                               Text="{Binding Path=Name}"
+                                               TextTrimming="CharacterEllipsis"
+                                               TextWrapping="NoWrap">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="True">
+                                                        <Setter Property="Foreground" Value="#999999" />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="False">
+                                                        <Setter Property="Foreground" Value="{StaticResource PMForegroundColorBrush}" />
+                                                    </DataTrigger>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter Property="TextDecorations" Value="Underline" />
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                        <TextBlock.ToolTip>
+                                            <ToolTip Content="{Binding Path=Name}" Style="{StaticResource GenericToolTipLight}" />
+                                        </TextBlock.ToolTip>
+                                    </TextBlock>
+
+                                    <!--  DynamoTeam badge icon (right after package name)  -->
+                                    <Image Grid.Column="1"
+                                           Width="14"
+                                           Height="14"
+                                           Margin="6,0,0,0"
+                                           VerticalAlignment="Center"
+                                           Source="/DynamoCoreWpf;component/UI/Images/dynamonotext.png"
+                                           Visibility="{Binding IsPublishedByDynamoTeam, Converter={StaticResource BoolToVisibilityCollapsedConverter}}">
+                                        <Image.ToolTip>
+                                            <ToolTip Content="Published by DynamoTeam" Style="{StaticResource GenericToolTipLight}" />
+                                        </Image.ToolTip>
+                                    </Image>
+                                </Grid>
 
                                 <!--  Tag Bubble  -->
                                 <Border Name="newPackageLabel"

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
@@ -23,6 +23,7 @@
             <controls:DependencyListToStringConverter x:Key="DependencyListToStringConverter" />
             <controls:ListHasMoreThanNItemsToVisibilityConverter x:Key="ListHasMoreThanNItemsToVisibilityConverter" />
             <controls:BoolToVisibilityCollapsedConverter x:Key="BoolToVisibilityCollapsedConverter" />
+            <controls:SubtractDoubleConverter x:Key="SubtractDoubleConverter" />
             <Style BasedOn="{StaticResource GenericToolTipLight}" TargetType="ToolTip" />
             <Style x:Key="RectangleStyle" TargetType="Rectangle">
                 <Setter Property="Opacity" Value="0" />
@@ -485,36 +486,59 @@
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
 
-                                <!--  Package Name  -->
-                                <TextBlock Name="packageName"
-                                           Grid.Column="0"
+                                <!--  Package Name + DynamoTeam badge  -->
+                                <Grid x:Name="packageNameArea" Grid.Column="0" HorizontalAlignment="Stretch">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <!--  Package Name  -->
+                                    <TextBlock Name="packageName"
+                                               Grid.Column="0"
+                                               VerticalAlignment="Center"
+                                               FontFamily="{StaticResource ArtifaktElementRegular}"
+                                               FontSize="14"
+                                               FontWeight="SemiBold"
+                                               MaxWidth="{Binding ActualWidth, ElementName=packageNameArea, Converter={StaticResource SubtractDoubleConverter}, ConverterParameter=22}"
+                                               MouseDown="PackageName_MouseDown"
+                                               Text="{Binding Path=Name}"
+                                               TextTrimming="CharacterEllipsis"
+                                               TextWrapping="NoWrap">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="True">
+                                                        <Setter Property="Foreground" Value="#999999" />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="False">
+                                                        <Setter Property="Foreground" Value="{StaticResource PMForegroundColorBrush}" />
+                                                    </DataTrigger>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter Property="TextDecorations" Value="Underline" />
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                        <TextBlock.ToolTip>
+                                            <ToolTip Content="{Binding Path=Name}" Style="{StaticResource GenericToolTipLight}" />
+                                        </TextBlock.ToolTip>
+                                    </TextBlock>
+
+                                    <!--  DynamoTeam badge icon (right after package name)  -->
+                                    <Image Grid.Column="1"
+                                           Width="14"
+                                           Height="14"
+                                           Margin="6,0,0,0"
                                            VerticalAlignment="Center"
-                                           FontFamily="{StaticResource ArtifaktElementRegular}"
-                                           FontSize="14"
-                                           FontWeight="SemiBold"
-                                           MouseDown="PackageName_MouseDown"
-                                           Text="{Binding Path=Name}"
-                                           TextTrimming="CharacterEllipsis"
-                                           TextWrapping="NoWrap">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="True">
-                                                    <Setter Property="Foreground" Value="#999999" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="False">
-                                                    <Setter Property="Foreground" Value="{StaticResource PMForegroundColorBrush}" />
-                                                </DataTrigger>
-                                                <Trigger Property="IsMouseOver" Value="True">
-                                                    <Setter Property="TextDecorations" Value="Underline" />
-                                                </Trigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                    <TextBlock.ToolTip>
-                                        <ToolTip Content="{Binding Path=Name}" Style="{StaticResource GenericToolTipLight}" />
-                                    </TextBlock.ToolTip>
-                                </TextBlock>
+                                           Source="/DynamoCoreWpf;component/UI/Images/dynamonotext.png"
+                                           Visibility="{Binding IsPublishedByDynamoTeam, Converter={StaticResource BoolToVisibilityCollapsedConverter}}">
+                                        <Image.ToolTip>
+                                            <ToolTip Content="Published by DynamoTeam" Style="{StaticResource GenericToolTipLight}" />
+                                        </Image.ToolTip>
+                                    </Image>
+                                </Grid>
 
                                 <!--  Tag Bubble  -->
                                 <Border Name="newPackageLabel"

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -621,56 +621,52 @@
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
-                                    <TextBlock
-                                        Name="packageName"
-                                        Grid.Column="0"
-                                        VerticalAlignment="Center"
-                                        FontFamily="{StaticResource ArtifaktElementRegular}"
-                                        FontSize="14"
-                                        FontWeight="SemiBold"
-                                        TextTrimming="CharacterEllipsis"
-                                        TextWrapping="NoWrap">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="True">
-                                                        <Setter Property="Foreground" Value="#999999" />
-                                                    </DataTrigger>
-                                                    <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="False">
-                                                        <Setter Property="Foreground" Value="{StaticResource PrimaryCharcoal200Brush}" />
-                                                    </DataTrigger>
-                                                    <Trigger Property="IsMouseOver" Value="True">
-                                                        <Setter Property="TextDecorations" Value="Underline" />
-                                                    </Trigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                        <TextBlock.ToolTip>
-                                            <ToolTip Content="{Binding Path=Model.Name}" Style="{StaticResource GenericToolTipLight}" />
-                                        </TextBlock.ToolTip>
-                                        <Run Text="{Binding Path=Model.Name}" />
-                                        <InlineUIContainer>
-                                            <Image Width="14"
-                                                   Height="14"
-                                                   Margin="6,0,0,0"
-                                                   VerticalAlignment="Center"
-                                                   Source="/DynamoCoreWpf;component/UI/Images/dynamonotext.png"
-                                                   Visibility="Collapsed">
-                                                <Image.Style>
-                                                    <Style TargetType="Image">
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding IsPublishedByDynamoTeam}" Value="True">
-                                                                <Setter Property="Visibility" Value="Visible" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </Image.Style>
-                                                <Image.ToolTip>
-                                                    <ToolTip Content="Published by DynamoTeam" Style="{StaticResource GenericToolTipLight}" />
-                                                </Image.ToolTip>
-                                            </Image>
-                                        </InlineUIContainer>
-                                    </TextBlock>
+                                    <Grid x:Name="packageNameArea" Grid.Column="0" HorizontalAlignment="Stretch">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock
+                                            Name="packageName"
+                                            Grid.Column="0"
+                                            VerticalAlignment="Center"
+                                            FontFamily="{StaticResource ArtifaktElementRegular}"
+                                            FontSize="14"
+                                            FontWeight="SemiBold"
+                                            Text="{Binding Path=Model.Name}"
+                                            TextTrimming="CharacterEllipsis"
+                                            TextWrapping="NoWrap">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="True">
+                                                            <Setter Property="Foreground" Value="#999999" />
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="False">
+                                                            <Setter Property="Foreground" Value="{StaticResource PrimaryCharcoal200Brush}" />
+                                                        </DataTrigger>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter Property="TextDecorations" Value="Underline" />
+                                                        </Trigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                            <TextBlock.ToolTip>
+                                                <ToolTip Content="{Binding Path=Model.Name}" Style="{StaticResource GenericToolTipLight}" />
+                                            </TextBlock.ToolTip>
+                                        </TextBlock>
+                                        <Image Grid.Column="1"
+                                               Width="14"
+                                               Height="14"
+                                               Margin="6,0,0,0"
+                                               VerticalAlignment="Center"
+                                               Source="/DynamoCoreWpf;component/UI/Images/dynamonotext.png"
+                                               Visibility="{Binding IsPublishedByDynamoTeam, Converter={StaticResource BoolToVisibilityCollapsedConverter}}">
+                                            <Image.ToolTip>
+                                                <ToolTip Content="Published by DynamoTeam" Style="{StaticResource GenericToolTipLight}" />
+                                            </Image.ToolTip>
+                                        </Image>
+                                    </Grid>
                                     <Border
                                         Name="newPackageLabel"
                                         Grid.Column="1"

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -33,6 +33,8 @@
             <controls:PrettyDateConverter x:Key="PrettyDateConverter" />
             <controls:DependencyListToStringConverter x:Key="DependencyListToStringConverter" />
             <controls:ListHasMoreThanNItemsToVisibilityConverter x:Key="ListHasMoreThanNItemsToVisibilityConverter" />
+            <controls:BoolToVisibilityCollapsedConverter x:Key="BoolToVisibilityCollapsedConverter" />
+            <controls:SubtractDoubleConverter x:Key="SubtractDoubleConverter" />
 
             <ResourceDictionary.MergedDictionaries>
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
@@ -620,35 +622,56 @@
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
-                                    <TextBlock
-                                        Name="packageName"
-                                        Grid.Column="0"
-                                        VerticalAlignment="Center"
-                                        FontFamily="{StaticResource ArtifaktElementRegular}"
-                                        FontSize="14"
-                                        FontWeight="SemiBold"
-                                        Text="{Binding Path=Model.Name}"
-                                        TextTrimming="CharacterEllipsis"
-                                        TextWrapping="NoWrap">
-                                        <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="True">
-                                                        <Setter Property="Foreground" Value="#999999" />
-                                                    </DataTrigger>
-                                                    <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="False">
-                                                        <Setter Property="Foreground" Value="{StaticResource PrimaryCharcoal200Brush}" />
-                                                    </DataTrigger>
-                                                    <Trigger Property="IsMouseOver" Value="True">
-                                                        <Setter Property="TextDecorations" Value="Underline" />
-                                                    </Trigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </TextBlock.Style>
-                                        <TextBlock.ToolTip>
-                                            <ToolTip Content="{Binding Path=Model.Name}" Style="{StaticResource GenericToolTipLight}" />
-                                        </TextBlock.ToolTip>
-                                    </TextBlock>
+                                    <!--  Package Name + DynamoTeam badge  -->
+                                    <Grid x:Name="packageNameArea" Grid.Column="0" HorizontalAlignment="Stretch">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock
+                                            Name="packageName"
+                                            Grid.Column="0"
+                                            VerticalAlignment="Center"
+                                            FontFamily="{StaticResource ArtifaktElementRegular}"
+                                            FontSize="14"
+                                            FontWeight="SemiBold"
+                                            MaxWidth="{Binding ActualWidth, ElementName=packageNameArea, Converter={StaticResource SubtractDoubleConverter}, ConverterParameter=22}"
+                                            Text="{Binding Path=Model.Name}"
+                                            TextTrimming="CharacterEllipsis"
+                                            TextWrapping="NoWrap">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="True">
+                                                            <Setter Property="Foreground" Value="#999999" />
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="False">
+                                                            <Setter Property="Foreground" Value="{StaticResource PrimaryCharcoal200Brush}" />
+                                                        </DataTrigger>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter Property="TextDecorations" Value="Underline" />
+                                                        </Trigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                            <TextBlock.ToolTip>
+                                                <ToolTip Content="{Binding Path=Model.Name}" Style="{StaticResource GenericToolTipLight}" />
+                                            </TextBlock.ToolTip>
+                                        </TextBlock>
+
+                                        <Image Grid.Column="1"
+                                               Width="14"
+                                               Height="14"
+                                               Margin="6,0,0,0"
+                                               VerticalAlignment="Center"
+                                               Source="/DynamoCoreWpf;component/UI/Images/dynamonotext.png"
+                                               Visibility="{Binding IsPublishedByDynamoTeam, Converter={StaticResource BoolToVisibilityCollapsedConverter}}">
+                                            <Image.ToolTip>
+                                                <ToolTip Content="Published by DynamoTeam" Style="{StaticResource GenericToolTipLight}" />
+                                            </Image.ToolTip>
+                                        </Image>
+                                    </Grid>
                                     <Border
                                         Name="newPackageLabel"
                                         Grid.Column="1"

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -34,7 +34,6 @@
             <controls:DependencyListToStringConverter x:Key="DependencyListToStringConverter" />
             <controls:ListHasMoreThanNItemsToVisibilityConverter x:Key="ListHasMoreThanNItemsToVisibilityConverter" />
             <controls:BoolToVisibilityCollapsedConverter x:Key="BoolToVisibilityCollapsedConverter" />
-            <controls:SubtractDoubleConverter x:Key="SubtractDoubleConverter" />
 
             <ResourceDictionary.MergedDictionaries>
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
@@ -622,56 +621,56 @@
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
-                                    <!--  Package Name + DynamoTeam badge  -->
-                                    <Grid x:Name="packageNameArea" Grid.Column="0" HorizontalAlignment="Stretch">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" />
-                                            <ColumnDefinition Width="Auto" />
-                                            <ColumnDefinition Width="*" />
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock
-                                            Name="packageName"
-                                            Grid.Column="0"
-                                            VerticalAlignment="Center"
-                                            FontFamily="{StaticResource ArtifaktElementRegular}"
-                                            FontSize="14"
-                                            FontWeight="SemiBold"
-                                            MaxWidth="{Binding ActualWidth, ElementName=packageNameArea, Converter={StaticResource SubtractDoubleConverter}, ConverterParameter=22}"
-                                            Text="{Binding Path=Model.Name}"
-                                            TextTrimming="CharacterEllipsis"
-                                            TextWrapping="NoWrap">
-                                            <TextBlock.Style>
-                                                <Style TargetType="TextBlock">
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="True">
-                                                            <Setter Property="Foreground" Value="#999999" />
-                                                        </DataTrigger>
-                                                        <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="False">
-                                                            <Setter Property="Foreground" Value="{StaticResource PrimaryCharcoal200Brush}" />
-                                                        </DataTrigger>
-                                                        <Trigger Property="IsMouseOver" Value="True">
-                                                            <Setter Property="TextDecorations" Value="Underline" />
-                                                        </Trigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </TextBlock.Style>
-                                            <TextBlock.ToolTip>
-                                                <ToolTip Content="{Binding Path=Model.Name}" Style="{StaticResource GenericToolTipLight}" />
-                                            </TextBlock.ToolTip>
-                                        </TextBlock>
-
-                                        <Image Grid.Column="1"
-                                               Width="14"
-                                               Height="14"
-                                               Margin="6,0,0,0"
-                                               VerticalAlignment="Center"
-                                               Source="/DynamoCoreWpf;component/UI/Images/dynamonotext.png"
-                                               Visibility="{Binding IsPublishedByDynamoTeam, Converter={StaticResource BoolToVisibilityCollapsedConverter}}">
-                                            <Image.ToolTip>
-                                                <ToolTip Content="Published by DynamoTeam" Style="{StaticResource GenericToolTipLight}" />
-                                            </Image.ToolTip>
-                                        </Image>
-                                    </Grid>
+                                    <TextBlock
+                                        Name="packageName"
+                                        Grid.Column="0"
+                                        VerticalAlignment="Center"
+                                        FontFamily="{StaticResource ArtifaktElementRegular}"
+                                        FontSize="14"
+                                        FontWeight="SemiBold"
+                                        TextTrimming="CharacterEllipsis"
+                                        TextWrapping="NoWrap">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="True">
+                                                        <Setter Property="Foreground" Value="#999999" />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="False">
+                                                        <Setter Property="Foreground" Value="{StaticResource PrimaryCharcoal200Brush}" />
+                                                    </DataTrigger>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter Property="TextDecorations" Value="Underline" />
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                        <TextBlock.ToolTip>
+                                            <ToolTip Content="{Binding Path=Model.Name}" Style="{StaticResource GenericToolTipLight}" />
+                                        </TextBlock.ToolTip>
+                                        <Run Text="{Binding Path=Model.Name}" />
+                                        <InlineUIContainer>
+                                            <Image Width="14"
+                                                   Height="14"
+                                                   Margin="6,0,0,0"
+                                                   VerticalAlignment="Center"
+                                                   Source="/DynamoCoreWpf;component/UI/Images/dynamonotext.png"
+                                                   Visibility="Collapsed">
+                                                <Image.Style>
+                                                    <Style TargetType="Image">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsPublishedByDynamoTeam}" Value="True">
+                                                                <Setter Property="Visibility" Value="Visible" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Image.Style>
+                                                <Image.ToolTip>
+                                                    <ToolTip Content="Published by DynamoTeam" Style="{StaticResource GenericToolTipLight}" />
+                                                </Image.ToolTip>
+                                            </Image>
+                                        </InlineUIContainer>
+                                    </TextBlock>
                                     <Border
                                         Name="newPackageLabel"
                                         Grid.Column="1"

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerSearchElementViewModelTests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerSearchElementViewModelTests.cs
@@ -130,6 +130,58 @@ namespace Dynamo.PackageManager.Wpf.Tests
             packageManagerSearchViewModel.ClearSearchResults();
         }
 
+        [Test]
+        public void IsPublishedByDynamoTeam_IsFalse_WhenMaintainersNull()
+        {
+            var tmpPackageVersion = new PackageVersion { version = "1.0.0", created = DateTime.Now.ToString() };
+            var vm = new PackageManagerSearchElementViewModel(
+                new PackageManagerSearchElement(new PackageHeader()
+                {
+                    name = "pkg",
+                    versions = new List<PackageVersion> { tmpPackageVersion },
+                    maintainers = null
+                }),
+                false);
+
+            Assert.IsFalse(vm.IsPublishedByDynamoTeam);
+        }
+
+        [Test]
+        public void IsPublishedByDynamoTeam_IsFalse_WhenMaintainersDoNotContainDynamoTeam()
+        {
+            var tmpPackageVersion = new PackageVersion { version = "1.0.0", created = DateTime.Now.ToString() };
+            var vm = new PackageManagerSearchElementViewModel(
+                new PackageManagerSearchElement(new PackageHeader()
+                {
+                    name = "pkg",
+                    versions = new List<PackageVersion> { tmpPackageVersion },
+                    maintainers = new List<User> { new User { username = "someoneElse" } }
+                }),
+                false);
+
+            Assert.IsFalse(vm.IsPublishedByDynamoTeam);
+        }
+
+        [Test]
+        public void IsPublishedByDynamoTeam_IsTrue_WhenMaintainersContainDynamoTeam_IgnoringCase()
+        {
+            var tmpPackageVersion = new PackageVersion { version = "1.0.0", created = DateTime.Now.ToString() };
+            var vm = new PackageManagerSearchElementViewModel(
+                new PackageManagerSearchElement(new PackageHeader()
+                {
+                    name = "pkg",
+                    versions = new List<PackageVersion> { tmpPackageVersion },
+                    maintainers = new List<User>
+                    {
+                        new User { username = "someoneElse" },
+                        new User { username = "dYnaMoTeAm" }
+                    }
+                }),
+                false);
+
+            Assert.IsTrue(vm.IsPublishedByDynamoTeam);
+        }
+
 
         /// <summary>
         /// A test to ensure that the label converted is equal the resources when localized


### PR DESCRIPTION
### Purpose

This PR adds a DynamoTeam badge icon next to the package name in the Package Manager search results, visible only for packages published by DynamoTeam. This helps users quickly identify official DynamoTeam packages.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Added a DynamoTeam badge icon immediately after the package name in the Package Manager results list, shown only when the package is published by DynamoTeam.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

---
<a href="https://cursor.com/background-agent?bcId=bc-8eb8120c-9834-46cd-8ca0-dff8a511fa25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8eb8120c-9834-46cd-8ca0-dff8a511fa25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

