### PR TITLE
Package manager updates sending

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -537,12 +537,7 @@ namespace Dynamo.UI.Views
             };
 
             var payload = new { payload = packageDetails };
-            var options = new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            };
-
-            var jsonPayload = JsonSerializer.Serialize(payload, options);
+            var jsonPayload = Newtonsoft.Json.JsonConvert.SerializeObject(payload, Formatting.None);
 
             // Include payload.versions[*].compatibility_matrix for the "Copy from" dropdown.
             try
@@ -1389,42 +1384,55 @@ namespace Dynamo.UI.Views
     public class PackageUpdateRequest : IEquatable<PackageUpdateRequest>
     {
         [JsonPropertyName("name")]
+        [JsonProperty("name")]
         public string Name { get; set; }
 
         [JsonPropertyName("description")]
+        [JsonProperty("description")]
         public string Description { get; set; }
 
         [JsonPropertyName("major")]
+        [JsonProperty("major")]
         public string Major { get; set; }
 
         [JsonPropertyName("minor")]
+        [JsonProperty("minor")]
         public string Minor { get; set; }
 
         [JsonPropertyName("patch")]
+        [JsonProperty("patch")]
         public string Patch { get; set; }
 
         [JsonPropertyName("keywords")]
+        [JsonProperty("keywords")]
         public List<string> Keywords { get; set; } = new();
 
         [JsonPropertyName("release_notes_url")]
+        [JsonProperty("release_notes_url")]
         public string ReleaseNotesUrl { get; set; }
 
         [JsonPropertyName("copyright_holder")]
+        [JsonProperty("copyright_holder")]
         public string CopyrightHolder { get; set; }
 
         [JsonPropertyName("copyright_year")]
+        [JsonProperty("copyright_year")]
         public string CopyrightYear { get; set; }
 
         [JsonPropertyName("license")]
+        [JsonProperty("license")]
         public string License { get; set; }
 
         [JsonPropertyName("repository_url")]
+        [JsonProperty("repository_url")]
         public string RepositoryUrl { get; set; }
 
         [JsonPropertyName("site_url")]
+        [JsonProperty("site_url")]
         public string SiteUrl { get; set; }
 
         [JsonPropertyName("group")]
+        [JsonProperty("group")]
         public string Group { get; set; }
 
         public bool Equals(PackageUpdateRequest other)


### PR DESCRIPTION
### Purpose

This PR switches the serialization of `PackageUpdateRequest` in `PackageManagerWizard.SendPackageUpdates` from `System.Text.Json` to `Newtonsoft.Json`. This change ensures consistent serialization throughout the process, avoiding issues with mixed serializers and maintaining correct payload formatting, particularly for version injection. `Newtonsoft.Json.JsonProperty` attributes have been added to `PackageUpdateRequest` properties to preserve field names during serialization.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

---
<a href="https://cursor.com/background-agent?bcId=bc-719934b5-933a-4907-8c26-9b49415f62c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-719934b5-933a-4907-8c26-9b49415f62c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

