### PR TITLE
Publish package tab keys

### DIFF
--- a/src/DynamoCoreWpf/DynamoCoreWpf.csproj
+++ b/src/DynamoCoreWpf/DynamoCoreWpf.csproj
@@ -809,6 +809,7 @@
     <Compile Include="Views\PackageManager\Controls\PackageManagerPackagesControl.xaml.cs" />
     <Compile Include="Views\PackageManager\Controls\PackageManagerPublishControl.xaml.cs" />
     <Compile Include="Views\PackageManager\Controls\PackageManagerPublishHost.xaml.cs" />
+    <Compile Include="Views\PackageManager\Controls\PackageManagerTabControl.cs" />
     <Compile Include="Views\PackageManager\Controls\PackageManagerSearchControl.xaml.cs" />
     <Compile Include="Views\PackageManager\Controls\SearchBoxControl.xaml.cs" />
     <Compile Include="Views\PackageManager\PackageManagerView.xaml.cs" />

--- a/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Components/PackageManagerWizard/PackageManagerWizard.xaml.cs
@@ -66,10 +66,14 @@ namespace Dynamo.UI.Views
         internal Action<string, string> RequestShowDialog;
         internal Action RequestCancelUpload;
         internal Action<int, int, string> RequestUploadProgress;
+        internal Action<bool> RequestSetTextInputFocus;
 
         private PackageUpdateRequest previousPackageDetails;
 
         private bool _hasPendingUpdates = false;
+        private bool _textInputFocusHooked = false;
+        internal bool IsTextInputFocused { get; private set; }
+        internal event Action<bool> TextInputFocusChanged;
         #endregion
 
         /// <summary>
@@ -107,6 +111,7 @@ namespace Dynamo.UI.Views
             RequestShowDialog = ShowDialog;
             RequestCancelUpload = CancelUpload;
             RequestUploadProgress = UploadProgress;
+            RequestSetTextInputFocus = SetTextInputFocus;
 
             DataContextChanged += OnDataContextChanged;
         }
@@ -237,6 +242,7 @@ namespace Dynamo.UI.Views
                 // Apply standard WebView2 settings with DevTools enabled for package manager debugging
                 dynWebView.ConfigureSettings(enableDevTools: true);
                 this.dynWebView.CoreWebView2.NewWindowRequested += CoreWebView2_NewWindowRequested;
+                this.dynWebView.CoreWebView2.NavigationCompleted += CoreWebView2_NavigationCompleted;
 
                 // Embed the font
                 var assembly = Assembly.GetExecutingAssembly();
@@ -269,7 +275,8 @@ namespace Dynamo.UI.Views
                             RequestApplicationLoaded,
                             RequestShowDialog,
                             RequestCancelUpload,
-                            RequestUploadProgress));
+                            RequestUploadProgress,
+                            RequestSetTextInputFocus));
 
                 }
                 catch (Exception ex)
@@ -968,6 +975,20 @@ namespace Dynamo.UI.Views
             }
         }
 
+        internal void SetTextInputFocus(bool isFocused)
+        {
+            if (!Dispatcher.CheckAccess())
+            {
+                Dispatcher.Invoke(() => SetTextInputFocus(isFocused));
+                return;
+            }
+
+            if (IsTextInputFocused == isFocused) return;
+
+            IsTextInputFocused = isFocused;
+            TextInputFocusChanged?.Invoke(isFocused);
+        }
+
         /// <summary>
         /// Reports progress of file upload operations
         /// </summary>
@@ -1024,6 +1045,57 @@ namespace Dynamo.UI.Views
         {
             e.Handled = true;
             ProcessUri(e.Uri);
+        }
+
+        private async void CoreWebView2_NavigationCompleted(object sender, CoreWebView2NavigationCompletedEventArgs e)
+        {
+            if (!e.IsSuccess) return;
+
+            try
+            {
+                await InjectTextInputFocusTracking();
+            }
+            catch (Exception ex)
+            {
+                LogMessage(ex);
+            }
+        }
+
+        private async Task InjectTextInputFocusTracking()
+        {
+            if (_textInputFocusHooked || dynWebView?.CoreWebView2 == null) return;
+
+            const string script = @"
+(function() {
+  if (window.__dynamoTextInputFocusHooked) { return; }
+  window.__dynamoTextInputFocusHooked = true;
+
+  const isEditableElement = (el) => {
+    if (!el) return false;
+    const tag = el.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA') {
+      return !el.readOnly && !el.disabled;
+    }
+    return !!el.isContentEditable;
+  };
+
+  const notify = () => {
+    const focused = isEditableElement(document.activeElement);
+    try {
+      const host = window.chrome && window.chrome.webview && window.chrome.webview.hostObjects && window.chrome.webview.hostObjects.scriptObject;
+      if (host && host.SetTextInputFocus) {
+        host.SetTextInputFocus(focused);
+      }
+    } catch (e) {}
+  };
+
+  document.addEventListener('focusin', notify, true);
+  document.addEventListener('focusout', notify, true);
+  notify();
+})();";
+
+            await dynWebView.CoreWebView2.ExecuteScriptAsync(script);
+            _textInputFocusHooked = true;
         }
 
         internal bool ProcessUri(string uri)
