### PR TITLE
Package manager UI updates

### DIFF
--- a/doc/distrib/xml/en-US/Analysis.xml
+++ b/doc/distrib/xml/en-US/Analysis.xml
@@ -80,28 +80,6 @@
             <param name="label"></param>
             <returns></returns>
         </member>
-        <member name="T:Analysis.PointData">
-            <summary>
-            A class for storing structure point analysis data.
-            </summary>
-        </member>
-        <member name="P:Analysis.PointData.ValueLocations">
-            <summary>
-            A list of Points.
-            </summary>
-        </member>
-        <member name="P:Analysis.PointData.Values">
-            <summary>
-            A dictionary of lists of double values.
-            </summary>
-        </member>
-        <member name="M:Analysis.PointData.ByPointsAndValues(System.Collections.Generic.IEnumerable{Autodesk.DesignScript.Geometry.Point},System.Collections.Generic.IList{System.Double})">
-            <summary>
-            Create a PointAnalysisData object.
-            </summary>
-            <param name="points">A list of Points.</param>
-            <param name="values">A list of double values.</param>
-        </member>
         <member name="T:Analysis.Properties.Resources">
             <summary>
               A strongly-typed resource class, for looking up localized strings, etc.
@@ -163,76 +141,10 @@
               Looks up a localized string similar to Use Vector nodes and Number nodes as direct inputs to nodes which previously used VectorData nodes.
             </summary>
         </member>
-        <member name="T:Analysis.SurfaceData">
-            <summary>
-            A class for storing structured surface analysis data.
-            </summary>
-        </member>
-        <member name="P:Analysis.SurfaceData.Surface">
-            <summary>
-            The surface which contains the locations.
-            </summary>
-        </member>
-        <member name="P:Analysis.SurfaceData.ValueLocations">
-            <summary>
-            A list of UV locations on the surface.
-            </summary>
-        </member>
-        <member name="P:Analysis.SurfaceData.Values">
-            <summary>
-            A dictionary of lists of doubles.
-            </summary>
-        </member>
-        <member name="M:Analysis.SurfaceData.BySurfaceAndPoints(Autodesk.DesignScript.Geometry.Surface,System.Collections.Generic.IEnumerable{Autodesk.DesignScript.Geometry.UV})">
-            <summary>
-            Create a SurfaceData object without values.
-            </summary>
-            <param name="surface">The surface which contains the locations.</param>
-            <param name="uvs">A list of UV locations on the surface.</param>
-            <returns></returns>
-        </member>
-        <member name="M:Analysis.SurfaceData.BySurfacePointsAndValues(Autodesk.DesignScript.Geometry.Surface,System.Collections.Generic.IEnumerable{Autodesk.DesignScript.Geometry.UV},System.Collections.Generic.IList{System.Double})">
-            <summary>
-            Create a SurfaceData object.
-            </summary>
-            <param name="surface">The surface which contains the locations.</param>
-            <param name="uvs">A list of UV locations on the surface.</param>
-            <param name="values">A list of double values.</param>
-        </member>
-        <member name="M:Analysis.AnalysisExtensions.IsAlmostEqualTo(Autodesk.DesignScript.Geometry.UV,Autodesk.DesignScript.Geometry.UV)">
-            <summary>
-            Takes two planes (of type UV) and returns True if the difference between the two planes is smaller than 1.0e-6 and returns False otherwise.
-            </summary>
-            <param name="a"></param>
-            <param name="b"></param>
-            <returns></returns>
-        </member>
         <member name="T:Analysis.Utils.ValueLocation`1">
             <summary>
             A class for storing a value at a location.
             </summary>
