### PR TITLE
Package data source

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -205,10 +205,6 @@ namespace Dynamo.UI.Views
                 if (publishPackageViewModel.PackageContents?.Count > 0) UpdatePackageContents();
                 if (publishPackageViewModel.PreviewPackageContents?.Count > 0) UpdatePreviewPackageContents();
                 if (publishPackageViewModel.CompatibilityMatrix?.Count > 0) SendCompatibilityMatrix(publishPackageViewModel.CompatibilityMatrix);
-                // If this publish flow is based on an existing local package, attempt to also send
-                // server-cached package/version info (including per-version compatibility matrices)
-                // in the format expected by the compatibility editor.
-                SendSelectedPackageFromCache();
                 if (publishPackageViewModel.RetainFolderStructureOverride) UpdateRetainFolderStructureFlag(publishPackageViewModel.RetainFolderStructureOverride);
             }
         }
@@ -660,6 +656,53 @@ namespace Dynamo.UI.Views
                 ReleaseNotesUrl = vm.ReleaseNotesUrl ?? string.Empty
             };
 
+            // IMPORTANT:
+            // The front-end uses receiveUpdatedPackageDetails({ payload }) to populate state.selectedPackage.
+            // To enable the "Copy from" dropdown in the compatibility editor, this payload must include
+            // package version history: payload.versions[*].compatibility_matrix.
+            var header = await TryGetPackageHeaderAsync(vm);
+            if (header != null)
+            {
+                packageDetails.Id = header._id ?? string.Empty;
+                packageDetails.Downloads = header.downloads;
+                packageDetails.Votes = header.votes;
+                packageDetails.UsedBy = header.used_by;
+
+                // Best-effort: use earliest version created date as package created date.
+                packageDetails.Created = header.versions?.FirstOrDefault()?.created ?? string.Empty;
+
+                packageDetails.Maintainers = header.maintainers?
+                    .Select(m => new PackageMaintainer
+                    {
+                        Id = m._id,
+                        Username = m.username
+                    })
+                    .ToList() ?? new List<PackageMaintainer>();
+
+                packageDetails.Versions = header.versions?
+                    .Where(v => v != null)
+                    .Select(v => new PackageVersionInfo
+                    {
+                        Version = v.version,
+                        Created = v.created,
+                        EngineVersion = v.engine_version,
+                        HostDependencies = v.host_dependencies?.ToList() ?? new List<string>(),
+                        CompatibilityMatrix = v.compatibility_matrix?
+                            .Where(c => c != null)
+                            .Select(c => new PackageCompatibilityEntry
+                            {
+                                Name = c.name,
+                                Versions = c.versions?.ToList(),
+                                Min = c.min,
+                                Max = c.max
+                            })
+                            .ToList() ?? new List<PackageCompatibilityEntry>()
+                    })
+                    .ToList() ?? new List<PackageVersionInfo>();
+
+                packageDetails.NumVersions = packageDetails.Versions.Count;
+            }
+
             var payload = new { payload = packageDetails };
             var options = new JsonSerializerOptions
             {
@@ -672,6 +715,30 @@ namespace Dynamo.UI.Views
             {
                 await dynWebView.CoreWebView2.ExecuteScriptAsync($"window.receiveUpdatedPackageDetails({jsonPayload});");
             }
+        }
+
+        private async Task<Greg.Responses.PackageHeader> TryGetPackageHeaderAsync(PublishPackageViewModel vm)
+        {
+            var pmClientVm = vm?.DynamoViewModel?.PackageManagerClientViewModel;
+            var pkgName = vm?.Package?.Name ?? vm?.Name;
+            if (string.IsNullOrWhiteSpace(pkgName) || pmClientVm == null) return null;
+
+            // Best-effort: prefer direct server call (one package) over cache.
+            // This call returns a PackageHeader that includes versions[*].compatibility_matrix.
+            if (pmClientVm.Model != null && !pmClientVm.Model.NoNetworkMode)
+            {
+                try
+                {
+                    return await Task.Run(() =>
+                        pmClientVm.Model.GetPackageMaintainers(new PackageInfo(pkgName, new Version(0, 0, 0))));
+                }
+                catch
+                {
+                    // Fall back to cached list below.
+                }
+            }
+
+            return pmClientVm.CachedPackageList?.FirstOrDefault(x => x.Name == pkgName)?.Header;
         }
 
         private async void UpdateRetainFolderStructureFlag(bool flag)

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -206,8 +206,9 @@ namespace Dynamo.UI.Views
                 if (publishPackageViewModel.PreviewPackageContents?.Count > 0) UpdatePreviewPackageContents();
                 if (publishPackageViewModel.CompatibilityMatrix?.Count > 0) SendCompatibilityMatrix(publishPackageViewModel.CompatibilityMatrix);
                 // If this publish flow is based on an existing local package, attempt to also send
