### PR TITLE
Package manager tab navigation

### DIFF
--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
@@ -76,21 +76,7 @@ namespace Dynamo.PackageManager.UI
 
         private bool IsTabStripFocused()
         {
-            if (Keyboard.FocusedElement == this)
-            {
-                return true;
-            }
-
-            for (var index = 0; index < Items.Count; index++)
-            {
-                if (ItemContainerGenerator.ContainerFromIndex(index) is TabItem tabItem &&
-                    tabItem.IsKeyboardFocusWithin)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return Keyboard.FocusedElement == this || Keyboard.FocusedElement is TabItem;
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 
@@ -9,6 +10,11 @@ namespace Dynamo.PackageManager.UI
 
         protected override void OnKeyDown(KeyEventArgs e)
         {
+            if (TryHandlePageNavigation(e))
+            {
+                return;
+            }
+
             if (SuppressHomeEndNavigation && (e.Key == Key.Home || e.Key == Key.End))
             {
                 // Skip base handling to prevent tab switching, but do not
@@ -17,6 +23,74 @@ namespace Dynamo.PackageManager.UI
             }
 
             base.OnKeyDown(e);
+        }
+
+        private bool TryHandlePageNavigation(KeyEventArgs e)
+        {
+            if (e.Key != Key.PageUp && e.Key != Key.PageDown)
+            {
+                return false;
+            }
+
+            // Only use PageUp/PageDown for tab navigation while the tab strip itself has focus.
+            // This lets the hosted page keep receiving these keys after a user clicks into it.
+            if (!IsTabStripFocused())
+            {
+                return false;
+            }
+
+            var direction = e.Key == Key.PageDown ? 1 : -1;
+            if (!TrySelectAdjacentTab(direction))
+            {
+                return false;
+            }
+
+            e.Handled = true;
+            return true;
+        }
+
+        private bool TrySelectAdjacentTab(int direction)
+        {
+            if (SelectedIndex < 0 || direction == 0)
+            {
+                return false;
+            }
+
+            var index = SelectedIndex + direction;
+            while (index >= 0 && index < Items.Count)
+            {
+                if (ItemContainerGenerator.ContainerFromIndex(index) is TabItem tabItem &&
+                    tabItem.IsEnabled &&
+                    tabItem.Visibility == Visibility.Visible)
+                {
+                    SelectedIndex = index;
+                    tabItem.Focus();
+                    return true;
+                }
+
+                index += direction;
+            }
+
+            return false;
+        }
+
+        private bool IsTabStripFocused()
+        {
+            if (Keyboard.FocusedElement == this)
+            {
+                return true;
+            }
+
+            for (var index = 0; index < Items.Count; index++)
+            {
+                if (ItemContainerGenerator.ContainerFromIndex(index) is TabItem tabItem &&
+                    tabItem.IsKeyboardFocusWithin)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 using Dynamo.Controls;
 using Dynamo.Logging;
 using Dynamo.Models;
@@ -70,6 +71,7 @@ namespace Dynamo.PackageManager.UI
 
             InitializeComponent();
             UpdatePublishTabKeyNavigation();
+            FocusSelectedTabHeader();
 
             if (packageManagerViewModel != null )
             {
@@ -216,12 +218,30 @@ namespace Dynamo.PackageManager.UI
         private void ProjectManagerTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             UpdatePublishTabKeyNavigation();
+            FocusSelectedTabHeader();
         }
 
         private void UpdatePublishTabKeyNavigation()
         {
             if (projectManagerTabControl == null) return;
             projectManagerTabControl.SuppressHomeEndNavigation = IsNewPMPublishWizardEnabled && publishTab?.IsSelected == true;
+        }
+
+        private void FocusSelectedTabHeader()
+        {
+            if (projectManagerTabControl == null) return;
+
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                if (projectManagerTabControl.SelectedItem is TabItem selectedTab)
+                {
+                    selectedTab.Focus();
+                }
+                else
+                {
+                    projectManagerTabControl.Focus();
+                }
+            }), DispatcherPriority.Background);
         }
 
         private void tab_PreviewMouseDown(object sender, MouseButtonEventArgs e)

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
@@ -217,6 +217,10 @@ namespace Dynamo.PackageManager.UI
 
         private void ProjectManagerTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            // SelectionChanged is a bubbling event. Ignore selection changes from child controls
+            // inside tab content and only react to actual package manager tab switches.
+            if (!ReferenceEquals(e.OriginalSource, projectManagerTabControl)) return;
+
             UpdatePublishTabKeyNavigation();
             FocusSelectedTabHeader();
         }


### PR DESCRIPTION
### Purpose

This PR enables `PageUp` and `PageDown` keys for navigating between tabs in the Package Manager. It also adjusts focus handling to ensure that the tab strip retains focus by default, allowing these keys to function for tab navigation, while embedded content (like the React wizard) only gains focus when explicitly clicked by the user. This resolves an issue where embedded content would automatically steal focus, preventing keyboard navigation of tabs.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Users can now navigate between Package Manager tabs (e.g., "Search for a Package", "Publish a Package") using the `PageUp` and `PageDown` keys.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of

---
<p><a href="https://cursor.com/background-agent?bcId=bc-0759dae7-5812-4534-97e3-f2ece31fbd44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0759dae7-5812-4534-97e3-f2ece31fbd44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

