### PR TITLE
UI trigger state evaluation

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1373,6 +1373,9 @@ Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.InstallAct
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.IsDeprecated.get -> bool
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.IsEnabledForInstall.get -> bool
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.IsOnwer.get -> bool
+Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.IsInstalledFallback.get -> bool
+Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.IsInstalledVersionSelected.get -> bool
+Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.IsUninstallState.get -> bool
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.IsSelectedVersionCompatible.get -> bool?
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.IsSelectedVersionCompatible.set -> void
 Dynamo.PackageManager.ViewModels.PackageManagerSearchElementViewModel.LatestVersion.get -> string

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
@@ -79,9 +79,18 @@ namespace Dynamo.PackageManager.ViewModels
         private readonly DelegateCommand uninstallCommand;
         private Func<bool> canUninstall;
         private bool HasInstalledVersion => !string.IsNullOrEmpty(installedVersion);
-        private bool IsInstalledVersionSelected => SelectedVersion?.IsInstalled == true;
-        private bool IsUninstallActionAvailable => canUninstall != null;
-        private bool IsInstalledFallback => IsInstalledVersionSelected && !IsUninstallActionAvailable;
+        /// <summary>
+        /// True when the selected version is installed.
+        /// </summary>
+        public bool IsInstalledVersionSelected => SelectedVersion?.IsInstalled == true;
+        /// <summary>
+        /// True when the selected installed version cannot be uninstalled.
+        /// </summary>
+        public bool IsInstalledFallback => IsInstalledVersionSelected && canUninstall == null;
+        /// <summary>
+        /// True when the selected installed version can be uninstalled.
+        /// </summary>
+        public bool IsUninstallState => IsInstalledVersionSelected && canUninstall != null;
 
         public bool? IsSelectedVersionCompatible
         {
@@ -115,6 +124,8 @@ namespace Dynamo.PackageManager.ViewModels
                     RaisePropertyChanged(nameof(InstallActionText));
                     RaisePropertyChanged(nameof(InstallActionCommand));
                     RaisePropertyChanged(nameof(IsInstalledVersionSelected));
+                    RaisePropertyChanged(nameof(IsInstalledFallback));
+                    RaisePropertyChanged(nameof(IsUninstallState));
                     RefreshUninstallCommandCanExecute();
                 }
             }
@@ -169,6 +180,8 @@ namespace Dynamo.PackageManager.ViewModels
                 {
                     canUninstall = value;
                     RaisePropertyChanged(nameof(InstallActionText));
+                    RaisePropertyChanged(nameof(IsInstalledFallback));
+                    RaisePropertyChanged(nameof(IsUninstallState));
                     RefreshUninstallCommandCanExecute();
                 }
             }
@@ -367,6 +380,8 @@ namespace Dynamo.PackageManager.ViewModels
             RaisePropertyChanged(nameof(InstallActionText));
             RaisePropertyChanged(nameof(InstallActionCommand));
             RaisePropertyChanged(nameof(IsInstalledVersionSelected));
+            RaisePropertyChanged(nameof(IsInstalledFallback));
+            RaisePropertyChanged(nameof(IsUninstallState));
             RefreshUninstallCommandCanExecute();
         }
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -918,6 +918,7 @@ namespace Dynamo.PackageManager
 
                 p.RequestDownload += this.PackageOnExecuted;
                 p.RequestUninstall += SearchElementViewModelOnRequestUninstall;
+                p.PropertyChanged += SearchElementViewModelOnVersionInfoChanged;
                 p.IsOnwer = true;
 
                 myPackages.Add(p);
@@ -934,6 +935,7 @@ namespace Dynamo.PackageManager
                 ele.RequestDownload -= PackageOnExecuted;
                 ele.RequestShowFileDialog -= OnRequestShowFileDialog;
                 ele.RequestUninstall -= SearchElementViewModelOnRequestUninstall;
+                ele.PropertyChanged -= SearchElementViewModelOnVersionInfoChanged;
             }
 
             this.SearchMyResults = null;
@@ -1435,6 +1437,7 @@ namespace Dynamo.PackageManager
             element.RequestDownload += this.PackageOnExecuted;
             element.RequestShowFileDialog += this.OnRequestShowFileDialog;
             element.RequestUninstall += SearchElementViewModelOnRequestUninstall;
+            element.PropertyChanged += SearchElementViewModelOnVersionInfoChanged;
 
             this.SearchResults.Add(element);
         }
@@ -1447,6 +1450,7 @@ namespace Dynamo.PackageManager
                 ele.RequestDownload -= PackageOnExecuted;
                 ele.RequestShowFileDialog -= OnRequestShowFileDialog;
                 ele.RequestUninstall -= SearchElementViewModelOnRequestUninstall;
+                ele.PropertyChanged -= SearchElementViewModelOnVersionInfoChanged;
 
                 ele?.Dispose();
             }