-                // server-cached per-version compatibility/host dependency info (if available).
-                SendCompatibilityAndHostsByVersionFromCache();
+                // server-cached package/version info (including per-version compatibility matrices)
+                // in the format expected by the compatibility editor.
+                SendSelectedPackageFromCache();
                 if (publishPackageViewModel.RetainFolderStructureOverride) UpdateRetainFolderStructureFlag(publishPackageViewModel.RetainFolderStructureOverride);
             }
         }
@@ -421,11 +422,15 @@ namespace Dynamo.UI.Views
         }
 
         /// <summary>
-        /// Sends per-version compatibility matrices (and host dependencies) for the current package,
-        /// using the cached package list (server metadata) if present. This is a best-effort call:
-        /// it is guarded so older front-ends without the handler do not throw.
+        /// Sends the selected package information (including all versions and their compatibility matrices)
+        /// using the cached package list (server metadata) if present.
+        ///
+        /// This payload is intended to match the shape expected by the compatibility editor, e.g.:
+        /// { timestamp, success, message, content: { name, _id, versions: [ { version, compatibility_matrix, host_dependencies, ... } ] } }
+        ///
+        /// This is a best-effort call and is guarded so older front-ends without the handler do not throw.
         /// </summary>
-        private async void SendCompatibilityAndHostsByVersionFromCache()
+        private async void SendSelectedPackageFromCache()
         {
             try
             {
@@ -436,20 +441,19 @@ namespace Dynamo.UI.Views
                 if (cachedList == null) return;
 
                 var cached = cachedList.FirstOrDefault(x => x.Name == pkg.Name);
-                var versions = cached?.Header?.versions;
-                if (versions == null || versions.Count == 0) return;
+                var header = cached?.Header;
+                var versions = header?.versions;
+                if (header == null || versions == null || versions.Count == 0) return;
 
-                // Normalize to a stable JSON shape for the front-end.
-                var versionData = versions
+                var versionsPayload = versions
                     .Where(v => v != null)
                     .Select(v => new
                     {
                         version = v.version,
                         created = v.created,
-                        hostDependencies = v.host_dependencies?.ToList(),
-                        // compatibility_matrix is a list of Greg.Responses.Compatibility objects.
-                        // Normalize fields to avoid relying on implementation-specific serialization details.
-                        compatibilityMatrix = v.compatibility_matrix?.Select(c => new
+                        engine_version = v.engine_version,
+                        host_dependencies = v.host_dependencies?.ToList(),
+                        compatibility_matrix = v.compatibility_matrix?.Select(c => new
                         {
                             name = c.name,
                             versions = c.versions,
@@ -459,24 +463,57 @@ namespace Dynamo.UI.Views
                     })
                     .ToList();
 
-                // Only send if there's meaningful per-version data.
-                if (!versionData.Any(d => (d.compatibilityMatrix?.Count ?? 0) > 0 || (d.hostDependencies?.Count ?? 0) > 0))
-                    return;
+                // Only useful if there's at least one compatibility matrix present.
+                if (!versionsPayload.Any(v => (v.compatibility_matrix?.Count ?? 0) > 0)) return;
 
-                var payload = new
+                var contentPayload = new
                 {
-                    packageName = cached?.Name ?? pkg.Name,
-                    installedVersion = pkg.VersionName,
-                    versions = versionData
+                    repository_url = header.repository_url,
+                    created = header.created,
+                    downloads = header.downloads,
+                    latest_version_update = header.latest_version_update,
+                    site_url = header.site_url,
+                    license = header.license,
+                    maintainers = header.maintainers?.Select(m => new { _id = m._id, username = m.username }).ToList(),
+                    keywords = header.keywords?.ToList(),
+                    description = header.description,
+                    engine = header.engine,
+                    used_by = header.used_by,
+                    versions = versionsPayload,
+                    _id = header._id,
+                    name = header.name,
+                    group = header.group,
+                    num_versions = header.num_versions
                 };
 
-                string jsonPayload = Newtonsoft.Json.JsonConvert.SerializeObject(payload, Formatting.None);
+                var selectedPackagePayload = new
+                {
+                    timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    success = true,
+                    message = "Found package",
+                    content = contentPayload
+                };
+
+                // Best-effort: use a computed version string for the current publish VM, fallback to installed package version.
+                var selectedVersion = $"{publishPackageViewModel?.MajorVersion}.{publishPackageViewModel?.MinorVersion}.{publishPackageViewModel?.BuildVersion}";
+                if (string.IsNullOrWhiteSpace(publishPackageViewModel?.MajorVersion) ||
+                    string.IsNullOrWhiteSpace(publishPackageViewModel?.MinorVersion) ||
+                    string.IsNullOrWhiteSpace(publishPackageViewModel?.BuildVersion))
+                {
+                    selectedVersion = pkg.VersionName;
+                }
+
+                string selectedPackageJson = Newtonsoft.Json.JsonConvert.SerializeObject(selectedPackagePayload, Formatting.None);
+                string selectedVersionJson = Newtonsoft.Json.JsonConvert.SerializeObject(new { version = selectedVersion }, Formatting.None);
 
                 if (dynWebView?.CoreWebView2 != null)
                 {
-                    // Guarded call: does nothing if the handler is missing on older front-ends.
+                    // Guarded calls: do nothing if the handler is missing on older front-ends.
                     await dynWebView.CoreWebView2.ExecuteScriptAsync(
-                        $"window.receiveCompatibilityAndHostsByVersion && window.receiveCompatibilityAndHostsByVersion({jsonPayload});");
+                        $"window.receiveSelectedPackage && window.receiveSelectedPackage({selectedPackageJson});");
+
+                    await dynWebView.CoreWebView2.ExecuteScriptAsync(
+                        $"window.receiveSelectedPackageVersion && window.receiveSelectedPackageVersion({selectedVersionJson});");
                 }
             }
             catch (Exception ex)

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -469,9 +469,7 @@ namespace Dynamo.UI.Views
                 var contentPayload = new
                 {
                     repository_url = header.repository_url,
-                    created = header.created,
                     downloads = header.downloads,
-                    latest_version_update = header.latest_version_update,
                     site_url = header.site_url,
                     license = header.license,
                     maintainers = header.maintainers?.Select(m => new { _id = m._id, username = m.username }).ToList(),

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -417,125 +417,10 @@ namespace Dynamo.UI.Views
             }
         }
 
-        /// <summary>
-        /// Sends the selected package information (including all versions and their compatibility matrices)
-        /// using the cached package list (server metadata) if present.
-        ///
-        /// This payload is intended to match the shape expected by the compatibility editor, e.g.:
-        /// { timestamp, success, message, content: { name, _id, versions: [ { version, compatibility_matrix, host_dependencies, ... } ] } }
-        ///
-        /// This is a best-effort call and is guarded so older front-ends without the handler do not throw.
-        /// </summary>
-        private async void SendSelectedPackageFromCache()
-        {
-            try
-            {
-                var pkg = publishPackageViewModel?.Package;
-                if (pkg == null) return;
-
-                var cachedList = publishPackageViewModel?.DynamoViewModel?.PackageManagerClientViewModel?.CachedPackageList;
-                var pmClientVm = publishPackageViewModel?.DynamoViewModel?.PackageManagerClientViewModel;
-
-                // Prefer a direct server call (best-effort) to fetch complete version history
-                // over relying on a potentially stale/partial cache.
-                Greg.Responses.PackageHeader header = null;
-                try
-                {
-                    if (pmClientVm?.Model != null && !pmClientVm.Model.NoNetworkMode)
-                    {
-                        header = await Task.Run(() =>
-                            pmClientVm.Model.GetPackageMaintainers(new PackageInfo(pkg.Name, new Version(pkg.VersionName))));
-                    }
-                }
-                catch
-                {
-                    // Fall back to cached list below.
-                }
-
-                if (header == null)
-                {
-                    if (cachedList == null) return;
-                    var cached = cachedList.FirstOrDefault(x => x.Name == pkg.Name);
-                    header = cached?.Header;
-                }
-
-                var versions = header?.versions;
-                if (header == null || versions == null || versions.Count == 0) return;
-
-                var versionsPayload = versions
-                    .Where(v => v != null)
-                    .Select(v => new
-                    {
-                        version = v.version,
-                        created = v.created,
-                        engine_version = v.engine_version,
-                        host_dependencies = v.host_dependencies?.ToList(),
-                        compatibility_matrix = v.compatibility_matrix?.Select(c => new
-                        {
-                            name = c.name,
-                            versions = c.versions,
-                            min = c.min,
-                            max = c.max
-                        }).ToList()
-                    })
-                    .ToList();
-
-                // Only useful if there's at least one compatibility matrix present.
-                if (!versionsPayload.Any(v => (v.compatibility_matrix?.Count ?? 0) > 0)) return;
-
-                var contentPayload = new
-                {
-                    repository_url = header.repository_url,
-                    downloads = header.downloads,
-                    site_url = header.site_url,
-                    license = header.license,
-                    maintainers = header.maintainers?.Select(m => new { _id = m._id, username = m.username }).ToList(),
-                    keywords = header.keywords?.ToList(),
-                    description = header.description,
-                    engine = header.engine,
-                    used_by = header.used_by,
-                    versions = versionsPayload,
-                    _id = header._id,
-                    name = header.name,
-                    group = header.group,
-                    num_versions = header.num_versions
-                };
-
-                var selectedPackagePayload = new
-                {
-                    timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                    success = true,
-                    message = "Found package",
-                    content = contentPayload
-                };
-
-                // Best-effort: use a computed version string for the current publish VM, fallback to installed package version.
-                var selectedVersion = $"{publishPackageViewModel?.MajorVersion}.{publishPackageViewModel?.MinorVersion}.{publishPackageViewModel?.BuildVersion}";
-                if (string.IsNullOrWhiteSpace(publishPackageViewModel?.MajorVersion) ||
-                    string.IsNullOrWhiteSpace(publishPackageViewModel?.MinorVersion) ||
-                    string.IsNullOrWhiteSpace(publishPackageViewModel?.BuildVersion))
-                {
-                    selectedVersion = pkg.VersionName;
-                }
-
-                string selectedPackageJson = Newtonsoft.Json.JsonConvert.SerializeObject(selectedPackagePayload, Formatting.None);
-                string selectedVersionJson = Newtonsoft.Json.JsonConvert.SerializeObject(new { version = selectedVersion }, Formatting.None);
-
-                if (dynWebView?.CoreWebView2 != null)
-                {
-                    // Guarded calls: do nothing if the handler is missing on older front-ends.
-                    await dynWebView.CoreWebView2.ExecuteScriptAsync(
-                        $"window.receiveSelectedPackage && window.receiveSelectedPackage({selectedPackageJson});");
-
-                    await dynWebView.CoreWebView2.ExecuteScriptAsync(
-                        $"window.receiveSelectedPackageVersion && window.receiveSelectedPackageVersion({selectedVersionJson});");
-                }
-            }
-            catch (Exception ex)
-            {
-                LogMessage(ex);
-            }
-        }
+        // NOTE:
+        // Previous iterations used a separate "selected package" side-channel message for version history.
+        // The current front-end architecture populates state.selectedPackage ONLY via
+        // window.receiveUpdatedPackageDetails({ payload }), so version history is now injected there instead.
 
         private async void SendUpdatedPackageContents(object frontendData, string type)
         {
@@ -656,60 +541,49 @@ namespace Dynamo.UI.Views
                 ReleaseNotesUrl = vm.ReleaseNotesUrl ?? string.Empty
             };
 
-            // IMPORTANT:
-            // The front-end uses receiveUpdatedPackageDetails({ payload }) to populate state.selectedPackage.
-            // To enable the "Copy from" dropdown in the compatibility editor, this payload must include
-            // package version history: payload.versions[*].compatibility_matrix.
-            var header = await TryGetPackageHeaderAsync(vm);
-            if (header != null)
-            {
-                packageDetails.Id = header._id ?? string.Empty;
-                packageDetails.Downloads = header.downloads;
-                packageDetails.Votes = header.votes;
-                packageDetails.UsedBy = header.used_by;
-
-                // Best-effort: use earliest version created date as package created date.
-                packageDetails.Created = header.versions?.FirstOrDefault()?.created ?? string.Empty;
-
-                packageDetails.Maintainers = header.maintainers?
-                    .Select(m => new PackageMaintainer
-                    {
-                        Id = m._id,
-                        Username = m.username
-                    })
-                    .ToList() ?? new List<PackageMaintainer>();
-
-                packageDetails.Versions = header.versions?
-                    .Where(v => v != null)
-                    .Select(v => new PackageVersionInfo
-                    {
-                        Version = v.version,
-                        Created = v.created,
-                        EngineVersion = v.engine_version,
-                        HostDependencies = v.host_dependencies?.ToList() ?? new List<string>(),
-                        CompatibilityMatrix = v.compatibility_matrix?
-                            .Where(c => c != null)
-                            .Select(c => new PackageCompatibilityEntry
-                            {
-                                Name = c.name,
-                                Versions = c.versions?.ToList(),
-                                Min = c.min,
-                                Max = c.max
-                            })
-                            .ToList() ?? new List<PackageCompatibilityEntry>()
-                    })
-                    .ToList() ?? new List<PackageVersionInfo>();
-
-                packageDetails.NumVersions = packageDetails.Versions.Count;
-            }
-
             var payload = new { payload = packageDetails };
             var options = new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
             };
 
-            string jsonPayload = JsonSerializer.Serialize(payload, options);
+            // Base payload for receiveUpdatedPackageDetails({ payload })
+            var jsonPayload = JsonSerializer.Serialize(payload, options);
+
+            // IMPORTANT:
+            // The front-end stores state.selectedPackage = payload (UPDATE_PACKAGE action).
+            // To populate the compatibility "Copy from" dropdown, this payload must include:
+            // payload.versions[*].compatibility_matrix (historical).
+            try
+            {
+                var header = await TryGetPackageHeaderAsync(vm);
+                if (header != null)
+                {
+                    var rootObj = JObject.Parse(jsonPayload);
+                    if (rootObj["payload"] is JObject payloadObj)
+                    {
+                        // Prefer server/header values for package identity & history; keep major/minor/patch fields too.
+                        payloadObj["_id"] = header._id ?? string.Empty;
+                        payloadObj["downloads"] = header.downloads;
+                        payloadObj["votes"] = header.votes;
+                        payloadObj["engine"] = header.engine ?? "dynamo";
+                        payloadObj["used_by"] = header.used_by != null ? JToken.FromObject(header.used_by) : new JArray();
+                        payloadObj["maintainers"] = header.maintainers != null ? JToken.FromObject(header.maintainers) : new JArray();
+                        payloadObj["versions"] = header.versions != null ? JToken.FromObject(header.versions) : new JArray();
+                        payloadObj["num_versions"] = header.num_versions != 0 ? header.num_versions : (header.versions?.Count ?? 0);
+
+                        // Best-effort: these are part of ExtendedPackage shape on the front-end.
+                        payloadObj["created"] = header.versions?.FirstOrDefault()?.created ?? string.Empty;
+                        payloadObj["latest_version_update"] = $"{vm.MajorVersion}.{vm.MinorVersion}.{vm.BuildVersion}";
+                    }
+
+                    jsonPayload = rootObj.ToString(Newtonsoft.Json.Formatting.None);
+                }
+            }
+            catch (Exception ex)
+            {
+                LogMessage(ex);
+            }
 
             if (dynWebView?.CoreWebView2 != null)   
             {
@@ -723,22 +597,25 @@ namespace Dynamo.UI.Views
             var pkgName = vm?.Package?.Name ?? vm?.Name;
             if (string.IsNullOrWhiteSpace(pkgName) || pmClientVm == null) return null;
 
-            // Best-effort: prefer direct server call (one package) over cache.
-            // This call returns a PackageHeader that includes versions[*].compatibility_matrix.
+            // Prefer cached header if available; otherwise, fetch from server via ListAll (best-effort).
+            // ListAll returns PackageHeader objects with versions[*].compatibility_matrix included (when present).
+            var cachedHeader = pmClientVm.CachedPackageList?.FirstOrDefault(x => x.Name == pkgName)?.Header;
+            if (cachedHeader != null) return cachedHeader;
+
             if (pmClientVm.Model != null && !pmClientVm.Model.NoNetworkMode)
             {
                 try
                 {
-                    return await Task.Run(() =>
-                        pmClientVm.Model.GetPackageMaintainers(new PackageInfo(pkgName, new Version(0, 0, 0))));
+                    await Task.Run(() => pmClientVm.ListAll());
+                    return pmClientVm.CachedPackageList?.FirstOrDefault(x => x.Name == pkgName)?.Header;
                 }
                 catch
                 {
-                    // Fall back to cached list below.
+                    // ignore
                 }
             }
 
-            return pmClientVm.CachedPackageList?.FirstOrDefault(x => x.Name == pkgName)?.Header;
+            return null;
         }
 
         private async void UpdateRetainFolderStructureFlag(bool flag)

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -562,19 +562,10 @@ namespace Dynamo.UI.Views
                     var rootObj = JObject.Parse(jsonPayload);
                     if (rootObj["payload"] is JObject payloadObj)
                     {
-                        // Prefer server/header values for package identity & history; keep major/minor/patch fields too.
-                        payloadObj["_id"] = header._id ?? string.Empty;
-                        payloadObj["downloads"] = header.downloads;
-                        payloadObj["votes"] = header.votes;
-                        payloadObj["engine"] = header.engine ?? "dynamo";
-                        payloadObj["used_by"] = header.used_by != null ? JToken.FromObject(header.used_by) : new JArray();
-                        payloadObj["maintainers"] = header.maintainers != null ? JToken.FromObject(header.maintainers) : new JArray();
+                        // Keep the original publish payload shape to avoid regressions,
+                        // and ONLY add the package version history so the compatibility editor
+                        // can populate the "Copy from" dropdown (versions[*].compatibility_matrix).
                         payloadObj["versions"] = header.versions != null ? JToken.FromObject(header.versions) : new JArray();
-                        payloadObj["num_versions"] = header.num_versions != 0 ? header.num_versions : (header.versions?.Count ?? 0);
-
-                        // Best-effort: these are part of ExtendedPackage shape on the front-end.
-                        payloadObj["created"] = header.versions?.FirstOrDefault()?.created ?? string.Empty;
-                        payloadObj["latest_version_update"] = $"{vm.MajorVersion}.{vm.MinorVersion}.{vm.BuildVersion}";
                     }
 
                     jsonPayload = rootObj.ToString(Newtonsoft.Json.Formatting.None);

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -205,6 +205,9 @@ namespace Dynamo.UI.Views
                 if (publishPackageViewModel.PackageContents?.Count > 0) UpdatePackageContents();
                 if (publishPackageViewModel.PreviewPackageContents?.Count > 0) UpdatePreviewPackageContents();
                 if (publishPackageViewModel.CompatibilityMatrix?.Count > 0) SendCompatibilityMatrix(publishPackageViewModel.CompatibilityMatrix);
+                // If this publish flow is based on an existing local package, attempt to also send
+                // server-cached per-version compatibility/host dependency info (if available).
+                SendCompatibilityAndHostsByVersionFromCache();
                 if (publishPackageViewModel.RetainFolderStructureOverride) UpdateRetainFolderStructureFlag(publishPackageViewModel.RetainFolderStructureOverride);
             }
         }