@@ -1206,6 +1278,7 @@ namespace Dynamo.UI.Views
                     if (this.dynWebView != null && this.dynWebView.CoreWebView2 != null)
                     {
                         this.dynWebView.CoreWebView2.NewWindowRequested -= CoreWebView2_NewWindowRequested;
+                        this.dynWebView.CoreWebView2.NavigationCompleted -= CoreWebView2_NavigationCompleted;
                     }
                 }
 
@@ -1237,6 +1310,7 @@ namespace Dynamo.UI.Views
         readonly Action<string, string> RequestShowDialog;
         readonly Action RequestCancelUpload;
         readonly Action<int, int, string> RequestUploadProgress;
+        readonly Action<bool> RequestSetTextInputFocus;
 
         public ScriptWizardObject(
             Action<string> requestAddFileOrFolder,
@@ -1255,7 +1329,8 @@ namespace Dynamo.UI.Views
             Action requestApplicationLoaded,
             Action<string, string> requestShowDialog,
             Action requestCancelUpload,
-            Action<int, int, string> requestUploadProgress)
+            Action<int, int, string> requestUploadProgress,
+            Action<bool> requestSetTextInputFocus)
         {
             RequestAddFileOrFolder = requestAddFileOrFolder;
             RequestRemoveFileOrFolder = requestRemoveFileOrFolder;
@@ -1274,6 +1349,7 @@ namespace Dynamo.UI.Views
             RequestShowDialog = requestShowDialog;
             RequestCancelUpload = requestCancelUpload;
             RequestUploadProgress = requestUploadProgress;
+            RequestSetTextInputFocus = requestSetTextInputFocus;
         }
 
         [DynamoJSInvokable]
@@ -1378,6 +1454,12 @@ namespace Dynamo.UI.Views
         public void UploadProgress(int currentFile, int totalFiles, string currentFileName)
         {
             RequestUploadProgress(currentFile, totalFiles, currentFileName);
+        }
+
+        [DynamoJSInvokable]
+        public void SetTextInputFocus(bool isFocused)
+        {
+            RequestSetTextInputFocus(isFocused);
         }
     }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
@@ -1,0 +1,22 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace Dynamo.PackageManager.UI
+{
+    public class PackageManagerTabControl : TabControl
+    {
+        public bool SuppressHomeEndNavigation { get; set; }
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            if (SuppressHomeEndNavigation && (e.Key == Key.Home || e.Key == Key.End))
+            {
+                // Skip base handling to prevent tab switching, but do not
+                // mark as handled so WebView2 can still process the key.
+                return;
+            }
+
+            base.OnKeyDown(e);
+        }
+    }
+}

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml
@@ -164,11 +164,12 @@
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
 
-                    <TabControl x:Name="projectManagerTabControl"
-                                Padding="0"
-                                Background="{StaticResource PreferencesWindowBackgroundColor}"
-                                BorderThickness="0"
-                                TabStripPlacement="Left">
+                    <local:PackageManagerTabControl x:Name="projectManagerTabControl"
+                                                    Padding="0"
+                                                    Background="{StaticResource PreferencesWindowBackgroundColor}"
+                                                    BorderThickness="0"
+                                                    TabStripPlacement="Left"
+                                                    SelectionChanged="ProjectManagerTabControl_SelectionChanged">
 
                         <TabItem Header="{x:Static p:Resources.PackageManagerSearchTab}"
                                  PreviewMouseDown="tab_PreviewMouseDown"
@@ -561,7 +562,7 @@
                             </Border>
                         </TabItem>
 
-                    </TabControl>
+                    </local:PackageManagerTabControl>
                 </Grid>
             </Grid>
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
@@ -69,6 +69,7 @@ namespace Dynamo.PackageManager.UI
             this.PackageManagerViewModel = packageManagerViewModel;
 
             InitializeComponent();
+            UpdatePublishTabKeyNavigation();
 
             if (packageManagerViewModel != null )
             {
@@ -210,6 +211,19 @@ namespace Dynamo.PackageManager.UI
         {
             this.loadingSearchWarningBar.Visibility = Visibility.Collapsed;
             this.loadingMyPackagesWarningBar.Visibility = Visibility.Collapsed;
+        }
+
+        private void ProjectManagerTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            UpdatePublishTabKeyNavigation();
+        }
+
+        private void UpdatePublishTabKeyNavigation()
+        {
+            if (projectManagerTabControl == null) return;
+
+            projectManagerTabControl.SuppressHomeEndNavigation =
+                IsNewPMPublishWizardEnabled && publishTab?.IsSelected == true;
         }
 
         private void tab_PreviewMouseDown(object sender, MouseButtonEventArgs e)

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
@@ -69,6 +69,7 @@ namespace Dynamo.PackageManager.UI
             this.PackageManagerViewModel = packageManagerViewModel;
 
             InitializeComponent();
