### PR TITLE
Package versioning display

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
@@ -79,6 +79,7 @@ namespace Dynamo.PackageManager.ViewModels
         private ICommand uninstallCommand;
         private bool HasInstalledVersion => !string.IsNullOrEmpty(installedVersion);
         private bool IsInstalledVersionSelected => SelectedVersion?.IsInstalled == true;
+        private bool IsInstalledFallback => IsInstalledVersionSelected && uninstallCommand == null;
 
         public bool? IsSelectedVersionCompatible
         {
@@ -112,6 +113,7 @@ namespace Dynamo.PackageManager.ViewModels
                     RaisePropertyChanged(nameof(InstallActionText));
                     RaisePropertyChanged(nameof(InstallActionCommand));
                     RaisePropertyChanged(nameof(IsInstalledVersionSelected));
+                    RefreshUninstallCommandCanExecute();
                 }
             }
         }
@@ -125,9 +127,14 @@ namespace Dynamo.PackageManager.ViewModels
             {
                 if (HasInstalledVersion)
                 {
-                    return IsInstalledVersionSelected
-                        ? Resources.PackageManagerUninstall
-                        : Resources.PackageManagerUpdate;
+                    if (IsInstalledVersionSelected)
+                    {
+                        return IsInstalledFallback
+                            ? Resources.PackageDownloadStateInstalled
+                            : Resources.PackageManagerUninstall;
+                    }
+
+                    return Resources.PackageManagerUpdate;
                 }
 
                 return Resources.PackageManagerInstall;
@@ -159,6 +166,8 @@ namespace Dynamo.PackageManager.ViewModels
                 {
                     uninstallCommand = value;
                     RaisePropertyChanged(nameof(InstallActionCommand));
+                    RaisePropertyChanged(nameof(InstallActionText));
+                    RefreshUninstallCommandCanExecute();
                 }
             }
         }
@@ -355,6 +364,7 @@ namespace Dynamo.PackageManager.ViewModels
             RaisePropertyChanged(nameof(InstallActionText));
             RaisePropertyChanged(nameof(InstallActionCommand));
             RaisePropertyChanged(nameof(IsInstalledVersionSelected));
+            RefreshUninstallCommandCanExecute();
         }
 
         private void SetDefaultSelectedVersion()
@@ -393,6 +403,14 @@ namespace Dynamo.PackageManager.ViewModels
             RaisePropertyChanged(nameof(ReversedVersionInformationList));
         }
 
+        private void RefreshUninstallCommandCanExecute()
+        {
+            if (uninstallCommand is DelegateCommand delegateCommand)
+            {
+                delegateCommand.RaiseCanExecuteChanged();
+            }
+        }
+
         private List<String> CustomPackageFolders;
         private bool? isSelectedVersionCompatible;
 
@@ -418,7 +436,12 @@ namespace Dynamo.PackageManager.ViewModels
 
         private void OnRequestDownload(bool downloadToCustomPath)
         {
-            var version = this.SearchElementModel.Header.versions.First(x => x.version.Equals(SelectedVersion.Version));
+            var version = SearchElementModel?.Header?.versions
+                ?.FirstOrDefault(x => x.version.Equals(SelectedVersion?.Version));
+            if (version == null)
+            {
+                return;
+            }
 
             string downloadPath = String.Empty;
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
@@ -23,7 +23,7 @@ namespace Dynamo.PackageManager.ViewModels
         public ICommand DownloadLatestToCustomPathCommand { get; set; }
         public ICommand InstallActionCommand
         {
-            get { return IsInstalledVersionSelected ? uninstallCommand ?? DownloadLatestCommand : DownloadLatestCommand; }
+            get { return IsInstalledVersionSelected ? uninstallCommand : DownloadLatestCommand; }
         }
 
         /// <summary>
@@ -76,10 +76,12 @@ namespace Dynamo.PackageManager.ViewModels
         private VersionInformation selectedVersion;
         private string installedVersion;
         private bool hasUpdateAvailable;
-        private ICommand uninstallCommand;
+        private readonly DelegateCommand uninstallCommand;
+        private Func<bool> canUninstall;
         private bool HasInstalledVersion => !string.IsNullOrEmpty(installedVersion);
         private bool IsInstalledVersionSelected => SelectedVersion?.IsInstalled == true;
-        private bool IsInstalledFallback => IsInstalledVersionSelected && uninstallCommand == null;
+        private bool IsUninstallActionAvailable => canUninstall != null;
+        private bool IsInstalledFallback => IsInstalledVersionSelected && !IsUninstallActionAvailable;
 
         public bool? IsSelectedVersionCompatible
         {
@@ -157,15 +159,15 @@ namespace Dynamo.PackageManager.ViewModels
             }
         }
 