@@ -414,6 +417,71 @@ namespace Dynamo.UI.Views
                 {
                     await dynWebView.CoreWebView2.ExecuteScriptAsync($"window.receiveCompatibilityMatrix({jsonPayload})");
                 }
+            }
+        }
+
+        /// <summary>
+        /// Sends per-version compatibility matrices (and host dependencies) for the current package,
+        /// using the cached package list (server metadata) if present. This is a best-effort call:
+        /// it is guarded so older front-ends without the handler do not throw.
+        /// </summary>
+        private async void SendCompatibilityAndHostsByVersionFromCache()
+        {
+            try
+            {
+                var pkg = publishPackageViewModel?.Package;
+                if (pkg == null) return;
+
+                var cachedList = publishPackageViewModel?.DynamoViewModel?.PackageManagerClientViewModel?.CachedPackageList;
+                if (cachedList == null) return;
+
+                var cached = cachedList.FirstOrDefault(x => x.Name == pkg.Name);
+                var versions = cached?.Header?.versions;
+                if (versions == null || versions.Count == 0) return;
+
+                // Normalize to a stable JSON shape for the front-end.
+                var versionData = versions
+                    .Where(v => v != null)
+                    .Select(v => new
+                    {
+                        version = v.version,
+                        created = v.created,
+                        hostDependencies = v.host_dependencies?.ToList(),
+                        // compatibility_matrix is a list of Greg.Responses.Compatibility objects.
+                        // Normalize fields to avoid relying on implementation-specific serialization details.
+                        compatibilityMatrix = v.compatibility_matrix?.Select(c => new
+                        {
+                            name = c.name,
+                            versions = c.versions,
+                            min = c.min,
+                            max = c.max
+                        }).ToList()
+                    })
+                    .ToList();
+
+                // Only send if there's meaningful per-version data.
+                if (!versionData.Any(d => (d.compatibilityMatrix?.Count ?? 0) > 0 || (d.hostDependencies?.Count ?? 0) > 0))
+                    return;
+
+                var payload = new
+                {
+                    packageName = cached?.Name ?? pkg.Name,
+                    installedVersion = pkg.VersionName,
+                    versions = versionData
+                };
+
+                string jsonPayload = Newtonsoft.Json.JsonConvert.SerializeObject(payload, Formatting.None);
+
+                if (dynWebView?.CoreWebView2 != null)
+                {
+                    // Guarded call: does nothing if the handler is missing on older front-ends.
+                    await dynWebView.CoreWebView2.ExecuteScriptAsync(
+                        $"window.receiveCompatibilityAndHostsByVersion && window.receiveCompatibilityAndHostsByVersion({jsonPayload});");
+                }
+            }
+            catch (Exception ex)
+            {
+                LogMessage(ex);
             }
         }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -438,10 +438,31 @@ namespace Dynamo.UI.Views
                 if (pkg == null) return;
 
                 var cachedList = publishPackageViewModel?.DynamoViewModel?.PackageManagerClientViewModel?.CachedPackageList;