+            packageManagerPublishHost.Loaded += PackageManagerPublishHost_Loaded;
             UpdatePublishTabKeyNavigation();
 
             if (packageManagerViewModel != null )
@@ -159,6 +160,15 @@ namespace Dynamo.PackageManager.UI
             this.packageManagerSearch?.Dispose();
             (this.Owner as DynamoView).EnableOverlayBlocker(false);
 
+            if (this.packageManagerPublishHost != null)
+            {
+                this.packageManagerPublishHost.Loaded -= PackageManagerPublishHost_Loaded;
+                if (this.packageManagerPublishHost.Wizard != null)
+                {
+                    this.packageManagerPublishHost.Wizard.TextInputFocusChanged -= Wizard_TextInputFocusChanged;
+                }
+            }
+
             if (PackageManagerViewModel == null) return;
             this.PackageManagerViewModel.PackageSearchViewModel.RequestShowFileDialog -= OnRequestShowFileDialog;
             this.PackageManagerViewModel.PackageSearchViewModel.PackageManagerViewClose();
@@ -213,6 +223,16 @@ namespace Dynamo.PackageManager.UI
             this.loadingMyPackagesWarningBar.Visibility = Visibility.Collapsed;
         }
 
+        private void PackageManagerPublishHost_Loaded(object sender, RoutedEventArgs e)
+        {
+            var wizard = this.packageManagerPublishHost?.Wizard;
+            if (wizard == null) return;
+
+            wizard.TextInputFocusChanged -= Wizard_TextInputFocusChanged;
+            wizard.TextInputFocusChanged += Wizard_TextInputFocusChanged;
+            UpdatePublishTabKeyNavigation();
+        }
+
         private void ProjectManagerTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             UpdatePublishTabKeyNavigation();
@@ -223,7 +243,14 @@ namespace Dynamo.PackageManager.UI
             if (projectManagerTabControl == null) return;
 
             projectManagerTabControl.SuppressHomeEndNavigation =
-                IsNewPMPublishWizardEnabled && publishTab?.IsSelected == true;
+                IsNewPMPublishWizardEnabled &&
+                publishTab?.IsSelected == true &&
+                this.packageManagerPublishHost?.Wizard?.IsTextInputFocused == true;
+        }
+
+        private void Wizard_TextInputFocusChanged(bool isFocused)
+        {
+            UpdatePublishTabKeyNavigation();
         }
 
         private void tab_PreviewMouseDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
<!--
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.
-->

### Purpose

Previously, pressing `Home` or `End` keys (with or without Ctrl/Shift) while typing in text fields within the Package Manager's Publish tab would incorrectly switch tabs instead of moving the text caret. This occurred because the WPF `TabControl` was intercepting these keys at the host level, even though the embedded WebView2 (React app) was attempting to handle them internally.

This PR introduces a custom `PackageManagerTabControl` that overrides the `OnKeyDown` behavior. When the Publish tab is active and the new wizard is enabled, this custom control prevents the WPF `TabControl` from performing its default tab navigation with `Home` and `End` keys. This ensures that these keys are correctly processed by the text fields within the WebView, allowing for proper caret movement and text selection.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixed an issue where pressing `Home` or `End` keys in text fields within the Package Manager's Publish tab would incorrectly switch tabs instead of moving the text caret. These keys now function as expected within the text fields.

### Reviewers

(FILL ME IN)

### FYIs

N/A

---
<p><a href="https://cursor.com/background-agent?bcId=bc-43d830a8-98af-4cb1-bb85-6585a67dc218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-43d830a8-98af-4cb1-bb85-6585a67dc218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI behavior change limited to `Home`/`End` key handling in the Package Manager publish flow; main risk is edge cases where focus tracking or suppression toggling could leave tab navigation inconsistent.
> 
> **Overview**
> Fixes `Home`/`End` key behavior in the Package Manager Publish tab so caret movement/selection works inside the embedded WebView2 wizard instead of WPF switching tabs.
> 
> This introduces a custom `PackageManagerTabControl` that can suppress WPF’s default `Home`/`End` tab navigation, and wires it up in `PackageManagerView` to enable suppression only when the *new publish wizard* is active, the Publish tab is selected, and a text-editable element in the WebView has focus. The wizard now injects a small JS focus tracker on `WebView2.NavigationCompleted` and exposes a new host-callable `SetTextInputFocus` to notify WPF when text inputs gain/lose focus.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a0e792efc76842ecd110a65f7c7403d31731975. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->