### PR TITLE
Watch node port connections

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -315,11 +315,11 @@ namespace Dynamo.Graph.Workspaces
             } // Conclude the deletion.
         }
 
-        private static List<(NodeModel StartNode, int StartIndex, NodeModel EndNode, int EndIndex)>
+        private static List<(NodeModel StartNode, int StartIndex, NodeModel EndNode, int EndIndex, List<(double X, double Y)> PinLocations)>
             CollectInlineWatchRewireData(List<ModelBase> models)
         {
             // Capture upstream -> watch -> downstream pairs for later reconnection.
-            var rewires = new List<(NodeModel StartNode, int StartIndex, NodeModel EndNode, int EndIndex)>();
+            var rewires = new List<(NodeModel StartNode, int StartIndex, NodeModel EndNode, int EndIndex, List<(double X, double Y)> PinLocations)>();
             var nodesToDelete = models.OfType<NodeModel>().ToList();
             if (nodesToDelete.Count == 0)
             {
@@ -355,6 +355,10 @@ namespace Dynamo.Graph.Workspaces
                     continue;
                 }
 
+                var inputPinLocations = inputConnector.ConnectorPinModels
+                    .Select(pin => (pin.X, pin.Y))
+                    .ToList();
+
                 var outputPort = node.OutPorts[0];
                 if (outputPort.Connectors.Count == 0)
                 {
@@ -375,7 +379,9 @@ namespace Dynamo.Graph.Workspaces
                         continue;
                     }
 
-                    rewires.Add((startNode, startPort.Index, endNode, endPort.Index));
+                    var pinLocations = new List<(double X, double Y)>(inputPinLocations);
+                    pinLocations.AddRange(outputConnector.ConnectorPinModels.Select(pin => (pin.X, pin.Y)));
+                    rewires.Add((startNode, startPort.Index, endNode, endPort.Index, pinLocations));
                 }
             }
 
@@ -393,7 +399,7 @@ namespace Dynamo.Graph.Workspaces
         }
 
         private void CreateInlineWatchRewireConnectors(
-            IEnumerable<(NodeModel StartNode, int StartIndex, NodeModel EndNode, int EndIndex)> rewires)
+            IEnumerable<(NodeModel StartNode, int StartIndex, NodeModel EndNode, int EndIndex, List<(double X, double Y)> PinLocations)> rewires)
         {
             if (rewires is null || undoRecorder is null)
             {
@@ -449,6 +455,18 @@ namespace Dynamo.Graph.Workspaces
                 }
 
                 undoRecorder.RecordCreationForUndo(connector);
+
+                // Recreate pins from both watch connectors on the new connector.
+                foreach (var pinLocation in rewire.PinLocations)
+                {
+                    var connectorPinModel = new ConnectorPinModel(
+                        pinLocation.X,
+                        pinLocation.Y,
+                        Guid.NewGuid(),
+                        connector.GUID);
+                    connector.AddPin(connectorPinModel);
+                    undoRecorder.RecordCreationForUndo(connectorPinModel);
+                }
             }
         }
 

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -356,7 +356,7 @@ namespace Dynamo.Graph.Workspaces
                 }
 
                 var inputPinLocations = inputConnector.ConnectorPinModels
-                    .Select(pin => (pin.X, pin.Y))
+                    .Select(pin => (pin.Position.X, pin.Position.Y))
                     .Distinct()
                     .ToList();
 
@@ -383,7 +383,7 @@ namespace Dynamo.Graph.Workspaces
                     var pinLocations = new HashSet<(double X, double Y)>(inputPinLocations);
                     foreach (var pin in outputConnector.ConnectorPinModels)
                     {
-                        pinLocations.Add((pin.X, pin.Y));
+                        pinLocations.Add((pin.Position.X, pin.Position.Y));
                     }
                     rewires.Add((startNode, startPort.Index, endNode, endPort.Index, pinLocations.ToList()));
                 }

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -203,6 +203,7 @@ namespace Dynamo.Graph.Workspaces
             if (!ShouldProceedWithRecording(models))
                 return; // There's nothing for deletion.
 
+            // Collect inline Watch connections before deletion severs them.
             var inlineWatchRewireData = CollectInlineWatchRewireData(models);
 
             // Gather a list of connectors first before the nodes they connect
