### PR TITLE
Package manager cleanup

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -327,10 +327,6 @@ Dynamo.Controls.InOutParamTypeConverter
 Dynamo.Controls.InOutParamTypeConverter.Convert(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
 Dynamo.Controls.InOutParamTypeConverter.ConvertBack(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
 Dynamo.Controls.InOutParamTypeConverter.InOutParamTypeConverter() -> void
-Dynamo.Controls.InstallButtonTextConverter
-Dynamo.Controls.InstallButtonTextConverter.Convert(object[] values, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
-Dynamo.Controls.InstallButtonTextConverter.ConvertBack(object value, System.Type[] targetTypes, object parameter, System.Globalization.CultureInfo culture) -> object[]
-Dynamo.Controls.InstallButtonTextConverter.InstallButtonTextConverter() -> void
 Dynamo.Controls.InstalledButtonTextConverter
 Dynamo.Controls.InstalledButtonTextConverter.Convert(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
 Dynamo.Controls.InstalledButtonTextConverter.ConvertBack(object value, System.Type targetType, object parameter, System.Globalization.CultureInfo culture) -> object
@@ -1362,8 +1358,6 @@ Dynamo.PackageManager.UI.TermsOfUseView.TermsOfUseView(string touFilePath) -> vo
 Dynamo.PackageManager.UI.TreeViewItemHelper
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.CanInstall.get -> bool
-Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.CanInstallOrUpgrade.get -> bool
-Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.CanUpgrade.get -> bool
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.DownloadLatestCommand.get -> System.Windows.Input.ICommand
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.DownloadLatestCommand.set -> void
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.DownloadLatestToCustomPathCommand.get -> System.Windows.Input.ICommand

--- a/src/DynamoCoreWpf/UI/Converters.cs
+++ b/src/DynamoCoreWpf/UI/Converters.cs
@@ -405,42 +405,6 @@ namespace Dynamo.Controls
     }
 
     /// <summary>
-    /// Determines what the Install button says on the Package Manager Search.
-    /// If the package can be installed it says 'Install', if it can be upgraded
-    /// it says 'Upgrade', otherwise 'Installed'.
-    /// </summary>
-    public class InstallButtonTextConverter : IMultiValueConverter
-    {
-        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (values == null || values.Length < 3) return null;
-            if (!(values[0] is bool canInstall) || !(values[1] is bool canUpgrade) || !(values[2] is bool canDowngrade)) return null;
-
-            if (canInstall)
-            {
-                return Resources.PackageManagerInstall;
-            }
-
-            if (canUpgrade)
-            {
-                return Resources.PackageManagerUpgrade;
-            }
-
-            if (canDowngrade)
-            {
-                return Resources.PackageManagerDowngrade;
-            }
-
-            return Resources.PackageDownloadStateInstalled;
-        }
-
-        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
-        {
-            return null;
-        }
-    }
-
-    /// <summary>
     /// If the given string is empty, false is returned, otherwise true is returned.
     /// </summary>
     public class EmptyStringToFalseConverter : IValueConverter

--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoConverters.xaml
@@ -62,7 +62,6 @@
     <controls:NegativeIntToZeroConverter x:Key="NegativeIntToZeroConverter" />
     <controls:NonEmptyStringToCollapsedConverter x:Key="NonEmptyStringToCollapsedConverter" />
     <controls:InstalledButtonTextConverter x:Key="InstalledButtonTextConverter" />
-    <controls:InstallButtonTextConverter x:Key="InstallButtonTextConverter" />
     <controls:SearchResultsToVisibilityConverter x:Key="SearchResultsToVisibilityConverter" />
     <controls:EnumToBooleanConverter x:Key="EnumToBoolConverter" />
     <controls:PackageUploadStateToStringConverter x:Key="PackageUploadStateToStringConverter" />

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
@@ -188,7 +188,7 @@ namespace Dynamo.PackageManager.ViewModels
 
             this.DownloadLatestCommand = new DelegateCommand(
                 () => OnRequestDownload(false),
-                () => !SearchElementModel.IsDeprecated && CanInstallOrUpgrade);
+                () => !SearchElementModel.IsDeprecated);
             this.DownloadLatestToCustomPathCommand = new DelegateCommand(() => OnRequestDownload(true));
 
             this.UpvoteCommand = new DelegateCommand(SearchElementModel.Upvote, () => canLogin);
@@ -259,68 +259,9 @@ namespace Dynamo.PackageManager.ViewModels
                 {
                     canInstall = value;
                     RaisePropertyChanged(nameof(CanInstall));
-                    RaisePropertyChanged(nameof(CanInstallOrUpgrade));
-                    RaiseDownloadLatestCommandCanExecuteChanged();
                 }
             }
         }