-        </member>
-        <member name="T:Analysis.VectorData">
-            <summary>
-            A class for storing structured vector analysis data.
-            </summary>
-        </member>
-        <member name="P:Analysis.VectorData.ValueLocations">
-            <summary>
-            A list of calculation locations.
-            </summary>
-        </member>
-        <member name="P:Analysis.VectorData.Values">
-            <summary>
-            A dictionary of results.
-            </summary>
-        </member>
-        <member name="M:Analysis.VectorData.ByPointsAndValues(System.Collections.Generic.IEnumerable{Autodesk.DesignScript.Geometry.Point},System.Collections.Generic.IList{Autodesk.DesignScript.Geometry.Vector})">
-            <summary>
-            Create a VectorAnalysisData object.
-            </summary>
-            <param name="points">A list of Points.</param>
-            <param name="values">A list of Vector values.</param>
         </member>
     </members>
 </doc>

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -6541,6 +6541,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to New version available.
+        /// </summary>
+        public static string PackageManagerPackageUpdateAvailable {
+            get {
+                return ResourceManager.GetString("PackageManagerPackageUpdateAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Updated.
         /// </summary>
         public static string PackageManagerPackageUpdated {
@@ -6672,6 +6681,24 @@ namespace Dynamo.Wpf.Properties {
         public static string PackageManagerTitle {
             get {
                 return ResourceManager.GetString("PackageManagerTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Uninstall.
+        /// </summary>
+        public static string PackageManagerUninstall {
+            get {
+                return ResourceManager.GetString("PackageManagerUninstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update.
+        /// </summary>
+        public static string PackageManagerUpdate {
+            get {
+                return ResourceManager.GetString("PackageManagerUpdate", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -3034,9 +3034,20 @@ This package will be unloaded after the next Dynamo restart.</value>
     <value>Install</value>
     <comment>Used on the package manager search result card. If the package is not installed, the button will say 'Install'.</comment>
   </data>
+  <data name="PackageManagerUpdate" xml:space="preserve">
+    <value>Update</value>
+    <comment>Used on the package manager search result card when a different version is selected.</comment>
+  </data>
+  <data name="PackageManagerUninstall" xml:space="preserve">
+    <value>Uninstall</value>
+    <comment>Used on the package manager search result card when the installed version is selected.</comment>
+  </data>
   <data name="PackageManagerPackageUpdated" xml:space="preserve">
     <value>Updated</value>
     <comment>Displays next to the package name in the Package Search window if the package has been updated in the last 30 days.</comment>
+  </data>
+  <data name="PackageManagerPackageUpdateAvailable" xml:space="preserve">
+    <value>New version available</value>
   </data>
   <data name="PackageManagerPackageNew" xml:space="preserve">
     <value>New</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1291,9 +1291,20 @@ Don't worry, you'll have the option to save your work.</value>
     <value>Install</value>
     <comment>Used on the package manager search result card. If the package is not installed, the button will say 'Install'.</comment>
   </data>
+  <data name="PackageManagerUpdate" xml:space="preserve">
+    <value>Update</value>
+    <comment>Used on the package manager search result card when a different version is selected.</comment>
+  </data>
+  <data name="PackageManagerUninstall" xml:space="preserve">
+    <value>Uninstall</value>
+    <comment>Used on the package manager search result card when the installed version is selected.</comment>
+  </data>
   <data name="PackageManagerPackageUpdated" xml:space="preserve">
     <value>Updated</value>
     <comment>Displays next to the package name in the Package Search window if the package has been updated in the last 30 days.</comment>
+  </data>
+  <data name="PackageManagerPackageUpdateAvailable" xml:space="preserve">
+    <value>New version available</value>
   </data>
   <data name="PackageManagerPackageNew" xml:space="preserve">
     <value>New</value>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1364,8 +1364,12 @@ Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.DownloadLa
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.DownloadLatestToCustomPathCommand.set -> void
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.Downloads.get -> int
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.Equals(Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel other) -> bool
+Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.HasUpdateAvailable.get -> bool
+Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.HasUpdateAvailable.set -> void
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.HasUpvote.get -> bool
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.Hosts.get -> System.Collections.Generic.List<string>
+Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.InstallActionCommand.get -> System.Windows.Input.ICommand
+Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.InstallActionText.get -> string
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.IsDeprecated.get -> bool
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.IsEnabledForInstall.get -> bool
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.IsOnwer.get -> bool
@@ -5160,6 +5164,9 @@ static Dynamo.Wpf.Properties.Resources.NodeAutoCompleteToolTip.get -> string
 static Dynamo.Wpf.Properties.Resources.OfflineStatusTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.OnlineStatusTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.PackageDuplicateAssembliesFoundMessage.get -> string
+static Dynamo.Wpf.Properties.Resources.PackageManagerPackageUpdateAvailable.get -> string
+static Dynamo.Wpf.Properties.Resources.PackageManagerUninstall.get -> string
+static Dynamo.Wpf.Properties.Resources.PackageManagerUpdate.get -> string
 static Dynamo.Wpf.Properties.Resources.PreferencesViewEnableNodeAutoCompleteNewUI.get -> string
 static Dynamo.Wpf.Properties.Resources.PreferencesViewEnableNodeAutoCompleteNewUITooltipText.get -> string
 static Dynamo.Wpf.Properties.Resources.NodeContextMenuEnablePeriodicUpdate.get -> string

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
@@ -23,7 +23,7 @@ namespace Dynamo.PackageManager.ViewModels
         public ICommand DownloadLatestToCustomPathCommand { get; set; }
         public ICommand InstallActionCommand
         {
-            get { return IsInstalledVersionSelected ? uninstallCommand ?? DownloadLatestCommand : DownloadLatestCommand; }
+            get { return IsInstalledVersionSelected ? uninstallCommand : DownloadLatestCommand; }
         }
 
         /// <summary>
@@ -75,6 +75,7 @@ namespace Dynamo.PackageManager.ViewModels
         /// </summary>
         private VersionInformation selectedVersion;
 
+        private readonly ICommand disabledCommand = new DelegateCommand(() => { }, () => false);
         private string installedVersion;
         private bool hasUpdateAvailable;
         private ICommand uninstallCommand;
@@ -130,9 +131,14 @@ namespace Dynamo.PackageManager.ViewModels
             {
                 if (HasInstalledVersion)
                 {
-                    return IsInstalledVersionSelected
-                        ? Resources.PackageManagerUninstall
-                        : Resources.PackageManagerUpdate;
+                    if (IsInstalledVersionSelected)
+                    {
+                        return CanUninstallSelectedVersion
+                            ? Resources.PackageManagerUninstall
+                            : Resources.PackageDownloadStateInstalled;
+                    }
+
+                    return Resources.PackageManagerUpdate;
                 }
 
                 return Resources.PackageManagerInstall;
@@ -163,11 +169,17 @@ namespace Dynamo.PackageManager.ViewModels
             get => uninstallCommand;
             set
             {
-                if (uninstallCommand != value)
+                if (uninstallCommand == value) return;
+
+                if (uninstallCommand != null)
                 {
-                    uninstallCommand = value;
-                    RaisePropertyChanged(nameof(InstallActionCommand));
+                    uninstallCommand.CanExecuteChanged -= OnUninstallCommandCanExecuteChanged;
                 }
+
+                uninstallCommand = value ?? disabledCommand;
+                uninstallCommand.CanExecuteChanged += OnUninstallCommandCanExecuteChanged;
+                RaisePropertyChanged(nameof(InstallActionCommand));
+                RaisePropertyChanged(nameof(InstallActionText));
             }
         }
 
@@ -183,6 +195,7 @@ namespace Dynamo.PackageManager.ViewModels
             : base(element)
         {
             this.SearchElementModel = element;
+            UninstallCommand = disabledCommand;
             CanInstall = install;
             IsEnabledForInstall = isEnabledForInstall;
 
@@ -368,6 +381,15 @@ namespace Dynamo.PackageManager.ViewModels
             RaisePropertyChanged(nameof(InstallActionText));
             RaisePropertyChanged(nameof(InstallActionCommand));
             RaisePropertyChanged(nameof(IsInstalledVersionSelected));
+        }
+
+        private bool CanUninstallSelectedVersion =>
+            IsInstalledVersionSelected && uninstallCommand?.CanExecute(null) == true;
+
+        private void OnUninstallCommandCanExecuteChanged(object sender, EventArgs e)
+        {
+            RaisePropertyChanged(nameof(InstallActionText));
+            RaisePropertyChanged(nameof(InstallActionCommand));
         }
 
         private void SetDefaultSelectedVersion()

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Data;
 using System.Windows.Input;
 using Dynamo.ViewModels;
+using Dynamo.Wpf.Properties;
 using Dynamo.Wpf.ViewModels;
 using Greg.Responses;
 using Prism.Commands;
@@ -20,6 +21,10 @@ namespace Dynamo.PackageManager.ViewModels
         public ICommand VisitSiteCommand { get; set; }
         public ICommand VisitRepositoryCommand { get; set; }
         public ICommand DownloadLatestToCustomPathCommand { get; set; }
+        public ICommand InstallActionCommand
+        {
+            get { return IsInstalledVersionSelected ? uninstallCommand ?? DownloadLatestCommand : DownloadLatestCommand; }
+        }
 
         /// <summary>
         /// VM IsDeprecated property
@@ -70,6 +75,16 @@ namespace Dynamo.PackageManager.ViewModels
         /// </summary>
         private VersionInformation selectedVersion;
 
+        private string installedVersion;
+        private bool hasUpdateAvailable;
+        private ICommand uninstallCommand;
+
+        private bool HasInstalledVersion =>
+            !string.IsNullOrEmpty(installedVersion);
+
+        private bool IsInstalledVersionSelected =>
+            SelectedVersion?.IsInstalled == true;
+
         public bool? IsSelectedVersionCompatible
         {
             get { return isSelectedVersionCompatible; }
@@ -96,8 +111,62 @@ namespace Dynamo.PackageManager.ViewModels
                     selectedVersion = value;
 
                     // Update the compatibility info so the icon of the currently selected version is updated
-                    IsSelectedVersionCompatible = selectedVersion.IsCompatible;
+                    IsSelectedVersionCompatible = selectedVersion?.IsCompatible;
                     SearchElementModel.SelectedVersion = selectedVersion;
+                    RaisePropertyChanged(nameof(SelectedVersion));
+                    RaisePropertyChanged(nameof(InstallActionText));
+                    RaisePropertyChanged(nameof(InstallActionCommand));
+                    RaisePropertyChanged(nameof(IsInstalledVersionSelected));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sets the install action text based on whether the package is installed, needs an update, or is not installed
+        /// </summary>
+        public string InstallActionText
+        {
+            get
+            {
+                if (HasInstalledVersion)
+                {
+                    return IsInstalledVersionSelected
+                        ? Resources.PackageManagerUninstall
+                        : Resources.PackageManagerUpdate;
+                }
+
+                return Resources.PackageManagerInstall;
+            }
+        }
+
+        /// <summary>
+        /// True if newer version is available for an installed package
+        /// </summary>
+        public bool HasUpdateAvailable
+        {
+            get => hasUpdateAvailable;
+            set
+            {
+                if (hasUpdateAvailable != value)
+                {
+                    hasUpdateAvailable = value;
+                    RaisePropertyChanged(nameof(HasUpdateAvailable));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the command that executes the uninstall operation.
+        /// </summary>
+        internal ICommand UninstallCommand
+        {
+            get => uninstallCommand;
+            set
+            {
+                if (uninstallCommand != value)
+                {
+                    uninstallCommand = value;
+                    RaisePropertyChanged(nameof(InstallActionCommand));
                 }
             }
         }
@@ -128,7 +197,7 @@ namespace Dynamo.PackageManager.ViewModels
 
             this.DownloadLatestCommand = new DelegateCommand(
                 () => OnRequestDownload(false),
-                () => !SearchElementModel.IsDeprecated && CanInstall);
+                () => !SearchElementModel.IsDeprecated);
             this.DownloadLatestToCustomPathCommand = new DelegateCommand(() => OnRequestDownload(true));
 
             this.UpvoteCommand = new DelegateCommand(SearchElementModel.Upvote, () => canLogin);
@@ -143,11 +212,11 @@ namespace Dynamo.PackageManager.ViewModels
         {
             if (e.PropertyName == nameof(SearchElementModel.LatestCompatibleVersion))
             {
-                this.SelectedVersion = this.SearchElementModel.LatestCompatibleVersion;
+                SetDefaultSelectedVersion();
             }
             if (e.PropertyName == nameof(SearchElementModel.VersionDetails))
             {
-                this.VersionInformationList = this.SearchElementModel.VersionDetails;
+                SetDefaultSelectedVersion();
             }
         }
 
@@ -191,8 +260,11 @@ namespace Dynamo.PackageManager.ViewModels
 
             internal set
             {
-                canInstall = value;
-                RaisePropertyChanged(nameof(CanInstall));
+                if (canInstall != value)
+                {
+                    canInstall = value;
+                    RaisePropertyChanged(nameof(CanInstall));
+                }
             }
         }
 
@@ -262,6 +334,7 @@ namespace Dynamo.PackageManager.ViewModels
                 {
                     versionInformationList = value;
                     RaisePropertyChanged(nameof(VersionInformationList));
+                    UpdateInstalledVersionFlags();
                 }
             }
         }
@@ -278,6 +351,61 @@ namespace Dynamo.PackageManager.ViewModels
             }
         }
 
+        /// <summary>
+        /// Updates the installed version and sets the default selected version
+        /// </summary>
+        /// <param name="version"></param>
+        /// <param name="setDefaultSelection"></param>
+        internal void UpdateInstalledVersion(string version, bool setDefaultSelection)
+        {
+            installedVersion = version;
+            UpdateInstalledVersionFlags();
+
+            if (setDefaultSelection)
+            {
+                SetDefaultSelectedVersion();
+            }
+            RaisePropertyChanged(nameof(InstallActionText));
+            RaisePropertyChanged(nameof(InstallActionCommand));
+            RaisePropertyChanged(nameof(IsInstalledVersionSelected));
+        }
+
+        private void SetDefaultSelectedVersion()
+        {
+            var defaultVersion = GetDefaultSelectedVersion();
+            if (defaultVersion != null && SelectedVersion != defaultVersion)
+            {
+                SelectedVersion = defaultVersion;
+            }
+        }
+
+        private VersionInformation GetDefaultSelectedVersion()
+        {
+            if (!string.IsNullOrEmpty(installedVersion))
+            {
+                var installedInfo = VersionInformationList?.FirstOrDefault(v => v.Version == installedVersion);
+                if (installedInfo != null)
+                {
+                    return installedInfo;
+                }
+            }
+
+            return SearchElementModel?.LatestCompatibleVersion;
+        }
+
+        private void UpdateInstalledVersionFlags()
+        {
+            if (VersionInformationList == null) return;
+
+            foreach (var versionInfo in VersionInformationList)
+            {
+                versionInfo.IsInstalled = !string.IsNullOrEmpty(installedVersion) &&
+                                          string.Equals(versionInfo.Version, installedVersion, StringComparison.OrdinalIgnoreCase);
+            }
+
+            RaisePropertyChanged(nameof(ReversedVersionInformationList));
+        }
+        
         private List<String> CustomPackageFolders;
         private bool? isSelectedVersionCompatible;
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -513,18 +513,12 @@ namespace Dynamo.PackageManager
                 (handle.DownloadState == PackageDownloadHandle.State.Downloaded ||
                  handle.DownloadState == PackageDownloadHandle.State.Downloading ||
                  handle.DownloadState == PackageDownloadHandle.State.Installing));
-            if (hasBlockingDownload)
-            {
-                element.CanInstall = false;
-                return;
-            }
-            if (!installedPackages.Any())
-            {
-                element.CanInstall = true;
-                return;
-            }
+            element.CanInstall = !hasBlockingDownload && !installedPackages.Any();
 
-            element.CanInstall = false;
+            if (element.UninstallCommand is DelegateCommand uninstallCommand)
+            {
+                uninstallCommand.RaiseCanExecuteChanged();
+            }
         }
 
         private void UninstallPackage(PackageManagerSearchElementViewModel element)

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -496,6 +496,164 @@ namespace Dynamo.PackageManager
             }
         }
 
+        private void UpdateInstallState(PackageManagerSearchElementViewModel element, bool setDefaultSelection = false)
+        {
+            if (element?.SearchElementModel == null) return;
+
+            var installedPackages = PackageManagerClientViewModel.PackageManagerExtension.PackageLoader.LocalPackages
+                .Where(x => (x.Name == element.SearchElementModel.Name) && !x.BuiltInPackage)
+                .ToList();
+
+            var installedVersion = installedPackages.Any() ? GetNewestInstalledVersion(installedPackages) : null;
+            element.UpdateInstalledVersion(installedVersion, setDefaultSelection);
+            element.HasUpdateAvailable = IsUpdateAvailable(installedVersion, element.VersionInformationList);
+
+            var hasBlockingDownload = PackageManagerClientViewModel.Downloads.Any(handle =>
+                handle.Name == element.SearchElementModel.Name &&
+                (handle.DownloadState == PackageDownloadHandle.State.Downloaded ||
+                 handle.DownloadState == PackageDownloadHandle.State.Downloading ||
+                 handle.DownloadState == PackageDownloadHandle.State.Installing));
+            if (hasBlockingDownload)
+            {
+                element.CanInstall = false;
+                return;
+            }
+            if (!installedPackages.Any())
+            {
+                element.CanInstall = true;
+                return;
+            }
+
+            element.CanInstall = false;
+        }
+
+        private void UninstallPackage(PackageManagerSearchElementViewModel element)
+        {
+            var installedPackage = GetInstalledPackageForSelectedVersion(element);
+            if (installedPackage == null) return;
+
+            var dynamoViewModel = PackageManagerClientViewModel?.DynamoViewModel;
+            if (dynamoViewModel == null) return;
+
+            if (installedPackage.LoadedAssemblies.Any())
+            {
+                var message = string.Format(Resources.MessageNeedToRestartAfterDelete,
+                    dynamoViewModel.BrandingResourceProvider.ProductName);
+                var title = Resources.MessageNeedToRestartAfterDeleteTitle;
+                var result = MessageBoxService.Show(dynamoViewModel.Owner, message, title,
+                    MessageBoxButton.OKCancel, MessageBoxImage.Exclamation);
+                if (result == MessageBoxResult.Cancel || result == MessageBoxResult.None)
+                {
+                    return;
+                }
+            }
+
+            var confirmResult = MessageBoxService.Show(dynamoViewModel.Owner,
+                string.Format(Resources.MessageConfirmToDeletePackage, installedPackage.Name),
+                Resources.MessageNeedToRestartAfterDeleteTitle,
+                MessageBoxButton.YesNo, MessageBoxImage.Question);
+
+            if (confirmResult == MessageBoxResult.No || confirmResult == MessageBoxResult.None)
+            {
+                return;
+            }
+
+            try
+            {
+                installedPackage.UninstallCore(dynamoViewModel.Model.CustomNodeManager,
+                    PackageManagerClientViewModel.PackageManagerExtension.PackageLoader,
+                    dynamoViewModel.Model.PreferenceSettings);
+            }
+            catch (Exception)
+            {
+                MessageBoxService.Show(dynamoViewModel.Owner,
+                    string.Format(Resources.MessageFailedToDelete, dynamoViewModel.BrandingResourceProvider.ProductName),
+                    Resources.DeleteFailureMessageBoxTitle,
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                UpdateInstallState(element);
+            }
+        }
+
+        private bool CanUninstallPackage(PackageManagerSearchElementViewModel element)
+        {
+            var installedPackage = GetInstalledPackageForSelectedVersion(element);
+            if (installedPackage == null) return false;
+
+            var dynamoModel = PackageManagerClientViewModel?.DynamoViewModel?.Model;
+            if (dynamoModel == null) return false;
+
+            if (!installedPackage.InUse(dynamoModel) || installedPackage.LoadedAssemblies.Any())
+            {
+                return IsLoadedWithNoScheduledOperation(installedPackage);
+            }
+
+            return false;
+        }
+
+        private static bool IsLoadedWithNoScheduledOperation(Package package)
+        {
+            return package.BuiltInPackage
+                ? package.LoadState.State != PackageLoadState.StateTypes.Unloaded &&
+                  package.LoadState.ScheduledState != PackageLoadState.ScheduledTypes.ScheduledForUnload
+                : package.LoadState.ScheduledState != PackageLoadState.ScheduledTypes.ScheduledForDeletion;
+        }
+
+        private Package GetInstalledPackageForSelectedVersion(PackageManagerSearchElementViewModel element)
+        {
+            if (element?.SelectedVersion?.IsInstalled != true || element.SearchElementModel == null) return null;
+
+            var installedPackages = PackageManagerClientViewModel.PackageManagerExtension.PackageLoader.LocalPackages
+                .Where(x => x.Name == element.SearchElementModel.Name && !x.BuiltInPackage)
+                .ToList();
+
+            if (!installedPackages.Any()) return null;
+
+            return installedPackages.FirstOrDefault(pkg =>
+                string.Equals(pkg.VersionName, element.SelectedVersion.Version, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static string GetNewestInstalledVersion(IEnumerable<Package> installedPackages)
+        {
+            if (installedPackages == null) return null;
+
+            var parsedVersions = installedPackages
+                .Select(pkg => new { Version = pkg.VersionName, Parsed = VersionUtilities.Parse(pkg.VersionName) })
+                .Where(x => x.Parsed != null)
+                .OrderBy(x => x.Parsed)
+                .LastOrDefault();
+
+            if (parsedVersions != null) return parsedVersions.Version;
+
+            return installedPackages.Select(pkg => pkg.VersionName).FirstOrDefault();
+        }
+
+        private static bool IsUpdateAvailable(string installedVersion, IEnumerable<VersionInformation> availableVersions)
+        {
+            if (string.IsNullOrEmpty(installedVersion) || availableVersions == null) return false;
+
+            var parsedInstalledVersion = VersionUtilities.Parse(installedVersion);
+            if (parsedInstalledVersion == null) return false;
+
+            var newestAvailableVersion = availableVersions
+                .Select(version => VersionUtilities.Parse(version.Version))
+                .Where(parsedVersion => parsedVersion != null)
+                .OrderBy(parsedVersion => parsedVersion)
+                .LastOrDefault();
+
+            if (newestAvailableVersion == null) return false;
+
+            return newestAvailableVersion > parsedInstalledVersion;
+        }
+
+        private PackageManagerSearchElementViewModel GetSearchElementViewModelByName(string name)
+        {
+            return SearchResults?.FirstOrDefault(x => x.SearchElementModel.Name == name)
+                ?? SearchMyResults?.FirstOrDefault(x => x.SearchElementModel.Name == name);
+        }
+
         public PackageSearchState _searchState; // TODO: Set private for 3.0.
 
         /// <summary>
@@ -726,6 +884,9 @@ namespace Dynamo.PackageManager
                 p.RequestDownload += this.PackageOnExecuted;
                 p.IsOnwer = true;
 
+                UpdateInstallState(p);
+                p.PropertyChanged += SearchElementViewModelOnPropertyChanged;
+
                 myPackages.Add(p);
             }
     
@@ -739,6 +900,7 @@ namespace Dynamo.PackageManager
             {
                 ele.RequestDownload -= PackageOnExecuted;
                 ele.RequestShowFileDialog -= OnRequestShowFileDialog;
+                ele.PropertyChanged -= SearchElementViewModelOnPropertyChanged;
             }
 
             this.SearchMyResults = null;
@@ -1239,6 +1401,7 @@ namespace Dynamo.PackageManager
         {
             element.RequestDownload += this.PackageOnExecuted;
             element.RequestShowFileDialog += this.OnRequestShowFileDialog;
+            element.PropertyChanged += SearchElementViewModelOnPropertyChanged;
 
             this.SearchResults.Add(element);
         }
@@ -1250,9 +1413,19 @@ namespace Dynamo.PackageManager
             {
                 ele.RequestDownload -= PackageOnExecuted;
                 ele.RequestShowFileDialog -= OnRequestShowFileDialog;
+                ele.PropertyChanged -= SearchElementViewModelOnPropertyChanged;
                 ele?.Dispose();
             }
             this.SearchResults.Clear();
+        }
+
+        private void SearchElementViewModelOnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(PackageManagerSearchElementViewModel.SelectedVersion) &&
+                sender is PackageManagerSearchElementViewModel element)
+            {
+                UpdateInstallState(element);
+            }
         }
 
         internal void PackageOnExecuted(PackageManagerSearchElement element, PackageVersion version, string downloadPath)
@@ -1297,10 +1470,10 @@ namespace Dynamo.PackageManager
                 // the Downloads collection before Download/Install begins.
                 if (eArgs.PropertyName == nameof(PackageDownloadHandle.DownloadState))
                 {
-                    PackageManagerSearchElementViewModel sr = SearchResults.FirstOrDefault(x => x.SearchElementModel.Name == handle.Name);
-                    if (sr == null) return;
+                    var searchElement = GetSearchElementViewModelByName(handle.Name);
+                    if (searchElement == null) return;
 
-                    sr.CanInstall = CanInstallPackage(o as PackageDownloadHandle);
+                    UpdateInstallState(searchElement);
                 }
             }
 
@@ -1649,10 +1822,17 @@ namespace Dynamo.PackageManager
         private PackageManagerSearchElementViewModel GetSearchElementViewModel(PackageManagerSearchElement package, bool bypassCustomPackageLocations = false)
         {
             var isEnabledForInstall = bypassCustomPackageLocations || !(Preferences as IDisablePackageLoadingPreferences).DisableCustomPackageLocations;
-            return new PackageManagerSearchElementViewModel(package,
+            var viewModel = new PackageManagerSearchElementViewModel(package,
                 PackageManagerClientViewModel.AuthenticationManager.HasAuthProvider,
                 CanInstallPackage(package.Name),
                 isEnabledForInstall);
+
+            viewModel.UninstallCommand = new DelegateCommand(
+                () => UninstallPackage(viewModel),
+                () => CanUninstallPackage(viewModel));
+            UpdateInstallState(viewModel, true);
+
+            return viewModel;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
@@ -359,6 +359,9 @@
                                                                                 <DataTrigger Binding="{Binding InstallActionText}" Value="{x:Static p:Resources.PackageManagerUninstall}">
                                                                                     <Setter Property="Visibility" Value="Collapsed" />
                                                                                 </DataTrigger>
+                                                                                <DataTrigger Binding="{Binding InstallActionText}" Value="{x:Static p:Resources.PackageDownloadStateInstalled}">
+                                                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                                                </DataTrigger>
                                                                             </Style.Triggers>
                                                                         </Style>
                                                                     </Button.Style>
@@ -382,6 +385,9 @@
                                                                         <Style TargetType="Rectangle">
                                                                             <Style.Triggers>
                                                                                 <DataTrigger Binding="{Binding Path=InstallActionText}" Value="{x:Static p:Resources.PackageManagerUninstall}">
+                                                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                                                </DataTrigger>
+                                                                                <DataTrigger Binding="{Binding Path=InstallActionText}" Value="{x:Static p:Resources.PackageDownloadStateInstalled}">
                                                                                     <Setter Property="Visibility" Value="Collapsed" />
                                                                                 </DataTrigger>
                                                                                 <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="True">

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
@@ -116,6 +116,25 @@
                     <TextBlock VerticalAlignment="Center"
                                Foreground="White"
                                Text="{Binding Version}" />
+                    <TextBlock VerticalAlignment="Center"
+                               Foreground="White"
+                               Text=" (installed)">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding IsInstalled}" Value="True" />
+                                            <Condition Binding="{Binding RelativeSource={RelativeSource AncestorType=ComboBoxItem}, Path=IsVisible}" Value="True" />
+                                            <Condition Binding="{Binding RelativeSource={RelativeSource AncestorType=ComboBox}, Path=IsDropDownOpen}" Value="True" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                        </TextBlock>
                 </StackPanel>
             </DataTemplate>
 
@@ -306,13 +325,15 @@
 
                             <!--  Install Button  -->
                             <Button Name="installButton"
-                                    Command="{Binding DownloadLatestCommand}"
-                                    Content="{Binding CanInstall, Converter={StaticResource InstalledButtonTextConverter}}"
+                                    Command="{Binding InstallActionCommand}"
                                     DockPanel.Dock="Right"
                                     IsEnabled="{Binding IsEnabledForInstall}"
                                     Loaded="DropDownInstallButton_Loaded"
                                     ToolTipService.ShowOnDisabled="True"
                                     Unloaded="DropDownInstallButton_Unloaded">
+                                <Button.Content>
+                                    <Binding Path="InstallActionText" />
+                                </Button.Content>
                                 <Button.Style>
                                     <Style TargetType="Button">
                                         <Setter Property="Visibility" Value="Visible" />
@@ -331,9 +352,16 @@
                                                                 <Button Name="dropDownInstallButton"
                                                                         BorderThickness="0"
                                                                         Cursor="Hand"
-                                                                        DockPanel.Dock="Right"
-                                                                        Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
-                                                                        Visibility="{Binding CanInstall, Converter={StaticResource BoolToVisibilityCollapsedConverter}}">
+                                                                        DockPanel.Dock="Right">
+                                                                    <Button.Style>
+                                                                        <Style BasedOn="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" TargetType="Button">
+                                                                            <Style.Triggers>
+                                                                                <DataTrigger Binding="{Binding InstallActionText}" Value="{x:Static p:Resources.PackageManagerUninstall}">
+                                                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                                                </DataTrigger>
+                                                                            </Style.Triggers>
+                                                                        </Style>
+                                                                    </Button.Style>
                                                                     <Image Width="7"
                                                                            Height="5"
                                                                            Source=" /DynamoCoreWpf;component/UI/Images/caret_drop_down.png" />
@@ -353,6 +381,9 @@
                                                                     <Rectangle.Style>
                                                                         <Style TargetType="Rectangle">
                                                                             <Style.Triggers>
+                                                                                <DataTrigger Binding="{Binding Path=InstallActionText}" Value="{x:Static p:Resources.PackageManagerUninstall}">
+                                                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                                                </DataTrigger>
                                                                                 <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="True">
                                                                                     <Setter Property="Fill">
                                                                                         <Setter.Value>
@@ -360,14 +391,6 @@
                                                                                         </Setter.Value>
                                                                                     </Setter>
                                                                                     <Setter Property="Opacity" Value="0.5" />
-                                                                                </DataTrigger>
-                                                                                <DataTrigger Binding="{Binding Path=CanInstall}" Value="False">
-                                                                                    <Setter Property="Fill">
-                                                                                        <Setter.Value>
-                                                                                            <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/checkmark - grey.png" />
-                                                                                        </Setter.Value>
-                                                                                    </Setter>
-                                                                                    <Setter Property="Opacity" Value="1" />
                                                                                 </DataTrigger>
                                                                                 <DataTrigger Binding="{Binding Path=IsEnabledForInstall}" Value="False">
                                                                                     <Setter Property="Fill">
@@ -380,7 +403,6 @@
                                                                                 <MultiDataTrigger>
                                                                                     <MultiDataTrigger.Conditions>
                                                                                         <Condition Binding="{Binding Path=IsDeprecated}" Value="False" />
-                                                                                        <Condition Binding="{Binding Path=CanInstall}" Value="True" />
                                                                                         <Condition Binding="{Binding Path=IsEnabledForInstall}" Value="True" />
                                                                                     </MultiDataTrigger.Conditions>
                                                                                     <Setter Property="Fill">
@@ -408,10 +430,6 @@
                                                             <Setter Property="TextBlock.Foreground" Value="#84D7CE" />
                                                             <Setter Property="ToolTip" Value="{x:Static p:Resources.PackageDeprecatedTooltip}" />
                                                         </DataTrigger>
-                                                        <DataTrigger Binding="{Binding CanInstall}" Value="False">
-                                                            <Setter Property="TextBlock.Foreground" Value="#999999" />
-                                                            <Setter Property="Opacity" Value="1" />
-                                                        </DataTrigger>
                                                         <DataTrigger Binding="{Binding IsEnabledForInstall}" Value="False">
                                                             <Setter Property="TextBlock.Foreground" Value="#999999" />
                                                             <Setter Property="TextBlock.Opacity" Value="1" />
@@ -419,18 +437,10 @@
                                                         <MultiDataTrigger>
                                                             <MultiDataTrigger.Conditions>
                                                                 <Condition Binding="{Binding Path=IsDeprecated}" Value="False" />
-                                                                <Condition Binding="{Binding Path=CanInstall}" Value="True" />
                                                                 <Condition Binding="{Binding Path=IsEnabledForInstall}" Value="True" />
                                                             </MultiDataTrigger.Conditions>
                                                             <Setter Property="TextBlock.Opacity" Value="1" />
                                                             <Setter Property="TextBlock.Foreground" Value="#84D7CE" />
-                                                        </MultiDataTrigger>
-                                                        <MultiDataTrigger>
-                                                            <MultiDataTrigger.Conditions>
-                                                                <Condition Binding="{Binding Path=CanInstall}" Value="False" />
-                                                                <Condition Binding="{Binding Path=IsOnwer}" Value="True" />
-                                                            </MultiDataTrigger.Conditions>
-                                                            <Setter Property="Visibility" Value="Collapsed" />
                                                         </MultiDataTrigger>
                                                     </ControlTemplate.Triggers>
                                                 </ControlTemplate>
@@ -517,34 +527,59 @@
                                 </TextBlock>
 
                                 <!--  Tag Bubble  -->
-                                <Border Name="newPackageLabel"
-                                        Grid.Column="1"
-                                        Width="Auto"
-                                        Height="20"
-                                        Margin="7,-3,7,0"
-                                        HorizontalAlignment="Right"
-                                        VerticalAlignment="Center"
-                                        Background="Transparent"
-                                        BorderBrush="{StaticResource PMBorderColorBrush}"
-                                        BorderThickness="1"
-                                        CornerRadius="3"
-                                        SnapsToDevicePixels="True"
-                                        UseLayoutRounding="True"
-                                        Visibility="{Binding Path=Model, Converter={StaticResource DateToVisibilityCollapsedConverter}}">
-                                    <TextBlock Margin="3,0"
-                                               Padding="0,1,0,0"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               FontFamily="{StaticResource ArtifaktElementRegular}"
-                                               FontSize="11"
-                                               Foreground="{StaticResource PMForegroundColorBrush}"
-                                               Text="{Binding Path=Model, Converter={StaticResource DateToPackageLabelTextConverter}}">
-                                        <TextBlock.ToolTip>
-                                            <ToolTip Content="{Binding Path=Model, Converter={StaticResource DateToPackageLabelTooltipConverter}}" Style="{StaticResource GenericToolTipLight}" />
-                                        </TextBlock.ToolTip>
-                                    </TextBlock>
-                                </Border>
-
+                                <StackPanel Grid.Column="1"
+                                            HorizontalAlignment="Right"
+                                            VerticalAlignment="Center"
+                                            Orientation="Horizontal">
+                                    <Border Name="newPackageLabel"
+                                            Width="Auto"
+                                            Height="20"
+                                            Margin="7,-3,4,0"
+                                            HorizontalAlignment="Right"
+                                            VerticalAlignment="Center"
+                                            Background="Transparent"
+                                            BorderBrush="{StaticResource PMBorderColorBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="3"
+                                            SnapsToDevicePixels="True"
+                                            UseLayoutRounding="True"
+                                            Visibility="{Binding Path=Model, Converter={StaticResource DateToVisibilityCollapsedConverter}}">
+                                        <TextBlock Margin="3,0"
+                                                   Padding="0,1,0,0"
+                                                   HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center"
+                                                   FontFamily="{StaticResource ArtifaktElementRegular}"
+                                                   FontSize="11"
+                                                   Foreground="{StaticResource PMForegroundColorBrush}"
+                                                   Text="{Binding Path=Model, Converter={StaticResource DateToPackageLabelTextConverter}}">
+                                            <TextBlock.ToolTip>
+                                                <ToolTip Content="{Binding Path=Model, Converter={StaticResource DateToPackageLabelTooltipConverter}}" Style="{StaticResource GenericToolTipLight}" />
+                                            </TextBlock.ToolTip>
+                                        </TextBlock>
+                                    </Border>
+                                    <Border Name="updateAvailableLabel"
+                                            Width="Auto"
+                                            Height="20"
+                                            Margin="3,-3,7,0"
+                                            HorizontalAlignment="Right"
+                                            VerticalAlignment="Center"
+                                            Background="Transparent"
+                                            BorderBrush="{StaticResource PMBorderColorBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="3"
+                                            SnapsToDevicePixels="True"
+                                            UseLayoutRounding="True"
+                                            Visibility="{Binding HasUpdateAvailable, Converter={StaticResource BoolToVisibilityCollapsedConverter}}">
+                                        <TextBlock Margin="3,0"
+                                                   Padding="0,1,0,0"
+                                                   HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center"
+                                                   FontFamily="{StaticResource ArtifaktElementRegular}"
+                                                   FontSize="11"
+                                                   Foreground="{StaticResource PMForegroundColorBrush}"
+                                                   Text="{x:Static p:Resources.PackageManagerPackageUpdateAvailable}" />
+                                    </Border>
+                                </StackPanel>
                             </Grid>
                         </DockPanel>
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -498,11 +498,13 @@
                                 <!--  Install Button  -->
                                 <Button
                                     Name="installButton"
-                                    Command="{Binding DownloadLatestCommand}"
-                                    Content="{Binding CanInstall, Converter={StaticResource InstalledButtonTextConverter}}"
+                                    Command="{Binding InstallActionCommand}"
                                     DockPanel.Dock="Right"
                                     ToolTipService.ShowOnDisabled="True"
                                     IsEnabled="{Binding IsEnabledForInstall}">
+                                    <Button.Content>
+                                        <Binding Path="InstallActionText" />
+                                    </Button.Content>
                                     <Button.Style>
                                         <Style TargetType="Button">
                                             <Setter Property="Template">
@@ -534,6 +536,9 @@
                                                                         <Rectangle.Style>
                                                                             <Style TargetType="Rectangle">
                                                                                 <Style.Triggers>
+                                                                                    <DataTrigger Binding="{Binding Path=InstallActionText}" Value="{x:Static p:Resources.PackageManagerUninstall}">
+                                                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                                                    </DataTrigger>
                                                                                     <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="True">
                                                                                         <Setter Property="Fill">
                                                                                             <Setter.Value>
@@ -541,14 +546,6 @@
                                                                                             </Setter.Value>
                                                                                         </Setter>
                                                                                         <Setter Property="Opacity" Value="0.5" />
-                                                                                    </DataTrigger>
-                                                                                    <DataTrigger Binding="{Binding Path=CanInstall}" Value="False">
-                                                                                        <Setter Property="Fill">
-                                                                                            <Setter.Value>
-                                                                                                <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/checkmark - grey.png" />
-                                                                                            </Setter.Value>
-                                                                                        </Setter>
-                                                                                        <Setter Property="Opacity" Value="1" />
                                                                                     </DataTrigger>
                                                                                     <DataTrigger Binding="{Binding Path=IsEnabledForInstall}" Value="False">
                                                                                         <Setter Property="Fill">
@@ -561,7 +558,6 @@
                                                                                     <MultiDataTrigger>
                                                                                         <MultiDataTrigger.Conditions>
                                                                                             <Condition Binding="{Binding Path=Model.IsDeprecated}" Value="False" />
-                                                                                            <Condition Binding="{Binding Path=CanInstall}" Value="True" />
                                                                                             <Condition Binding="{Binding Path=IsEnabledForInstall}" Value="True" />
                                                                                         </MultiDataTrigger.Conditions>
                                                                                         <Setter Property="Fill">
@@ -589,10 +585,6 @@
                                                                 <Setter Property="TextBlock.Foreground" Value="#84D7CE" />
                                                                 <Setter Property="ToolTip" Value="{x:Static p:Resources.PackageDeprecatedTooltip}" />
                                                             </DataTrigger>
-                                                            <DataTrigger Binding="{Binding CanInstall}" Value="False">
-                                                                <Setter Property="TextBlock.Foreground" Value="#999999" />
-                                                                <Setter Property="Opacity" Value="1" />
-                                                            </DataTrigger>
                                                             <DataTrigger Binding="{Binding IsEnabledForInstall}" Value="False">
                                                                 <Setter Property="TextBlock.Foreground" Value="#999999" />
                                                                 <Setter Property="TextBlock.Opacity" Value="1" />
@@ -600,7 +592,6 @@
                                                             <MultiDataTrigger>
                                                                 <MultiDataTrigger.Conditions>
                                                                     <Condition Binding="{Binding Path=Model.IsDeprecated}" Value="False" />
-                                                                    <Condition Binding="{Binding Path=CanInstall}" Value="True" />
                                                                     <Condition Binding="{Binding Path=IsEnabledForInstall}" Value="True" />
                                                                 </MultiDataTrigger.Conditions>
                                                                 <Setter Property="TextBlock.Opacity" Value="1" />

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerSearchView.xaml
@@ -539,6 +539,9 @@
                                                                                     <DataTrigger Binding="{Binding Path=InstallActionText}" Value="{x:Static p:Resources.PackageManagerUninstall}">
                                                                                         <Setter Property="Visibility" Value="Collapsed" />
                                                                                     </DataTrigger>
+                                                                                    <DataTrigger Binding="{Binding Path=InstallActionText}" Value="{x:Static p:Resources.PackageDownloadStateInstalled}">
+                                                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                                                    </DataTrigger>
                                                                                     <DataTrigger Binding="{Binding Path=Model.IsDeprecated}" Value="True">
                                                                                         <Setter Property="Fill">
                                                                                             <Setter.Value>

--- a/src/DynamoPackages/PackageManagerSearchElement.cs
+++ b/src/DynamoPackages/PackageManagerSearchElement.cs
@@ -23,6 +23,11 @@ namespace Dynamo.PackageManager
         public bool? IsCompatible { get; set; }
 
         /// <summary>
+        /// Indicates whether this version is currently installed locally.
+        /// </summary>
+        public bool IsInstalled { get; set; }
+
+        /// <summary>
         /// A helper method to determine the compatibility of a specific package version from the provided version details.
         /// </summary>
         /// <param name="versionDetails">A collection of VersionInformation </param>


### PR DESCRIPTION
### Purpose

This PR refines the Package Manager UI to dynamically update the "Install" button's label and icon based on the package's installation status and the selected version. It ensures that if an installed package's version is selected and an uninstall command is not available, the button correctly displays "Installed" and hides action icons. Additionally, it improves the responsiveness of the uninstall command's availability.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

The Package Manager UI now dynamically updates the install button label and icon based on the package's installation status and selected version. If an installed package's version is selected and uninstall is not available, the button will display "Installed" and hide the action icons. The button state also refreshes when uninstall availability changes.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of

---
<a href="https://cursor.com/background-agent?bcId=bc-514eb33b-2d49-4621-9ea4-26cb46992c9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-514eb33b-2d49-4621-9ea4-26cb46992c9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