@@ -317,6 +318,7 @@ namespace Dynamo.Graph.Workspaces
         private static List<(NodeModel StartNode, int StartIndex, NodeModel EndNode, int EndIndex)>
             CollectInlineWatchRewireData(List<ModelBase> models)
         {
+            // Capture upstream -> watch -> downstream pairs for later reconnection.
             var rewires = new List<(NodeModel StartNode, int StartIndex, NodeModel EndNode, int EndIndex)>();
             var nodesToDelete = models.OfType<NodeModel>().ToList();
             if (nodesToDelete.Count == 0)
@@ -339,6 +341,7 @@ namespace Dynamo.Graph.Workspaces
                 }
 
                 var inputPort = node.InPorts[0];
+                // Only handle the simple inline Watch case (one input wire).
                 if (inputPort.Connectors.Count != 1)
                 {
                     continue;
@@ -397,6 +400,7 @@ namespace Dynamo.Graph.Workspaces
                 return;
             }
 
+            // Avoid duplicate reconnects when multiple Watch nodes map to same ports.
             var createdKeys = new HashSet<(Guid StartNode, int StartIndex, Guid EndNode, int EndIndex)>();
 
             foreach (var rewire in rewires)

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -315,11 +315,37 @@ namespace Dynamo.Graph.Workspaces
             } // Conclude the deletion.
         }
 
-        private static List<(NodeModel StartNode, int StartIndex, NodeModel EndNode, int EndIndex, List<(double X, double Y)> PinLocations)>
+        private sealed class InlineWatchRewireData
+        {
+            internal InlineWatchRewireData(
+                NodeModel startNode,
+                int startIndex,
+                NodeModel endNode,
+                int endIndex,
+                IReadOnlyList<(double X, double Y)> pinLocations)
+            {
+                StartNode = startNode;
+                StartIndex = startIndex;
+                EndNode = endNode;
+                EndIndex = endIndex;
+                PinLocations = pinLocations ?? Array.Empty<(double X, double Y)>();
+            }
+
+            internal NodeModel StartNode { get; }
+            internal int StartIndex { get; }
+            internal NodeModel EndNode { get; }
+            internal int EndIndex { get; }
+            internal IReadOnlyList<(double X, double Y)> PinLocations { get; }
+
+            internal (Guid StartNode, int StartIndex, Guid EndNode, int EndIndex) Key =>
+                (StartNode.GUID, StartIndex, EndNode.GUID, EndIndex);
+        }
+
+        private static List<InlineWatchRewireData>
             CollectInlineWatchRewireData(List<ModelBase> models)
         {
             // Capture upstream -> watch -> downstream pairs for later reconnection.
-            var rewires = new List<(NodeModel StartNode, int StartIndex, NodeModel EndNode, int EndIndex, List<(double X, double Y)> PinLocations)>();
+            var rewires = new List<InlineWatchRewireData>();
             var nodesToDelete = models.OfType<NodeModel>().ToList();
             if (nodesToDelete.Count == 0)
             {
@@ -385,7 +411,12 @@ namespace Dynamo.Graph.Workspaces
                     {
                         pinLocations.Add((pin.Position.X, pin.Position.Y));
                     }
-                    rewires.Add((startNode, startPort.Index, endNode, endPort.Index, pinLocations.ToList()));
+                    rewires.Add(new InlineWatchRewireData(
+                        startNode,
+                        startPort.Index,
+                        endNode,
+                        endPort.Index,
+                        pinLocations.ToList()));
                 }
             }
 
@@ -402,8 +433,7 @@ namespace Dynamo.Graph.Workspaces
             return node.GetOriginalName() == "Watch";
         }
 