-
-        private bool canDowngrade;
-        /// <summary>
-        /// A Boolean flag reporting whether or not the user can downgrade this SearchElement's package.
-        /// </summary>
-        public bool CanDowngrade
-        {
-            get
-            {
-                return canDowngrade;
-            }
-
-            internal set
-            {
-                if (canDowngrade != value)
-                {
-                    canDowngrade = value;
-                    RaisePropertyChanged(nameof(CanDowngrade));
-                    RaisePropertyChanged(nameof(CanInstallOrUpgrade));
-                    RaiseDownloadLatestCommandCanExecuteChanged();
-                }
-            }
-        }
-
-        private bool canUpgrade;
-        /// <summary>
-        /// A Boolean flag reporting whether or not the user can updgrade this SearchElement's package.
-        /// </summary>
-        public bool CanUpgrade
-        {
-            get
-            {
-                return canUpgrade;
-            }
-
-            internal set
-            {
-                if (canUpgrade != value)
-                {
-                    canUpgrade = value;
-                    RaisePropertyChanged(nameof(CanUpgrade));
-                    RaisePropertyChanged(nameof(CanInstallOrUpgrade));
-                    RaiseDownloadLatestCommandCanExecuteChanged();
-                }
-            }
-        }
-
-        /// <summary>
-        /// A Boolean flag reporting whether or not the user can install or upgrade this SearchElement's package.
-        /// </summary>
-        public bool CanInstallOrUpgrade => true;
-        //{
-        //    get
-        //    {
-        //        return CanInstall || CanUpgrade || CanDowngrade;
-        //    }
-        //}
 
         /// <summary>
         /// True if package is enabled for download if custom package paths are not disabled,
@@ -463,13 +404,6 @@ namespace Dynamo.PackageManager.ViewModels
         private bool IsInstalledVersionSelected
         {
             get { return SelectedVersion?.IsInstalled == true; }
-        }
-        private void RaiseDownloadLatestCommandCanExecuteChanged()
-        {
-            if (DownloadLatestCommand is DelegateCommand command)
-            {
-                command.RaiseCanExecuteChanged();
-            }
         }
 
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -528,8 +528,6 @@ namespace Dynamo.PackageManager
             if (hasBlockingDownload)
             {
                 element.CanInstall = false;
-                element.CanUpgrade = false;
-                element.CanDowngrade = false;
                 // RaiseUninstallCommandCanExecuteChanged(element);
                 return;
             }
@@ -541,14 +539,10 @@ namespace Dynamo.PackageManager
             if (!installedPackages.Any())
             {
                 element.CanInstall = true;
-                element.CanUpgrade = false;
-                element.CanDowngrade = false;
                 return;
             }
 
             element.CanInstall = false;
-            element.CanUpgrade = IsUpgradeAvailable(element.SelectedVersion?.Version, installedPackages);
-            element.CanDowngrade = IsDowngradeAvailable(element.SelectedVersion?.Version, installedPackages);
         }
 
 
@@ -714,57 +708,6 @@ namespace Dynamo.PackageManager
 
 
 