-        internal ICommand UninstallCommand
+        internal ICommand UninstallCommand => uninstallCommand;
+        internal Func<bool> CanUninstall
         {
-            get { return uninstallCommand; }
+            get { return canUninstall; }
             set
             {
-                if (uninstallCommand != value)
+                if (canUninstall != value)
                 {
-                    uninstallCommand = value;
-                    RaisePropertyChanged(nameof(InstallActionCommand));
+                    canUninstall = value;
                     RaisePropertyChanged(nameof(InstallActionText));
                     RefreshUninstallCommandCanExecute();
                 }
@@ -186,6 +188,7 @@ namespace Dynamo.PackageManager.ViewModels
             this.SearchElementModel = element;
             CanInstall = install;
             IsEnabledForInstall = isEnabledForInstall;
+            uninstallCommand = new DelegateCommand(OnRequestUninstall, () => CanUninstall?.Invoke() == true);
 
             // Attempts to show the latest compatible version. If no compatible, will return the latest instead.
             this.SelectedVersion = this.SearchElementModel.LatestCompatibleVersion;
@@ -417,6 +420,7 @@ namespace Dynamo.PackageManager.ViewModels
         public delegate void PackageSearchElementDownloadHandler(
             PackageManagerSearchElement element, PackageVersion version, string downloadPath = null);
         public event PackageSearchElementDownloadHandler RequestDownload;
+        internal event Action<PackageManagerSearchElementViewModel> RequestUninstall;
         
         public void OnRequestDownload(PackageVersion version, bool downloadToCustomPath)
         {
@@ -432,6 +436,14 @@ namespace Dynamo.PackageManager.ViewModels
 
             if (RequestDownload != null)
                 RequestDownload(this.SearchElementModel, version, downloadPath);
+        }
+
+        private void OnRequestUninstall()
+        {
+            if (RequestUninstall != null)
+            {
+                RequestUninstall(this);
+            }
         }
 
         private void OnRequestDownload(bool downloadToCustomPath)

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -917,6 +917,7 @@ namespace Dynamo.PackageManager
                 var p = GetSearchElementViewModel(pkg, true);
 
                 p.RequestDownload += this.PackageOnExecuted;
+                p.RequestUninstall += SearchElementViewModelOnRequestUninstall;
                 p.IsOnwer = true;
 
                 UpdateInstallState(p);
@@ -936,6 +937,7 @@ namespace Dynamo.PackageManager
                 ele.RequestDownload -= PackageOnExecuted;
                 ele.RequestShowFileDialog -= OnRequestShowFileDialog;
                 ele.PropertyChanged -= SearchElementViewModelOnPropertyChanged;
+                ele.RequestUninstall -= SearchElementViewModelOnRequestUninstall;
             }
 
             this.SearchMyResults = null;
@@ -1437,6 +1439,7 @@ namespace Dynamo.PackageManager
             element.RequestDownload += this.PackageOnExecuted;
             element.RequestShowFileDialog += this.OnRequestShowFileDialog;
             element.PropertyChanged += SearchElementViewModelOnPropertyChanged;
+            element.RequestUninstall += SearchElementViewModelOnRequestUninstall;
 
             this.SearchResults.Add(element);
         }
@@ -1449,10 +1452,16 @@ namespace Dynamo.PackageManager
                 ele.RequestDownload -= PackageOnExecuted;
                 ele.RequestShowFileDialog -= OnRequestShowFileDialog;
                 ele.PropertyChanged -= SearchElementViewModelOnPropertyChanged;