-        private void CreateInlineWatchRewireConnectors(
-            IEnumerable<(NodeModel StartNode, int StartIndex, NodeModel EndNode, int EndIndex, List<(double X, double Y)> PinLocations)> rewires)
+        private void CreateInlineWatchRewireConnectors(IEnumerable<InlineWatchRewireData> rewires)
         {
             if (rewires is null || undoRecorder is null)
             {
@@ -422,7 +452,7 @@ namespace Dynamo.Graph.Workspaces
                     continue;
                 }
 
-                var key = (startNode.GUID, rewire.StartIndex, endNode.GUID, rewire.EndIndex);
+                var key = rewire.Key;
                 if (!createdKeys.Add(key))
                 {
                     continue;

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -357,6 +357,7 @@ namespace Dynamo.Graph.Workspaces
 
                 var inputPinLocations = inputConnector.ConnectorPinModels
                     .Select(pin => (pin.X, pin.Y))
+                    .Distinct()
                     .ToList();
 
                 var outputPort = node.OutPorts[0];
@@ -379,9 +380,12 @@ namespace Dynamo.Graph.Workspaces
                         continue;
                     }
 
-                    var pinLocations = new List<(double X, double Y)>(inputPinLocations);
-                    pinLocations.AddRange(outputConnector.ConnectorPinModels.Select(pin => (pin.X, pin.Y)));
-                    rewires.Add((startNode, startPort.Index, endNode, endPort.Index, pinLocations));
+                    var pinLocations = new HashSet<(double X, double Y)>(inputPinLocations);
+                    foreach (var pin in outputConnector.ConnectorPinModels)
+                    {
+                        pinLocations.Add((pin.X, pin.Y));
+                    }
+                    rewires.Add((startNode, startPort.Index, endNode, endPort.Index, pinLocations.ToList()));
                 }
             }
 

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -314,28 +314,10 @@ namespace Dynamo.Graph.Workspaces
             } // Conclude the deletion.
         }
 
-        private readonly struct InlineWatchRewireData
+        private static List<(NodeModel StartNode, int StartIndex, NodeModel EndNode, int EndIndex)>
+            CollectInlineWatchRewireData(List<ModelBase> models)
         {
-            internal InlineWatchRewireData(NodeModel startNode, int startIndex, NodeModel endNode, int endIndex)
-            {
-                StartNode = startNode;
-                StartIndex = startIndex;
-                EndNode = endNode;
-                EndIndex = endIndex;
-            }
-
-            internal NodeModel StartNode { get; }
-            internal int StartIndex { get; }
-            internal NodeModel EndNode { get; }
-            internal int EndIndex { get; }
-
-            internal (Guid StartNode, int StartIndex, Guid EndNode, int EndIndex) Key =>
-                (StartNode.GUID, StartIndex, EndNode.GUID, EndIndex);
-        }
-
-        private static List<InlineWatchRewireData> CollectInlineWatchRewireData(List<ModelBase> models)
-        {
-            var rewires = new List<InlineWatchRewireData>();
+            var rewires = new List<(NodeModel StartNode, int StartIndex, NodeModel EndNode, int EndIndex)>();
             var nodesToDelete = models.OfType<NodeModel>().ToList();
             if (nodesToDelete.Count == 0)
             {
@@ -390,7 +372,7 @@ namespace Dynamo.Graph.Workspaces
                         continue;
                     }
 
-                    rewires.Add(new InlineWatchRewireData(startNode, startPort.Index, endNode, endPort.Index));
+                    rewires.Add((startNode, startPort.Index, endNode, endPort.Index));
                 }
             }
 
@@ -407,7 +389,8 @@ namespace Dynamo.Graph.Workspaces
             return node.GetOriginalName() == "Watch";
         }
 
-        private void CreateInlineWatchRewireConnectors(IEnumerable<InlineWatchRewireData> rewires)
+        private void CreateInlineWatchRewireConnectors(
+            IEnumerable<(NodeModel StartNode, int StartIndex, NodeModel EndNode, int EndIndex)> rewires)
         {
             if (rewires is null || undoRecorder is null)
             {
@@ -418,12 +401,15 @@ namespace Dynamo.Graph.Workspaces
 
             foreach (var rewire in rewires)
             {
-                if (rewire.StartNode is null || rewire.EndNode is null)
+                var startNode = rewire.StartNode;
+                var endNode = rewire.EndNode;
+                if (startNode is null || endNode is null)
                 {
                     continue;
                 }
 
-                if (!createdKeys.Add(rewire.Key))
+                var key = (startNode.GUID, rewire.StartIndex, endNode.GUID, rewire.EndIndex);
+                if (!createdKeys.Add(key))
                 {
                     continue;
                 }
@@ -433,14 +419,14 @@ namespace Dynamo.Graph.Workspaces
                     continue;
                 }
 
-                if (rewire.StartNode.OutPorts.Count <= rewire.StartIndex ||
-                    rewire.EndNode.InPorts.Count <= rewire.EndIndex)
+                if (startNode.OutPorts.Count <= rewire.StartIndex ||
+                    endNode.InPorts.Count <= rewire.EndIndex)
                 {
                     continue;
                 }
 
-                var startPort = rewire.StartNode.OutPorts[rewire.StartIndex];
-                var endPort = rewire.EndNode.InPorts[rewire.EndIndex];
+                var startPort = startNode.OutPorts[rewire.StartIndex];
+                var endPort = endNode.InPorts[rewire.EndIndex];
 
                 if (startPort.Connectors.Any(connector => connector.End == endPort))
                 {
@@ -448,8 +434,8 @@ namespace Dynamo.Graph.Workspaces
                 }
 
                 var connector = ConnectorModel.Make(
-                    rewire.StartNode,
-                    rewire.EndNode,
+                    startNode,
+                    endNode,
                     rewire.StartIndex,
                     rewire.EndIndex);
 

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -203,6 +203,8 @@ namespace Dynamo.Graph.Workspaces
             if (!ShouldProceedWithRecording(models))
                 return; // There's nothing for deletion.
 
+            var inlineWatchRewireData = CollectInlineWatchRewireData(models);
+
             // Gather a list of connectors first before the nodes they connect
             // to are deleted. We will have to delete the connectors first
             // before
@@ -307,7 +309,157 @@ namespace Dynamo.Graph.Workspaces
                         HasUnsavedChanges = true;
                     }
                 }
