### PR TITLE
Package manager tab control review

### DIFF
--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -1315,8 +1315,6 @@ Dynamo.PackageManager.UI.PackageManagerSearchView.PackageManagerSearchView(Dynam
 Dynamo.PackageManager.UI.PackageManagerSearchView.ViewModel.get -> Dynamo.PackageManager.PackageManagerSearchViewModel
 Dynamo.PackageManager.UI.PackageManagerTabControl
 Dynamo.PackageManager.UI.PackageManagerTabControl.PackageManagerTabControl() -> void
-Dynamo.PackageManager.UI.PackageManagerTabControl.SuppressHomeEndNavigation.get -> bool
-Dynamo.PackageManager.UI.PackageManagerTabControl.SuppressHomeEndNavigation.set -> void
 Dynamo.PackageManager.UI.PackageManagerView
 Dynamo.PackageManager.UI.PackageManagerView.InitializeComponent() -> void
 Dynamo.PackageManager.UI.PackageManagerView.IsNewPMPublishWizardEnabled.get -> bool
@@ -4533,6 +4531,8 @@ static Dynamo.Nodes.AnnotationView.SelectAllTextOnFocus -> System.Windows.Depend
 static Dynamo.PackageManager.PackageManagerSearchViewModel.FormatPackageVersionList(System.Collections.Generic.IEnumerable<System.Tuple<Greg.Responses.PackageHeader, Greg.Responses.PackageVersion>> packages) -> string
 static Dynamo.PackageManager.PublishPackageViewModel.FromLocalPackage(Dynamo.ViewModels.DynamoViewModel dynamoViewModel, Dynamo.PackageManager.Package pkg) -> Dynamo.PackageManager.PublishPackageViewModel
 static Dynamo.PackageManager.UI.MyTreeViewHelper.GetIsMouseDirectlyOverItem(System.Windows.DependencyObject obj) -> bool
+static Dynamo.PackageManager.UI.PackageManagerTabControl.GetSuppressHomeEndWhenSelected(System.Windows.DependencyObject element) -> bool
+static Dynamo.PackageManager.UI.PackageManagerTabControl.SetSuppressHomeEndWhenSelected(System.Windows.DependencyObject element, bool value) -> void
 static Dynamo.PackageManager.UI.PackageNameLengthValidationRule.IsValidName(string value) -> bool
 static Dynamo.PackageManager.UI.PublishPackagePublishPage.GetUserControlFromPage(System.Windows.Controls.Page page) -> System.Windows.Controls.UserControl
 static Dynamo.PackageManager.UI.TreeViewItemHelper.GetIndent(System.Windows.DependencyObject obj) -> System.Windows.GridLength
@@ -5884,6 +5884,7 @@ static readonly Dynamo.PackageManager.UI.NumericUpDownControl.ValueProperty -> S
 static readonly Dynamo.PackageManager.UI.NumericUpDownControl.WatermarkProperty -> System.Windows.DependencyProperty
 static readonly Dynamo.PackageManager.UI.PackageManagerPackagesControl.SearchItemsProperty -> System.Windows.DependencyProperty
 static readonly Dynamo.PackageManager.UI.PackageManagerPackagesControl.SelectedItemProperty -> System.Windows.DependencyProperty
+static readonly Dynamo.PackageManager.UI.PackageManagerTabControl.SuppressHomeEndWhenSelectedProperty -> System.Windows.DependencyProperty
 static readonly Dynamo.PackageManager.UI.TreeViewItemHelper.IndentProperty -> System.Windows.DependencyProperty
 static readonly Dynamo.UI.Controls.CodeCompletionEditor.CodeProperty -> System.Windows.DependencyProperty
 static readonly Dynamo.UI.Controls.DynamoToolTip.AttachmentSideProperty -> System.Windows.DependencyProperty

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
@@ -169,7 +169,8 @@ namespace Dynamo.PackageManager.UI
             // fighting WPF's internal focus transitions during tab changes.
             Dispatcher.BeginInvoke(new Action(() =>
             {
-                if (SelectedItem is TabItem selectedTab)
+                var selectedTab = ItemContainerGenerator.ContainerFromItem(SelectedItem) as TabItem;
+                if (selectedTab != null)
                 {
                     selectedTab.Focus();
                 }

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
@@ -1,21 +1,53 @@
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 
 namespace Dynamo.PackageManager.UI
 {
     public class PackageManagerTabControl : TabControl
     {
-        internal bool SuppressHomeEndNavigation { get; set; }
+        public static readonly DependencyProperty SuppressHomeEndWhenSelectedProperty =
+            DependencyProperty.RegisterAttached(
+                "SuppressHomeEndWhenSelected",
+                typeof(bool),
+                typeof(PackageManagerTabControl),
+                new FrameworkPropertyMetadata(false));
+
+        public static bool GetSuppressHomeEndWhenSelected(DependencyObject element)
+        {
+            return (bool)element.GetValue(SuppressHomeEndWhenSelectedProperty);
+        }
+
+        public static void SetSuppressHomeEndWhenSelected(DependencyObject element, bool value)
+        {
+            element.SetValue(SuppressHomeEndWhenSelectedProperty, value);
+        }
+
+        public PackageManagerTabControl()
+        {
+            Loaded += OnLoaded;
+        }
+
+        protected override void OnSelectionChanged(SelectionChangedEventArgs e)
+        {
+            base.OnSelectionChanged(e);
+
+            if (ReferenceEquals(e.OriginalSource, this))
+            {
+                FocusSelectedTabHeaderAsync();
+            }
+        }
 
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            if(TryHandlePageNavigation(e))
+            if (TryHandlePageUpDownNavigation(e))
             {
                 return;
             }
 
-            if (SuppressHomeEndNavigation && (e.Key == Key.Home || e.Key == Key.End))
+            if (ShouldSuppressHomeEndNavigation(e.Key))
             {
                 // Skip base handling to prevent tab switching, but do not
                 // mark as handled so WebView2 can still process the key.
@@ -25,7 +57,23 @@ namespace Dynamo.PackageManager.UI
             base.OnKeyDown(e);
         }
 
-        private bool TryHandlePageNavigation(KeyEventArgs e)
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            FocusSelectedTabHeaderAsync();
+        }
+
+        private bool ShouldSuppressHomeEndNavigation(Key key)
+        {
+            if (key != Key.Home && key != Key.End)
+            {
+                return false;
+            }
+
+            return SelectedItem is DependencyObject selectedTab &&
+                   GetSuppressHomeEndWhenSelected(selectedTab);
+        }
+
+        private bool TryHandlePageUpDownNavigation(KeyEventArgs e)
         {
             if (e.Key != Key.PageUp && e.Key != Key.PageDown)
             {
@@ -76,7 +124,34 @@ namespace Dynamo.PackageManager.UI
 
         private bool IsTabStripFocused()
         {
-            return Keyboard.FocusedElement == this || Keyboard.FocusedElement is TabItem;
+            if (Keyboard.FocusedElement == this)
+            {
+                return true;
+            }
+
+            if (Keyboard.FocusedElement is TabItem tabItem)
+            {
+                return ReferenceEquals(ItemsControl.ItemsControlFromItemContainer(tabItem), this);
+            }
+
+            return false;
+        }
+
+        private void FocusSelectedTabHeaderAsync()
+        {
+            // Defer focus until layout/selection updates are applied to avoid
+            // fighting WPF's internal focus transitions during tab changes.
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                if (SelectedItem is TabItem selectedTab)
+                {
+                    selectedTab.Focus();
+                }
+                else
+                {
+                    Focus();
+                }
+            }), DispatcherPriority.Background);
         }
     }
 }

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
@@ -6,8 +6,16 @@ using System.Windows.Threading;
 
 namespace Dynamo.PackageManager.UI
 {
+    /// <summary>
+    /// TabControl for Package Manager tabs that customizes keyboard navigation
+    /// to preserve editing shortcuts inside tab content when required.
+    /// </summary>
     public class PackageManagerTabControl : TabControl
     {
+        /// <summary>
+        /// Attached property used on a tab item to disable Home/End tab switching
+        /// while that tab is selected.
+        /// </summary>
         public static readonly DependencyProperty SuppressHomeEndWhenSelectedProperty =
             DependencyProperty.RegisterAttached(
                 "SuppressHomeEndWhenSelected",
@@ -15,16 +23,29 @@ namespace Dynamo.PackageManager.UI
                 typeof(PackageManagerTabControl),
                 new FrameworkPropertyMetadata(false));
 
+        /// <summary>
+        /// Gets whether Home/End tab switching is suppressed for the provided element.
+        /// </summary>
+        /// <param name="element">The element that stores the attached value.</param>
+        /// <returns><c>true</c> if Home/End tab switching should be suppressed.</returns>
         public static bool GetSuppressHomeEndWhenSelected(DependencyObject element)
         {
             return (bool)element.GetValue(SuppressHomeEndWhenSelectedProperty);
         }
 
+        /// <summary>
+        /// Sets whether Home/End tab switching is suppressed for the provided element.
+        /// </summary>
+        /// <param name="element">The element that stores the attached value.</param>
+        /// <param name="value"><c>true</c> to suppress Home/End tab switching.</param>
         public static void SetSuppressHomeEndWhenSelected(DependencyObject element, bool value)
         {
             element.SetValue(SuppressHomeEndWhenSelectedProperty, value);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PackageManagerTabControl"/> class.
+        /// </summary>
         public PackageManagerTabControl()
         {
             Loaded += OnLoaded;

--- a/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/Controls/PackageManagerTabControl.cs
@@ -69,7 +69,12 @@ namespace Dynamo.PackageManager.UI
                 return false;
             }
 
-            return SelectedItem is DependencyObject selectedTab &&
+            if (SelectedItem == null)
+            {
+                return false;
+            }
+
+            return ItemContainerGenerator.ContainerFromItem(SelectedItem) is DependencyObject selectedTab &&
                    GetSuppressHomeEndWhenSelected(selectedTab);
         }
 

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml
@@ -164,12 +164,11 @@
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
 
-                    <local:PackageManagerTabControl x:Name="projectManagerTabControl"
+                    <local:PackageManagerTabControl x:Name="packageManagerTabControl"
                                 Padding="0"
                                 Background="{StaticResource PreferencesWindowBackgroundColor}"
                                 BorderThickness="0"
-                                TabStripPlacement="Left"
-                                SelectionChanged="ProjectManagerTabControl_SelectionChanged">
+                                TabStripPlacement="Left">
 
                         <TabItem Header="{x:Static p:Resources.PackageManagerSearchTab}"
                                  PreviewMouseDown="tab_PreviewMouseDown"
@@ -252,6 +251,7 @@
 
                         <TabItem x:Name="publishTab"
                                  Header="{x:Static p:Resources.PackageManagerPublishTab}"
+                                 local:PackageManagerTabControl.SuppressHomeEndWhenSelected="{Binding IsNewPMPublishWizardEnabled, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"
                                  PreviewMouseDown="tab_PreviewMouseDown"
                                  Style="{StaticResource PackageManagerTab}">
                             <!--  Publish Packages Tab  -->

--- a/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/PackageManager/PackageManagerView.xaml.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Threading;
 using Dynamo.Controls;
 using Dynamo.Logging;
 using Dynamo.Models;
@@ -70,8 +69,6 @@ namespace Dynamo.PackageManager.UI
             this.PackageManagerViewModel = packageManagerViewModel;
 
             InitializeComponent();
-            UpdatePublishTabKeyNavigation();
-            FocusSelectedTabHeader();
 
             if (packageManagerViewModel != null )
             {
@@ -185,7 +182,7 @@ namespace Dynamo.PackageManager.UI
         /// <param name="tabName">Tab name to navigate to</param>
         internal void Navigate(string tabName)
         {
-            var tabControl = this.projectManagerTabControl;
+            var tabControl = this.packageManagerTabControl;
 
             var preferencesTab = (from TabItem tabItem in tabControl.Items
                                   where tabItem.Header.ToString().Equals(tabName)
@@ -213,39 +210,6 @@ namespace Dynamo.PackageManager.UI
         {
             this.loadingSearchWarningBar.Visibility = Visibility.Collapsed;
             this.loadingMyPackagesWarningBar.Visibility = Visibility.Collapsed;
-        }
-
-        private void ProjectManagerTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            // SelectionChanged is a bubbling event. Ignore selection changes from child controls
-            // inside tab content and only react to actual package manager tab switches.
-            if (!ReferenceEquals(e.OriginalSource, projectManagerTabControl)) return;
-
-            UpdatePublishTabKeyNavigation();
-            FocusSelectedTabHeader();
-        }
-
-        private void UpdatePublishTabKeyNavigation()
-        {
-            if (projectManagerTabControl == null) return;
-            projectManagerTabControl.SuppressHomeEndNavigation = IsNewPMPublishWizardEnabled && publishTab?.IsSelected == true;
-        }
-
-        private void FocusSelectedTabHeader()
-        {
-            if (projectManagerTabControl == null) return;
-
-            Dispatcher.BeginInvoke(new Action(() =>
-            {
-                if (projectManagerTabControl.SelectedItem is TabItem selectedTab)
-                {
-                    selectedTab.Focus();
-                }
-                else
-                {
-                    projectManagerTabControl.Focus();
-                }
-            }), DispatcherPriority.Background);
         }
 
         private void tab_PreviewMouseDown(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
### Purpose

This PR rationalizes the `PackageManagerTabControl` by centralizing keyboard navigation (Home/End, PageUp/PageDown) and tab focus logic within the control itself. It improves code structure, naming consistency, and hardens focus ownership checks, removing related plumbing from `PackageManagerView.xaml.cs`.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Internal refactor to improve keyboard navigation and focus handling for Package Manager tabs. This includes centralizing tab-specific keyboard logic and hardening focus ownership checks.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of

---
<p><a href="https://cursor.com/background-agent?bcId=bc-ab2a6401-c866-4d77-b05d-96a9a4f47138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab2a6401-c866-4d77-b05d-96a9a4f47138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