-                if (cachedList == null) return;
+                var pmClientVm = publishPackageViewModel?.DynamoViewModel?.PackageManagerClientViewModel;
 
-                var cached = cachedList.FirstOrDefault(x => x.Name == pkg.Name);
-                var header = cached?.Header;
+                // Prefer a direct server call (best-effort) to fetch complete version history
+                // over relying on a potentially stale/partial cache.
+                Greg.Responses.PackageHeader header = null;
+                try
+                {
+                    if (pmClientVm?.Model != null && !pmClientVm.Model.NoNetworkMode)
+                    {
+                        header = await Task.Run(() =>
+                            pmClientVm.Model.GetPackageMaintainers(new PackageInfo(pkg.Name, new Version(pkg.VersionName))));
+                    }
+                }
+                catch
+                {
+                    // Fall back to cached list below.
+                }
+
+                if (header == null)
+                {
+                    if (cachedList == null) return;
+                    var cached = cachedList.FirstOrDefault(x => x.Name == pkg.Name);
+                    header = cached?.Header;
+                }
+
                 var versions = header?.versions;
                 if (header == null || versions == null || versions.Count == 0) return;
 

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -550,10 +550,7 @@ namespace Dynamo.UI.Views
             // Base payload for receiveUpdatedPackageDetails({ payload })
             var jsonPayload = JsonSerializer.Serialize(payload, options);
 