+
+                CreateInlineWatchRewireConnectors(inlineWatchRewireData);
             } // Conclude the deletion.
+        }
+
+        private readonly struct InlineWatchRewireData
+        {
+            internal InlineWatchRewireData(NodeModel startNode, int startIndex, NodeModel endNode, int endIndex)
+            {
+                StartNode = startNode;
+                StartIndex = startIndex;
+                EndNode = endNode;
+                EndIndex = endIndex;
+            }
+
+            internal NodeModel StartNode { get; }
+            internal int StartIndex { get; }
+            internal NodeModel EndNode { get; }
+            internal int EndIndex { get; }
+
+            internal (Guid StartNode, int StartIndex, Guid EndNode, int EndIndex) Key =>
+                (StartNode.GUID, StartIndex, EndNode.GUID, EndIndex);
+        }
+
+        private static List<InlineWatchRewireData> CollectInlineWatchRewireData(List<ModelBase> models)
+        {
+            var rewires = new List<InlineWatchRewireData>();
+            var nodesToDelete = models.OfType<NodeModel>().ToList();
+            if (nodesToDelete.Count == 0)
+            {
+                return rewires;
+            }
+
+            var deletedNodeGuids = new HashSet<Guid>(nodesToDelete.Select(node => node.GUID));
+
+            foreach (var node in nodesToDelete)
+            {
+                if (!IsInlineWatchNode(node))
+                {
+                    continue;
+                }
+
+                if (node.InPorts.Count == 0 || node.OutPorts.Count == 0)
+                {
+                    continue;
+                }
+
+                var inputPort = node.InPorts[0];
+                if (inputPort.Connectors.Count != 1)
+                {
+                    continue;
+                }
+
+                var inputConnector = inputPort.Connectors[0];
+                var startPort = inputConnector.Start;
+                var startNode = startPort?.Owner;
+                if (startNode is null || deletedNodeGuids.Contains(startNode.GUID))
+                {
+                    continue;
+                }
+
+                var outputPort = node.OutPorts[0];
+                if (outputPort.Connectors.Count == 0)
+                {
+                    continue;
+                }
+
+                foreach (var outputConnector in outputPort.Connectors.ToList())
+                {
+                    var endPort = outputConnector.End;
+                    var endNode = endPort?.Owner;
+                    if (endNode is null || deletedNodeGuids.Contains(endNode.GUID))
+                    {
+                        continue;
+                    }
+
+                    if (startNode.GUID == endNode.GUID)
+                    {
+                        continue;
+                    }
+
+                    rewires.Add(new InlineWatchRewireData(startNode, startPort.Index, endNode, endPort.Index));
+                }
+            }
+
+            return rewires;
+        }
+
+        private static bool IsInlineWatchNode(NodeModel node)
+        {
+            if (node is null)
+            {
+                return false;
+            }
+
+            return node.GetOriginalName() == "Watch";
+        }
+
+        private void CreateInlineWatchRewireConnectors(IEnumerable<InlineWatchRewireData> rewires)
+        {
+            if (rewires is null || undoRecorder is null)
+            {
+                return;
+            }
+
+            var createdKeys = new HashSet<(Guid StartNode, int StartIndex, Guid EndNode, int EndIndex)>();
+
+            foreach (var rewire in rewires)
+            {
+                if (rewire.StartNode is null || rewire.EndNode is null)
+                {
+                    continue;
+                }
+
+                if (!createdKeys.Add(rewire.Key))
+                {
+                    continue;
+                }
+
+                if (rewire.StartIndex < 0 || rewire.EndIndex < 0)
+                {
+                    continue;
+                }
+
+                if (rewire.StartNode.OutPorts.Count <= rewire.StartIndex ||
+                    rewire.EndNode.InPorts.Count <= rewire.EndIndex)
+                {
+                    continue;
+                }
+
+                var startPort = rewire.StartNode.OutPorts[rewire.StartIndex];
+                var endPort = rewire.EndNode.InPorts[rewire.EndIndex];
+
+                if (startPort.Connectors.Any(connector => connector.End == endPort))
+                {
+                    continue;
+                }
+
+                var connector = ConnectorModel.Make(
+                    rewire.StartNode,
+                    rewire.EndNode,
+                    rewire.StartIndex,
+                    rewire.EndIndex);
+
+                if (connector is null)
+                {
+                    continue;
+                }
+
+                undoRecorder.RecordCreationForUndo(connector);
+            }
         }
 
         internal void DeleteSavedModels()

