### PR TITLE
Pr changed files

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchElementViewModel.cs
@@ -27,7 +27,8 @@ namespace Dynamo.PackageManager.ViewModels
         }
 
         /// <summary>
-        /// VM IsDeprecated property
+        /// Indicates the package is deprecated. Used to disable install/update
+        /// actions (DownloadLatestCommand CanExecute), while uninstall remains available.
         /// </summary>
         public bool IsDeprecated { get { return this.SearchElementModel.IsDeprecated; } }
         /// <summary>
@@ -78,10 +79,15 @@ namespace Dynamo.PackageManager.ViewModels
         private bool hasUpdateAvailable;
         private readonly DelegateCommand uninstallCommand;
         private Func<bool> canUninstall;
+        /// <summary>
+        /// True when any version of this package is installed locally. Used with
+        /// IsInstalledVersionSelected to drive Install vs Update vs Uninstall UI.
+        /// </summary>
         private bool HasInstalledVersion => !string.IsNullOrEmpty(installedVersion);
 
         /// <summary>
-        /// True when the selected version is installed.
+        /// True when the selected version is installed. Drives whether the install
+        /// button maps to Uninstall versus Install/Update.
         /// </summary>
         public bool IsInstalledVersionSelected => SelectedVersion?.IsInstalled == true;
         /// <summary>
@@ -93,6 +99,10 @@ namespace Dynamo.PackageManager.ViewModels
         /// </summary>
         public bool IsUninstallState => IsInstalledVersionSelected && canUninstall != null;
 
+        /// <summary>
+        /// Compatibility of the currently selected version with the current host.
+        /// This is used for indicators and warnings only; it does not block install/update.
+        /// </summary>
         public bool? IsSelectedVersionCompatible
         {
             get { return isSelectedVersionCompatible; }
@@ -287,8 +297,8 @@ namespace Dynamo.PackageManager.ViewModels
         }
 
         /// <summary>
-        /// True if package is enabled for download if custom package paths are not disabled,
-        /// False if custom package paths are disabled.
+        /// True when install actions are enabled (custom package locations allowed or bypassed).
+        /// Bound to the install button IsEnabled, independent of deprecation or version selection.
         /// </summary>
         public bool IsEnabledForInstall { get; private set; }
 


### PR DESCRIPTION
### Purpose

This PR adds clarifying comments to properties in `PackageManagerSearchElementViewModel.cs` to better explain the logic behind the package manager's install/update/uninstall button states. This addresses reviewer feedback regarding the complexity and intent of the new version-selection flow.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of

---
<a href="https://cursor.com/background-agent?bcId=bc-4296bc14-5f67-4f76-beac-3da132656027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4296bc14-5f67-4f76-beac-3da132656027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