-
-
-        /// <summary>
-        /// Checks if an upgrade is available for the given selected version compared to the installed packages.
-        /// </summary>
-        /// <param name="selectedVersion"></param>
-        /// <param name="installedPackages"></param>
-        /// <returns></returns>
-        private bool IsUpgradeAvailable(string selectedVersion, IEnumerable<Package> installedPackages)
-        {
-            var parsedSelectedVersion = VersionUtilities.Parse(selectedVersion);
-            if (parsedSelectedVersion == null)
-            {
-                return false;
-            }
-
-            var newestInstalledVersion = installedPackages
-                .Select(pkg => VersionUtilities.Parse(pkg.VersionName))
-                .Where(parsedVersion => parsedVersion != null)
-                .OrderBy(parsedVersion => parsedVersion)
-                .LastOrDefault();
-
-            if (newestInstalledVersion == null)
-            {
-                return false;
-            }
-
-            return parsedSelectedVersion > newestInstalledVersion;
-        }
-
-        private bool IsDowngradeAvailable(string selectedVersion, IEnumerable<Package> installedPackages)
-        {
-            var parsedSelectedVersion = VersionUtilities.Parse(selectedVersion);
-            if (parsedSelectedVersion == null)
-            {
-                return false;
-            }
-
-            var newestInstalledVersion = installedPackages
-                .Select(pkg => VersionUtilities.Parse(pkg.VersionName))
-                .Where(parsedVersion => parsedVersion != null)
-                .OrderBy(parsedVersion => parsedVersion)
-                .LastOrDefault();
-
-            if (newestInstalledVersion == null)
-            {
-                return false;
-            }
-
-            return parsedSelectedVersion < newestInstalledVersion;
-        }
 
 
 

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
@@ -355,11 +355,7 @@
                                             DockPanel.Dock="Right">
                                                                     <Button.Style>
                                                                         <Style BasedOn="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" TargetType="Button">
-                                                                            <Setter Property="Visibility" Value="{Binding CanInstallOrUpgrade, Converter={StaticResource BoolToVisibilityCollapsedConverter}}" />
                                                                             <Style.Triggers>
-                                                                                <DataTrigger Binding="{Binding IsInstalledVersionSelected}" Value="True">
-                                                                                    <Setter Property="Visibility" Value="Collapsed" />
-                                                                                </DataTrigger>
                                                                                 <!-- CHANGED: also hide when text == Uninstall -->
                                                                                 <DataTrigger Binding="{Binding InstallActionText}" Value="{x:Static p:Resources.PackageManagerUninstall}">
                                                                                     <Setter Property="Visibility" Value="Collapsed" />
@@ -386,9 +382,6 @@
                                                                     <Rectangle.Style>
                                                                         <Style TargetType="Rectangle">
                                                                             <Style.Triggers>
-                                                                                <DataTrigger Binding="{Binding Path=IsInstalledVersionSelected}" Value="True">
-                                                                                    <Setter Property="Visibility" Value="Collapsed" />
-                                                                                </DataTrigger>
                                                                                 <!-- CHANGED: also hide when text == Uninstall -->
                                                                                 <DataTrigger Binding="{Binding Path=InstallActionText}" Value="{x:Static p:Resources.PackageManagerUninstall}">
                                                                                     <Setter Property="Visibility" Value="Collapsed" />
@@ -401,14 +394,6 @@
                                                                                     </Setter>
                                                                                     <Setter Property="Opacity" Value="0.5" />
                                                                                 </DataTrigger>
-                                                                                <DataTrigger Binding="{Binding Path=CanInstallOrUpgrade}" Value="False">
-                                                                                    <Setter Property="Fill">
-                                                                                        <Setter.Value>
-                                                                                            <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/checkmark - grey.png" />
-                                                                                        </Setter.Value>
-                                                                                    </Setter>
-                                                                                    <Setter Property="Opacity" Value="1" />
-                                                                                </DataTrigger>
                                                                                 <DataTrigger Binding="{Binding Path=IsEnabledForInstall}" Value="False">
                                                                                     <Setter Property="Fill">
                                                                                         <Setter.Value>
@@ -420,7 +405,6 @@
                                                                                 <MultiDataTrigger>
                                                                                     <MultiDataTrigger.Conditions>
                                                                                         <Condition Binding="{Binding Path=IsDeprecated}" Value="False" />
-                                                                                        <Condition Binding="{Binding Path=CanInstallOrUpgrade}" Value="True" />
                                                                                         <Condition Binding="{Binding Path=IsEnabledForInstall}" Value="True" />
                                                                                     </MultiDataTrigger.Conditions>
                                                                                     <Setter Property="Fill">