@@ -1455,6 +1459,39 @@ namespace Dynamo.PackageManager
         private void SearchElementViewModelOnRequestUninstall(PackageManagerSearchElementViewModel element)
         {
             UninstallPackage(element);
+        }
+
+        private void SearchElementViewModelOnVersionInfoChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (sender is PackageManagerSearchElementViewModel element &&
+                e.PropertyName == nameof(PackageManagerSearchElementViewModel.VersionInformationList))
+            {
+                UpdateInstallState(element);
+            }
+        }
+
+        private void OnLocalPackageAdded(Package package)
+        {
+            RefreshInstallStateForPackage(package?.Name);
+        }
+
+        private void OnLocalPackageRemoved(Package package)
+        {
+            RefreshInstallStateForPackage(package?.Name);
+        }
+
+        private void RefreshInstallStateForPackage(string packageName)
+        {
+            if (string.IsNullOrEmpty(packageName))
+            {
+                return;
+            }
+
+            var element = GetSearchElementViewModelByName(packageName);
+            if (element != null)
+            {
+                UpdateInstallState(element);
+            }
         }
 
         internal void PackageOnExecuted(PackageManagerSearchElement element, PackageVersion version, string downloadPath)
@@ -1617,16 +1654,20 @@ namespace Dynamo.PackageManager
         {
             SearchResults.CollectionChanged += SearchResultsOnCollectionChanged;
             PackageManagerClientViewModel.Downloads.CollectionChanged += DownloadsOnCollectionChanged;
-            PackageManagerClientViewModel.PackageManagerExtension.PackageLoader.ConflictingCustomNodePackageLoaded +=
-                ConflictingCustomNodePackageLoaded;
+            var packageLoader = PackageManagerClientViewModel.PackageManagerExtension.PackageLoader;
+            packageLoader.ConflictingCustomNodePackageLoaded += ConflictingCustomNodePackageLoaded;
+            packageLoader.PackageAdded += OnLocalPackageAdded;
+            packageLoader.PackageRemoved += OnLocalPackageRemoved;
         }
 
         internal void UnregisterTransientHandlers()
         {
             SearchResults.CollectionChanged -= SearchResultsOnCollectionChanged;
             PackageManagerClientViewModel.Downloads.CollectionChanged -= DownloadsOnCollectionChanged;
-            PackageManagerClientViewModel.PackageManagerExtension.PackageLoader.ConflictingCustomNodePackageLoaded -=
-                ConflictingCustomNodePackageLoaded;
+            var packageLoader = PackageManagerClientViewModel.PackageManagerExtension.PackageLoader;
+            packageLoader.ConflictingCustomNodePackageLoaded -= ConflictingCustomNodePackageLoaded;
+            packageLoader.PackageAdded -= OnLocalPackageAdded;
+            packageLoader.PackageRemoved -= OnLocalPackageRemoved;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerPackagesControl.xaml
@@ -356,10 +356,7 @@
                                                                     <Button.Style>
                                                                         <Style BasedOn="{StaticResource {x:Static ToolBar.ButtonStyleKey}}" TargetType="Button">
                                                                             <Style.Triggers>
-                                                                                <DataTrigger Binding="{Binding InstallActionText}" Value="{x:Static p:Resources.PackageManagerUninstall}">
-                                                                                    <Setter Property="Visibility" Value="Collapsed" />
-                                                                                </DataTrigger>
-                                                                                <DataTrigger Binding="{Binding InstallActionText}" Value="{x:Static p:Resources.PackageDownloadStateInstalled}">
+                                                                                <DataTrigger Binding="{Binding IsInstalledVersionSelected}" Value="True">
                                                                                     <Setter Property="Visibility" Value="Collapsed" />
                                                                                 </DataTrigger>
                                                                             </Style.Triggers>
@@ -384,7 +381,7 @@
                                                                     <Rectangle.Style>
                                                                         <Style TargetType="Rectangle">
                                                                             <Style.Triggers>
-                                                                                <DataTrigger Binding="{Binding Path=InstallActionText}" Value="{x:Static p:Resources.PackageManagerUninstall}">
+                                                                                <DataTrigger Binding="{Binding IsUninstallState}" Value="True">
                                                                                     <Setter Property="Visibility" Value="Collapsed" />
                                                                                 </DataTrigger>
                                                                                 <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="True">
@@ -414,7 +411,7 @@
                                                                                         </Setter.Value>
                                                                                     </Setter>
                                                                                 </MultiDataTrigger>
-                                                                                <DataTrigger Binding="{Binding Path=InstallActionText}" Value="{x:Static p:Resources.PackageDownloadStateInstalled}">
+                                                                                <DataTrigger Binding="{Binding IsInstalledFallback}" Value="True">
                                                                                     <Setter Property="Fill">
                                                                                         <Setter.Value>
                                                                                             <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/checkmark - grey.png" />
@@ -453,7 +450,7 @@
                                                             <Setter Property="TextBlock.Opacity" Value="1" />
                                                             <Setter Property="TextBlock.Foreground" Value="#84D7CE" />
                                                         </MultiDataTrigger>
-                                                        <DataTrigger Binding="{Binding InstallActionText}" Value="{x:Static p:Resources.PackageDownloadStateInstalled}">
+                                                        <DataTrigger Binding="{Binding IsInstalledFallback}" Value="True">
                                                             <Setter Property="TextBlock.Foreground" Value="#999999" />
                                                             <Setter Property="TextBlock.Opacity" Value="1" />
                                                         </DataTrigger>


### PR DESCRIPTION
### Purpose

This PR refactors the package manager UI logic by replacing string-based XAML `DataTrigger` comparisons with dedicated boolean state properties in the ViewModel. This decouples UI behavior from localized display text, improving maintainability and robustness.

### Declarations

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A (Internal refactoring of UI logic)

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

---
<a href="https://cursor.com/background-agent?bcId=bc-00027a26-2cc9-416d-acd8-453999340fd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-00027a26-2cc9-416d-acd8-453999340fd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