-            // IMPORTANT:
-            // The front-end stores state.selectedPackage = payload (UPDATE_PACKAGE action).
-            // To populate the compatibility "Copy from" dropdown, this payload must include:
-            // payload.versions[*].compatibility_matrix (historical).
+            // IMPORTANT: include payload.versions[*].compatibility_matrix for "Copy from".
             try
             {
                 var header = await TryGetPackageHeaderAsync(vm);
@@ -582,7 +579,11 @@ namespace Dynamo.UI.Views
             }
         }
 
-        private async Task<Greg.Responses.PackageHeader> TryGetPackageHeaderAsync(PublishPackageViewModel vm)
+        /// <summary>
+        /// Tries to retrieve the server-side <see cref="Greg.Responses.PackageHeader"/> for the current package.
+        /// Uses <see cref="PackageManagerClientViewModel.CachedPackageList"/> when available; otherwise refreshes
+        /// the cache via <see cref="PackageManagerClientViewModel.ListAll"/> (best-effort, respects NoNetworkMode).
+        /// </summary>
         {
             var pmClientVm = vm?.DynamoViewModel?.PackageManagerClientViewModel;
             var pkgName = vm?.Package?.Name ?? vm?.Name;


### PR DESCRIPTION
### Purpose

This PR amends the Package Manager Wizard to send per-version compatibility matrices and host dependencies for existing packages to the frontend. This addresses a user request to provide historical compatibility information in the wizard when publishing a new version of an existing package.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

When publishing a new version of an existing package, the Package Manager Wizard now sends historical compatibility matrices and host dependencies for all available versions (from cached server metadata) to the frontend. This enables the UI to display a more comprehensive view of the package's compatibility over time.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

---
<a href="https://cursor.com/background-agent?bcId=bc-278408aa-f9cb-4458-a76a-cf93b0fc0b17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-278408aa-f9cb-4458-a76a-cf93b0fc0b17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