@@ -448,10 +432,6 @@
                                                             <Setter Property="TextBlock.Foreground" Value="#84D7CE" />
                                                             <Setter Property="ToolTip" Value="{x:Static p:Resources.PackageDeprecatedTooltip}" />
                                                         </DataTrigger>
-                                                        <DataTrigger Binding="{Binding CanInstallOrUpgrade}" Value="False">
-                                                            <Setter Property="TextBlock.Foreground" Value="#999999" />
-                                                            <Setter Property="Opacity" Value="1" />
-                                                        </DataTrigger>
                                                         <DataTrigger Binding="{Binding IsEnabledForInstall}" Value="False">
                                                             <Setter Property="TextBlock.Foreground" Value="#999999" />
                                                             <Setter Property="TextBlock.Opacity" Value="1" />
@@ -459,27 +439,10 @@
                                                         <MultiDataTrigger>
                                                             <MultiDataTrigger.Conditions>
                                                                 <Condition Binding="{Binding Path=IsDeprecated}" Value="False" />
-                                                                <Condition Binding="{Binding Path=IsInstalledVersionSelected}" Value="True" />
                                                                 <Condition Binding="{Binding Path=IsEnabledForInstall}" Value="True" />
                                                             </MultiDataTrigger.Conditions>
                                                             <Setter Property="TextBlock.Opacity" Value="1" />
                                                             <Setter Property="TextBlock.Foreground" Value="#84D7CE" />
-                                                        </MultiDataTrigger>
-                                                        <MultiDataTrigger>
-                                                            <MultiDataTrigger.Conditions>
-                                                                <Condition Binding="{Binding Path=IsDeprecated}" Value="False" />
-                                                                <Condition Binding="{Binding Path=CanInstallOrUpgrade}" Value="True" />
-                                                                <Condition Binding="{Binding Path=IsEnabledForInstall}" Value="True" />
-                                                            </MultiDataTrigger.Conditions>
-                                                            <Setter Property="TextBlock.Opacity" Value="1" />
-                                                            <Setter Property="TextBlock.Foreground" Value="#84D7CE" />
-                                                        </MultiDataTrigger>
-                                                        <MultiDataTrigger>
-                                                            <MultiDataTrigger.Conditions>
-                                                                <Condition Binding="{Binding Path=CanInstallOrUpgrade}" Value="False" />
-                                                                <Condition Binding="{Binding Path=IsOnwer}" Value="True" />
-                                                            </MultiDataTrigger.Conditions>
-                                                            <Setter Property="Visibility" Value="Collapsed" />
                                                         </MultiDataTrigger>
                                                     </ControlTemplate.Triggers>
                                                 </ControlTemplate>

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -536,9 +536,6 @@
                                                                         <Rectangle.Style>
                                                                             <Style TargetType="Rectangle">
                                                                                 <Style.Triggers>
-                                                                                    <DataTrigger Binding="{Binding Path=IsInstalledVersionSelected}" Value="True">
-                                                                                        <Setter Property="Visibility" Value="Collapsed" />
-                                                                                    </DataTrigger>
                                                                                     <DataTrigger Binding="{Binding Path=InstallActionText}" Value="{x:Static p:Resources.PackageManagerUninstall}">
                                                                                         <Setter Property="Visibility" Value="Collapsed" />
                                                                                     </DataTrigger>
@@ -549,14 +546,6 @@
                                                                                             </Setter.Value>
                                                                                         </Setter>
                                                                                         <Setter Property="Opacity" Value="0.5" />
-                                                                                    </DataTrigger>
-                                                                                    <DataTrigger Binding="{Binding Path=CanInstallOrUpgrade}" Value="False">
-                                                                                        <Setter Property="Fill">
-                                                                                            <Setter.Value>
-                                                                                                <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/checkmark - grey.png" />
-                                                                                            </Setter.Value>
-                                                                                        </Setter>
-                                                                                        <Setter Property="Opacity" Value="1" />
                                                                                     </DataTrigger>
                                                                                     <DataTrigger Binding="{Binding Path=IsEnabledForInstall}" Value="False">
                                                                                         <Setter Property="Fill">
