### PR TITLE
Code review comment

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -542,7 +542,7 @@ namespace Dynamo.UI.Views
             {
                 ContractResolver = new CamelCasePropertyNamesContractResolver()
             };
-            var jsonSerializer = JsonSerializer.Create(jsonSerializerSettings);
+            var jsonSerializer = Newtonsoft.Json.JsonSerializer.Create(jsonSerializerSettings);
             var rootObj = JObject.FromObject(payload, jsonSerializer);
             var jsonPayload = rootObj.ToString(Newtonsoft.Json.Formatting.None);
 

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -544,7 +544,6 @@ namespace Dynamo.UI.Views
             };
             var jsonSerializer = Newtonsoft.Json.JsonSerializer.Create(jsonSerializerSettings);
             var rootObj = JObject.FromObject(payload, jsonSerializer);
-            var jsonPayload = rootObj.ToString(Newtonsoft.Json.Formatting.None);
 
             // Include payload.versions[*].compatibility_matrix for the "Copy from" dropdown.
             try
@@ -559,7 +558,6 @@ namespace Dynamo.UI.Views
                             : new JArray();
                     }
 
-                    jsonPayload = rootObj.ToString(Newtonsoft.Json.Formatting.None);
                 }
             }
             catch (Exception ex)
@@ -567,6 +565,7 @@ namespace Dynamo.UI.Views
                 LogMessage(ex);
             }
 
+            var jsonPayload = rootObj.ToString(Newtonsoft.Json.Formatting.None);
 
             if (dynWebView?.CoreWebView2 != null)   
             {

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -22,6 +22,7 @@ using Newtonsoft.Json;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 using Greg.Requests;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 using Dynamo.Models;
 using System.Globalization;
 
@@ -537,12 +538,13 @@ namespace Dynamo.UI.Views
             };
 
             var payload = new { payload = packageDetails };
-            var options = new JsonSerializerOptions
+            var jsonSerializerSettings = new JsonSerializerSettings
             {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
             };
-
-            var jsonPayload = JsonSerializer.Serialize(payload, options);
+            var jsonSerializer = JsonSerializer.Create(jsonSerializerSettings);
+            var rootObj = JObject.FromObject(payload, jsonSerializer);
+            var jsonPayload = rootObj.ToString(Newtonsoft.Json.Formatting.None);
 
             // Include payload.versions[*].compatibility_matrix for the "Copy from" dropdown.
             try
@@ -550,10 +552,11 @@ namespace Dynamo.UI.Views
                 var header = await TryGetPackageHeaderAsync(vm);
                 if (header != null)
                 {
-                    var rootObj = JObject.Parse(jsonPayload);
                     if (rootObj["payload"] is JObject payloadObj)
-                    {                        
-                        payloadObj["versions"] = header.versions != null ? JToken.FromObject(header.versions) : new JArray();
+                    {
+                        payloadObj["versions"] = header.versions != null
+                            ? JToken.FromObject(header.versions, jsonSerializer)
+                            : new JArray();
                     }
 
                     jsonPayload = rootObj.ToString(Newtonsoft.Json.Formatting.None);


### PR DESCRIPTION
### Purpose

This PR refactors the `SendPackageUpdates` method to exclusively use `Newtonsoft.Json` for all JSON serialization and manipulation of the package payload. This resolves an inconsistency where `System.Text.Json` and `Newtonsoft.Json` were being mixed in the same JSON processing flow, ensuring consistent camelCase property naming and preventing potential serialization conflicts.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A (Internal refactor)

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

---
<a href="https://cursor.com/background-agent?bcId=bc-a6edbf05-ef32-4ac2-befa-df691014c627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a6edbf05-ef32-4ac2-befa-df691014c627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

