### PR TITLE
Publish wizard key handling

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1315,8 +1315,6 @@ Dynamo.PackageManager.UI.PackageManagerSearchView.PackageManagerSearchView(Dynam
 Dynamo.PackageManager.UI.PackageManagerSearchView.ViewModel.get -> Dynamo.PackageManager.PackageManagerSearchViewModel
 Dynamo.PackageManager.UI.PackageManagerTabControl
 Dynamo.PackageManager.UI.PackageManagerTabControl.PackageManagerTabControl() -> void
-Dynamo.PackageManager.UI.PackageManagerTabControl.SuppressHomeEndNavigation.get -> bool
-Dynamo.PackageManager.UI.PackageManagerTabControl.SuppressHomeEndNavigation.set -> void
 Dynamo.PackageManager.UI.PackageManagerView
 Dynamo.PackageManager.UI.PackageManagerView.InitializeComponent() -> void
 Dynamo.PackageManager.UI.PackageManagerView.IsNewPMPublishWizardEnabled.get -> bool

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 
@@ -6,13 +7,17 @@ namespace Dynamo.PackageManager.UI
     public class PackageManagerTabControl : TabControl
     {
         public bool SuppressHomeEndNavigation { get; set; }
+        internal UIElement SuppressHomeEndNavigationFocusScope { get; set; }
 
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            if (SuppressHomeEndNavigation && (e.Key == Key.Home || e.Key == Key.End))
+            if (SuppressHomeEndNavigation &&
+                (e.Key == Key.Home || e.Key == Key.End) &&
+                SuppressHomeEndNavigationFocusScope?.IsKeyboardFocusWithin == true)
             {
-                // Skip base handling to prevent tab switching, but do not
-                // mark as handled so WebView2 can still process the key.
+                // Skip base handling to prevent tab switching only when focus
+                // is inside the publish wizard, but keep the event unhandled
+                // so WebView2 can still process Home/End in text fields.
                 return;
             }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
@@ -6,7 +6,7 @@ namespace Dynamo.PackageManager.UI
 {
     public class PackageManagerTabControl : TabControl
     {
-        public bool SuppressHomeEndNavigation { get; set; }
+        internal bool SuppressHomeEndNavigation { get; set; }
         internal UIElement SuppressHomeEndNavigationFocusScope { get; set; }
 
         protected override void OnKeyDown(KeyEventArgs e)

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
@@ -221,6 +221,7 @@ namespace Dynamo.PackageManager.UI
         private void UpdatePublishTabKeyNavigation()
         {
             if (projectManagerTabControl == null) return;
+            projectManagerTabControl.SuppressHomeEndNavigationFocusScope = packageManagerPublishHost?.Wizard ?? packageManagerPublishHost;
             projectManagerTabControl.SuppressHomeEndNavigation = IsNewPMPublishWizardEnabled && publishTab?.IsSelected == true;
         }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
@@ -221,7 +221,8 @@ namespace Dynamo.PackageManager.UI
         private void UpdatePublishTabKeyNavigation()
         {
             if (projectManagerTabControl == null) return;
-            projectManagerTabControl.SuppressHomeEndNavigationFocusScope = packageManagerPublishHost?.Wizard ?? packageManagerPublishHost;
+            projectManagerTabControl.SuppressHomeEndNavigationFocusScope =
+                packageManagerPublishHost?.Wizard as UIElement ?? packageManagerPublishHost;
             projectManagerTabControl.SuppressHomeEndNavigation = IsNewPMPublishWizardEnabled && publishTab?.IsSelected == true;
         }
 


### PR DESCRIPTION
### Purpose

This PR refines the handling of Home and End keys within the new Package Publish Wizard. Previously, WPF's `TabControl` would intercept these keys, preventing their use for cursor navigation in text fields within the React-based wizard.

The initial fix (commit `7c1a2980bf`) suppressed `Home/End` navigation for the entire publish tab. This PR scopes that suppression more tightly: `Home/End` keys are now only prevented from triggering tab navigation when the publish tab is active *and* keyboard focus is specifically within the publish wizard's WebView2 host. This ensures Home/End keys work as expected in wizard text fields while preserving their default WPF behavior for other elements (e.g., tab headers) on the same tab.

### Declarations

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Home and End keys now correctly function within text fields of the new Package Publish Wizard, allowing cursor navigation without unintended tab switching.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

---
<p><a href="https://cursor.com/background-agent?bcId=bc-a8f5c358-d7ba-4cb6-bea3-ca4806cc2f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a8f5c358-d7ba-4cb6-bea3-ca4806cc2f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