@@ -569,7 +558,6 @@
                                                                                     <MultiDataTrigger>
                                                                                         <MultiDataTrigger.Conditions>
                                                                                             <Condition Binding="{Binding Path=Model.IsDeprecated}" Value="False" />
-                                                                                            <Condition Binding="{Binding Path=CanInstallOrUpgrade}" Value="True" />
                                                                                             <Condition Binding="{Binding Path=IsEnabledForInstall}" Value="True" />
                                                                                         </MultiDataTrigger.Conditions>
                                                                                         <Setter Property="Fill">
@@ -597,10 +585,6 @@
                                                                 <Setter Property="TextBlock.Foreground" Value="#84D7CE" />
                                                                 <Setter Property="ToolTip" Value="{x:Static p:Resources.PackageDeprecatedTooltip}" />
                                                             </DataTrigger>
-                                                            <DataTrigger Binding="{Binding CanInstallOrUpgrade}" Value="False">
-                                                                <Setter Property="TextBlock.Foreground" Value="#999999" />
-                                                                <Setter Property="Opacity" Value="1" />
-                                                            </DataTrigger>
                                                             <DataTrigger Binding="{Binding IsEnabledForInstall}" Value="False">
                                                                 <Setter Property="TextBlock.Foreground" Value="#999999" />
                                                                 <Setter Property="TextBlock.Opacity" Value="1" />
@@ -608,16 +592,6 @@
                                                             <MultiDataTrigger>
                                                                 <MultiDataTrigger.Conditions>
                                                                     <Condition Binding="{Binding Path=Model.IsDeprecated}" Value="False" />
-                                                                    <Condition Binding="{Binding Path=IsInstalledVersionSelected}" Value="True" />
-                                                                    <Condition Binding="{Binding Path=IsEnabledForInstall}" Value="True" />
-                                                                </MultiDataTrigger.Conditions>
-                                                                <Setter Property="TextBlock.Opacity" Value="1" />
-                                                                <Setter Property="TextBlock.Foreground" Value="#84D7CE" />
-                                                            </MultiDataTrigger>
-                                                            <MultiDataTrigger>
-                                                                <MultiDataTrigger.Conditions>
-                                                                    <Condition Binding="{Binding Path=Model.IsDeprecated}" Value="False" />
-                                                                    <Condition Binding="{Binding Path=CanInstallOrUpgrade}" Value="True" />
                                                                     <Condition Binding="{Binding Path=IsEnabledForInstall}" Value="True" />
                                                                 </MultiDataTrigger.Conditions>
                                                                 <Setter Property="TextBlock.Opacity" Value="1" />


### PR DESCRIPTION
### Purpose

This PR removes redundant and unused code from the Package Manager UI, specifically related to package installation/upgrade/downgrade logic and associated XAML bindings. This cleanup was performed to improve code maintainability without altering existing functionality.

### Declarations

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Removed unused `InstallButtonTextConverter`, `CanUpgrade`, `CanDowngrade`, and `CanInstallOrUpgrade` properties, along with associated dead logic and XAML triggers in the Package Manager UI. This is a code cleanup and does not change user-facing functionality.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

---
<a href="https://cursor.com/background-agent?bcId=bc-79212f0d-0c41-48d3-aa22-cca5b8a86445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79212f0d-0c41-48d3-aa22-cca5b8a86445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes redundant install/upgrade/downgrade logic from the Package Manager UI to reduce complexity while preserving behavior.
> 
> - Delete `InstallButtonTextConverter` and its resource from `Converters.cs` and `DynamoConverters.xaml`
> - Remove `CanUpgrade`, `CanDowngrade`, and `CanInstallOrUpgrade` from `PackageManagerSearchElementViewModel` and related state propagation/helpers
> - Simplify `DownloadLatestCommand` `CanExecute` to only check `IsDeprecated`; drop `RaiseDownloadLatestCommandCanExecuteChanged`
> - Strip XAML triggers/icons dependent on removed flags in `PackageManagerPackagesControl.xaml` and `PackageManagerSearchView.xaml`
> - Update `PublicAPI.Unshipped.txt` to reflect removed API surface
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbbfe8d0adfb278fae86a5b5f9b233c4be5d9b28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->