--- a/test/DynamoCoreTests/Models/DynamoModelEventsTest.cs
+++ b/test/DynamoCoreTests/Models/DynamoModelEventsTest.cs
@@ -220,6 +220,38 @@ namespace Dynamo.Tests.ModelsTest
             Assert.IsTrue(deletionStarted);
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void DeletingInlineWatchReconnectsPorts()
+        {
+            var codeBlockNodeA = CreateCodeBlockNode();
+            UpdateCodeBlockNodeContent(codeBlockNodeA, "1;");
+
+            var codeBlockNodeB = CreateCodeBlockNode();
+            UpdateCodeBlockNodeContent(codeBlockNodeB, "x + 1;");
+
+            var watch = new Watch();
+            var command = new DynCmd.CreateNodeCommand(
+                watch, 0, 0, true, false);
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            ConnectorModel.Make(codeBlockNodeA, watch, 0, 0);
+            ConnectorModel.Make(watch, codeBlockNodeB, 0, 0);
+
+            Assert.AreEqual(3, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            Assert.AreEqual(1, codeBlockNodeB.InPorts[0].Connectors.Count);
+            Assert.AreSame(watch, codeBlockNodeB.InPorts[0].Connectors[0].Start.Owner);
+
+            CurrentDynamoModel.DeleteModelInternal(new List<ModelBase> { watch });
+
+            Assert.AreEqual(2, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            Assert.IsFalse(CurrentDynamoModel.CurrentWorkspace.Nodes.Contains(watch));
+            Assert.AreEqual(1, codeBlockNodeB.InPorts[0].Connectors.Count);
+            Assert.AreSame(codeBlockNodeA, codeBlockNodeB.InPorts[0].Connectors[0].Start.Owner);
+            Assert.AreEqual(1, codeBlockNodeA.OutPorts[0].Connectors.Count);
+            Assert.AreSame(codeBlockNodeB, codeBlockNodeA.OutPorts[0].Connectors[0].End.Owner);
+        }
+
         /// <summary>
         /// This test method will execute the event OnDeletionComplete
         /// </summary>

--- a/test/DynamoCoreTests/Models/DynamoModelEventsTest.cs
+++ b/test/DynamoCoreTests/Models/DynamoModelEventsTest.cs
@@ -306,8 +306,12 @@ namespace Dynamo.Tests.ModelsTest
                 (50, 60)
             };
 
-            var actualPinsToB = connectorToB.ConnectorPinModels.Select(pin => (pin.X, pin.Y)).ToHashSet();
-            var actualPinsToC = connectorToC.ConnectorPinModels.Select(pin => (pin.X, pin.Y)).ToHashSet();
+            var actualPinsToB = connectorToB.ConnectorPinModels
+                .Select(pin => (pin.Position.X, pin.Position.Y))
+                .ToHashSet();
+            var actualPinsToC = connectorToC.ConnectorPinModels
+                .Select(pin => (pin.Position.X, pin.Position.Y))
+                .ToHashSet();
 
             CollectionAssert.AreEquivalent(expectedPinsToB, actualPinsToB);
             CollectionAssert.AreEquivalent(expectedPinsToC, actualPinsToC);

--- a/test/DynamoCoreTests/Models/DynamoModelEventsTest.cs
+++ b/test/DynamoCoreTests/Models/DynamoModelEventsTest.cs
@@ -252,6 +252,67 @@ namespace Dynamo.Tests.ModelsTest
             Assert.AreSame(codeBlockNodeB, codeBlockNodeA.OutPorts[0].Connectors[0].End.Owner);
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void DeletingInlineWatchPreservesConnectorPins()
+        {
+            var codeBlockNodeA = CreateCodeBlockNode();
+            UpdateCodeBlockNodeContent(codeBlockNodeA, "1;");
+
+            var codeBlockNodeB = CreateCodeBlockNode();
+            UpdateCodeBlockNodeContent(codeBlockNodeB, "x + 1;");
+
+            var codeBlockNodeC = CreateCodeBlockNode();
+            UpdateCodeBlockNodeContent(codeBlockNodeC, "x + 2;");
+
+            var watch = new Watch();
+            var command = new DynCmd.CreateNodeCommand(
+                watch, 0, 0, true, false);
+            CurrentDynamoModel.ExecuteCommand(command);
+
+            ConnectorModel.Make(codeBlockNodeA, watch, 0, 0);
+            ConnectorModel.Make(watch, codeBlockNodeB, 0, 0);
+            ConnectorModel.Make(watch, codeBlockNodeC, 0, 0);
+
+            var inputConnector = watch.InPorts[0].Connectors[0];
+            var outputConnectorB = watch.OutPorts[0].Connectors
+                .First(connector => connector.End.Owner == codeBlockNodeB);
+            var outputConnectorC = watch.OutPorts[0].Connectors
+                .First(connector => connector.End.Owner == codeBlockNodeC);
+
+            inputConnector.ConnectorPinModels.Add(new ConnectorPinModel(10, 20, Guid.NewGuid(), inputConnector.GUID));
+            inputConnector.ConnectorPinModels.Add(new ConnectorPinModel(15, 25, Guid.NewGuid(), inputConnector.GUID));
+            outputConnectorB.ConnectorPinModels.Add(new ConnectorPinModel(30, 40, Guid.NewGuid(), outputConnectorB.GUID));
+            outputConnectorC.ConnectorPinModels.Add(new ConnectorPinModel(50, 60, Guid.NewGuid(), outputConnectorC.GUID));
+
+            CurrentDynamoModel.DeleteModelInternal(new List<ModelBase> { watch });
+
+            var connectorToB = codeBlockNodeB.InPorts[0].Connectors[0];
+            var connectorToC = codeBlockNodeC.InPorts[0].Connectors[0];
+
+            Assert.AreSame(codeBlockNodeA, connectorToB.Start.Owner);
+            Assert.AreSame(codeBlockNodeA, connectorToC.Start.Owner);
+
+            var expectedPinsToB = new HashSet<(double X, double Y)>
+            {
+                (10, 20),
+                (15, 25),
+                (30, 40)
+            };
+            var expectedPinsToC = new HashSet<(double X, double Y)>
+            {
+                (10, 20),
+                (15, 25),
+                (50, 60)
+            };
+
+            var actualPinsToB = connectorToB.ConnectorPinModels.Select(pin => (pin.X, pin.Y)).ToHashSet();
+            var actualPinsToC = connectorToC.ConnectorPinModels.Select(pin => (pin.X, pin.Y)).ToHashSet();
+
+            CollectionAssert.AreEquivalent(expectedPinsToB, actualPinsToB);
+            CollectionAssert.AreEquivalent(expectedPinsToC, actualPinsToC);
+        }
+
         /// <summary>
         /// This test method will execute the event OnDeletionComplete
         /// </summary>


### PR DESCRIPTION
### Purpose

This PR addresses the user request to automatically reconnect upstream and downstream nodes when an inline Watch node is deleted. Previously, deleting an inline Watch node would break the connection between the preceding and succeeding nodes. This change improves the user experience by maintaining graph connectivity, effectively bypassing the deleted Watch node without requiring manual re-connection. This was achieved by integrating the reconnection logic into the existing deletion flow, avoiding the creation of new commands.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Deleting an inline Watch node will now automatically reconnect the upstream and downstream nodes, maintaining graph connectivity.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of

---
<p><a href="https://cursor.com/background-agent?bcId=bc-29be44ed-8866-4661-97ab-955a98d0c46b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29be44ed-8866-4661-97ab-955a98d0c46b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