+                ele.RequestUninstall -= SearchElementViewModelOnRequestUninstall;
 
                 ele?.Dispose();
             }
             this.SearchResults.Clear();
+        }
+
+        private void SearchElementViewModelOnRequestUninstall(PackageManagerSearchElementViewModel element)
+        {
+            UninstallPackage(element);
         }
 
         private void SearchElementViewModelOnPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -1861,10 +1870,7 @@ namespace Dynamo.PackageManager
                 PackageManagerClientViewModel.AuthenticationManager.HasAuthProvider,
                 CanInstallPackage(package.Name),
                 isEnabledForInstall);
-
-            viewModel.UninstallCommand = new DelegateCommand(
-                () => UninstallPackage(viewModel),
-                () => CanUninstallPackage(viewModel));
+            viewModel.CanUninstall = () => CanUninstallPackage(viewModel);
             UpdateInstallState(viewModel, true);
 
             return viewModel;

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
@@ -359,6 +359,9 @@
                                                                                 <DataTrigger Binding="{Binding InstallActionText}" Value="{x:Static p:Resources.PackageManagerUninstall}">
                                                                                     <Setter Property="Visibility" Value="Collapsed" />
                                                                                 </DataTrigger>
+                                                                                <DataTrigger Binding="{Binding InstallActionText}" Value="{x:Static p:Resources.PackageDownloadStateInstalled}">
+                                                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                                                </DataTrigger>
                                                                             </Style.Triggers>
                                                                         </Style>
                                                                     </Button.Style>
@@ -411,6 +414,14 @@
                                                                                         </Setter.Value>
                                                                                     </Setter>
                                                                                 </MultiDataTrigger>
+                                                                                <DataTrigger Binding="{Binding Path=InstallActionText}" Value="{x:Static p:Resources.PackageDownloadStateInstalled}">
+                                                                                    <Setter Property="Fill">
+                                                                                        <Setter.Value>
+                                                                                            <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/checkmark - grey.png" />
+                                                                                        </Setter.Value>
+                                                                                    </Setter>
+                                                                                    <Setter Property="Opacity" Value="1" />
+                                                                                </DataTrigger>
                                                                             </Style.Triggers>
                                                                         </Style>
                                                                     </Rectangle.Style>
@@ -442,6 +453,10 @@
                                                             <Setter Property="TextBlock.Opacity" Value="1" />
                                                             <Setter Property="TextBlock.Foreground" Value="#84D7CE" />
                                                         </MultiDataTrigger>
+                                                        <DataTrigger Binding="{Binding InstallActionText}" Value="{x:Static p:Resources.PackageDownloadStateInstalled}">
+                                                            <Setter Property="TextBlock.Foreground" Value="#999999" />
+                                                            <Setter Property="TextBlock.Opacity" Value="1" />
+                                                        </DataTrigger>
                                                     </ControlTemplate.Triggers>
                                                 </ControlTemplate>
                                             </Setter.Value>


### PR DESCRIPTION
```
### Purpose

This PR enhances the Package Manager UI to provide clearer feedback on package status and available actions. This includes:
- Displaying a "New version available" badge for installed packages with newer versions.
- Modifying the version dropdown to default to the installed version (if present), or the highest compatible/available version.
- Implementing dynamic labeling ("Install", "Update", "Uninstall", "Installed") and icon visibility for the action button based on package status and selected version.
- Addressing issues with uninstall command availability and potential crashes during download requests.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

- Added a "New version available" badge to installed packages when a newer version is published.
- The package version dropdown now defaults to the installed version if present, otherwise to the highest compatible or available version.
- The package action button dynamically displays "Install", "Update", or "Uninstall". If the installed version is selected and uninstall is not available, it shows "Installed" with a checkmark.
- Improved reliability of uninstall command state and package download requests.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
```

---
<a href="https://cursor.com/background-agent?bcId=bc-6be79294-ec4b-4934-ad70-0f70332d27de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6be79294-ec4b-4934-ad70-0f70332d27de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

