### PR TITLE
Watch node removal connections

### DIFF
--- a/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
+++ b/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
@@ -251,6 +251,51 @@ namespace Dynamo.Graph.Connectors
         }
 
         /// <summary>
+        /// Retarget the start port of this connector while preserving the connector instance.
+        /// </summary>
+        /// <param name="newStart">The new start/output port.</param>
+        /// <returns>True if retargeting was successful, false otherwise.</returns>
+        internal bool TryUpdateStartPort(PortModel newStart)
+        {
+            if (newStart == null || End == null || Start == null)
+                return false;
+
+            if (ReferenceEquals(Start, newStart))
+                return false;
+
+            if (newStart.PortType != PortType.Output)
+                return false;
+
+            if (ReferenceEquals(newStart, End) || newStart.Owner == null || End.Owner == null)
+                return false;
+
+            if (ReferenceEquals(newStart.Owner, End.Owner))
+                return false;
+
+            var oldStart = Start;
+            var endPort = End;
+
+            // Keep node input/output lookup tables synchronized with the moved connector.
+            oldStart.Owner.DisconnectOutput(oldStart.Index, endPort.Index, endPort.Owner);
+            endPort.Owner.DisconnectInput(endPort.Index);
+
+            oldStart.Connectors.Remove(this);
+            Start = newStart;
+            if (!newStart.Connectors.Contains(this))
+            {
+                newStart.Connectors.Add(this);
+            }
+
+            endPort.Owner.ConnectInput(endPort.Index, newStart.Index, newStart.Owner);
+            newStart.Owner.ConnectOutput(newStart.Index, endPort.Index, endPort.Owner);
+
+            RaisePropertyChanged(nameof(Start));
+            endPort.Owner.OnNodeModified();
+
+            return true;
+        }
+
+        /// <summary>
         /// Delete the connector without raising port disconnection events.
         /// </summary>
         internal void Delete()

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -17,6 +17,8 @@ namespace Dynamo.Graph.Workspaces
 {
     public partial class WorkspaceModel
     {
+        private const string WatchNodeTypeName = "CoreNodeModels.Watch";
+
         /// <summary>
         /// Returns the current UndoRedoRecorder that is associated with the current
         /// WorkspaceModel. Note that external parties should not have the needs
@@ -203,6 +205,9 @@ namespace Dynamo.Graph.Workspaces
             if (!ShouldProceedWithRecording(models))
                 return; // There's nothing for deletion.
 
+            var nodesScheduledForDeletion = new HashSet<Guid>(
+                models.OfType<NodeModel>().Select(node => node.GUID));
+
             // Gather a list of connectors first before the nodes they connect
             // to are deleted. We will have to delete the connectors first
             // before
@@ -256,6 +261,10 @@ namespace Dynamo.Graph.Workspaces
                         bool silentFlag = node.RaisesModificationEvents;
                         node.RaisesModificationEvents = false;
 
+                        // Removing an inline Watch node should preserve existing
+                        // downstream connectors by retargeting their start ports.
+                        TryReconnectInlineWatchNode(node, nodesScheduledForDeletion);
+
                         // Note that AllConnectors is duplicated as a separate list
                         // by calling its "ToList" method. This is the because the
                         // "Connectors.Remove" will modify "AllConnectors", causing
@@ -308,6 +317,54 @@ namespace Dynamo.Graph.Workspaces
                     }
                 }
             } // Conclude the deletion.
+        }
+
+        private bool TryReconnectInlineWatchNode(NodeModel node, ISet<Guid> nodesScheduledForDeletion)
+        {
+            if (!IsInlineWatchNode(node))
+                return false;
+
+            var inputPort = node.InPorts[0];
+            var outputPort = node.OutPorts[0];
+            if (inputPort.Connectors.Count != 1 || outputPort.Connectors.Count == 0)
+                return false;
+
+            var incomingConnector = inputPort.Connectors[0];
+            var upstreamPort = incomingConnector.Start;
+            if (upstreamPort == null || upstreamPort.Owner == null)
+                return false;
+
+            if (nodesScheduledForDeletion.Contains(upstreamPort.Owner.GUID))
+                return false;
+
+            var reconnectedAnyConnector = false;
+            foreach (var downstreamConnector in outputPort.Connectors.ToList())
+            {
+                var endOwner = downstreamConnector.End?.Owner;
+                if (endOwner == null || nodesScheduledForDeletion.Contains(endOwner.GUID))
+                    continue;
+
+                undoRecorder.RecordModificationForUndo(downstreamConnector);
+                if (downstreamConnector.TryUpdateStartPort(upstreamPort))
+                {
+                    reconnectedAnyConnector = true;
+                }
+            }
+
+            if (reconnectedAnyConnector && workspaceLoaded)
+            {
+                upstreamPort.Owner.ComputeUpstreamOnDownstreamNodes();
+            }
+
+            return reconnectedAnyConnector;
+        }
+
+        private static bool IsInlineWatchNode(NodeModel node)
+        {
+            return node != null &&
+                   node.InPorts.Count == 1 &&
+                   node.OutPorts.Count == 1 &&
+                   string.Equals(node.GetType().FullName, WatchNodeTypeName, StringComparison.Ordinal);
         }
 
         internal void DeleteSavedModels()
@@ -457,7 +514,32 @@ namespace Dynamo.Graph.Workspaces
             ModelBase model = GetModelForElement(modelData);
             if (model != null)
             {
+                if (model is ConnectorModel connectorModel)
+                {
+                    UpdateConnectorStartFromXml(connectorModel, modelData);
+                }
+
                 model.Deserialize(modelData, SaveContext.Undo);
+            }
+        }
+
+        private void UpdateConnectorStartFromXml(ConnectorModel connectorModel, XmlElement modelData)
+        {
+            var helper = new XmlElementHelper(modelData);
+            var startNodeGuid = helper.ReadGuid("start", Guid.Empty);
+            var startPortIndex = helper.ReadInteger("start_index", -1);
+
+            if (startNodeGuid == Guid.Empty || startPortIndex < 0)
+                return;
+
+            var startNode = Nodes.FirstOrDefault(node => node.GUID == startNodeGuid);
+            if (startNode == null || startPortIndex >= startNode.OutPorts.Count)
+                return;
+
+            var startPort = startNode.OutPorts[startPortIndex];
+            if (!ReferenceEquals(connectorModel.Start, startPort))
+            {
+                connectorModel.TryUpdateStartPort(startPort);
             }
         }
 

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -207,12 +207,15 @@ namespace Dynamo.Graph.Workspaces
 
             var nodesScheduledForDeletion = new HashSet<Guid>(
                 models.OfType<NodeModel>().Select(node => node.GUID));
+            // Deleting inline watch nodes can preserve data flow (rewire pass-through connectors),
+            // so we can defer execution until the next explicit graph run.
+            var requestRunOnDispose = !ShouldSuppressRunAfterDelete(models);
 
             // Gather a list of connectors first before the nodes they connect
             // to are deleted. We will have to delete the connectors first
             // before
 
-            using (BeginDelayedGraphExecution())// Delayed execution
+            using (BeginDelayedGraphExecution(requestRunOnDispose))// Delayed execution
             using (undoRecorder.BeginActionGroup()) // Start a new action group.
             {
                 foreach (var model in models)
@@ -357,6 +360,30 @@ namespace Dynamo.Graph.Workspaces
             }
 
             return reconnectedAnyConnector;
+        }
+
+        private bool ShouldSuppressRunAfterDelete(IEnumerable<ModelBase> models)
+        {
+            var deletedModels = models.ToList();
+            var deletedNodes = deletedModels.OfType<NodeModel>().ToList();
+            if (!deletedNodes.Any())
+            {
+                return false;
+            }
+
+            if (deletedNodes.Any(node => !IsInlineWatchNode(node)))
+            {
+                return false;
+            }
+
+            // If connectors/pins are explicitly in the deletion set, keep existing
+            // run behavior because the deletion may include non-watch graph edits.
+            if (deletedModels.Any(model => model is ConnectorModel || model is ConnectorPinModel))
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private static bool IsInlineWatchNode(NodeModel node)

--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -216,17 +216,22 @@ namespace Dynamo.Graph.Workspaces
         internal class DelayedGraphExecution : IDisposable
         {
             private readonly WorkspaceModel workspace;
+            private readonly bool requestRunOnDispose;
 
-            public DelayedGraphExecution(WorkspaceModel wModel)
+            public DelayedGraphExecution(WorkspaceModel wModel, bool requestRunOnDispose = true)
             {
                 workspace = wModel;
+                this.requestRunOnDispose = requestRunOnDispose;
                 Interlocked.Increment(ref workspace.delayGraphExecutionCounter);
             }
 
             public virtual void Dispose()
             {
                 Interlocked.Decrement(ref workspace.delayGraphExecutionCounter);
-                workspace.RequestRun();
+                if (requestRunOnDispose)
+                {
+                    workspace.RequestRun();
+                }
             }
         }
         #endregion
@@ -2776,9 +2781,9 @@ namespace Dynamo.Graph.Workspaces
         /// <summary>
         ///     Returns a DelayedGraphExecution object.
         /// </summary>
-        internal DelayedGraphExecution BeginDelayedGraphExecution()
+        internal DelayedGraphExecution BeginDelayedGraphExecution(bool requestRunOnDispose = true)
         {
-            return new DelayedGraphExecution(this);
+            return new DelayedGraphExecution(this, requestRunOnDispose);
         }
     }
 }

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -35,6 +35,10 @@ namespace Dynamo.ViewModels
         private readonly WorkspaceViewModel workspaceViewModel;
         private PortModel activeStartPort;
         private ConnectorModel model;
+        private PortModel subscribedStartPort;
+        private PortModel subscribedEndPort;
+        private NodeViewModel subscribedStartNodeViewModel;
+        private NodeViewModel subscribedEndNodeViewModel;
         private bool isConnecting = false;
         private bool isCollapsed = false;
         private bool isHidden = false;
@@ -1041,22 +1045,10 @@ namespace Dynamo.ViewModels
                 }
             }
 
-            connectorModel.Start.PropertyChanged += StartPortModel_PropertyChanged;
-            connectorModel.End.PropertyChanged += EndPortModel_PropertyChanged;
-
-            connectorModel.Start.Owner.PropertyChanged += StartOwner_PropertyChanged;
-            connectorModel.End.Owner.PropertyChanged += EndOwner_PropertyChanged;
+            UpdatePortSubscriptions(connectorModel.Start, connectorModel.End);
 
             workspaceViewModel.DynamoViewModel.PropertyChanged += DynamoViewModel_PropertyChanged;
-            if (Nodevm != null)
-            {
-                Nodevm.PropertyChanged += nodeViewModel_PropertyChanged;
-            }
-
-            if (NodeEnd != null)
-            {
-                NodeEnd.PropertyChanged += nodeEndViewModel_PropertyChanged;
-            }
+            UpdateNodeViewModelSubscriptions();
             
             UpdateDynamicStrokeThickness();
             Redraw();
@@ -1078,8 +1070,82 @@ namespace Dynamo.ViewModels
                     }
                     IsHidden = connector.IsHidden;
                     break;
+                case nameof(ConnectorModel.Start):
+                case nameof(ConnectorModel.End):
+                    UpdatePortSubscriptions(model.Start, model.End);
+                    UpdateNodeViewModelSubscriptions();
+                    RaisePropertyChanged(nameof(Nodevm));
+                    RaisePropertyChanged(nameof(NodeEnd));
+                    RaisePropertyChanged(nameof(PreviewState));
+                    UpdateConnectorDataToolTip();
+                    Redraw();
+                    break;
                 default:
                     break;
+            }
+        }
+
+        private void UpdatePortSubscriptions(PortModel newStartPort, PortModel newEndPort)
+        {
+            if (subscribedStartPort != null)
+            {
+                subscribedStartPort.PropertyChanged -= StartPortModel_PropertyChanged;
+                subscribedStartPort.Owner.PropertyChanged -= StartOwner_PropertyChanged;
+            }
+
+            if (subscribedEndPort != null)
+            {
+                subscribedEndPort.PropertyChanged -= EndPortModel_PropertyChanged;
+                subscribedEndPort.Owner.PropertyChanged -= EndOwner_PropertyChanged;
+            }
+
+            subscribedStartPort = newStartPort;
+            subscribedEndPort = newEndPort;
+
+            if (subscribedStartPort != null)
+            {
+                subscribedStartPort.PropertyChanged += StartPortModel_PropertyChanged;
+                subscribedStartPort.Owner.PropertyChanged += StartOwner_PropertyChanged;
+            }
+
+            if (subscribedEndPort != null)
+            {
+                subscribedEndPort.PropertyChanged += EndPortModel_PropertyChanged;
+                subscribedEndPort.Owner.PropertyChanged += EndOwner_PropertyChanged;
+            }
+        }
+
+        private void UpdateNodeViewModelSubscriptions(bool subscribeToCurrentNodes = true)
+        {
+            if (subscribedStartNodeViewModel != null)
+            {
+                subscribedStartNodeViewModel.PropertyChanged -= nodeViewModel_PropertyChanged;
+            }
+
+            if (subscribedEndNodeViewModel != null)
+            {
+                subscribedEndNodeViewModel.PropertyChanged -= nodeEndViewModel_PropertyChanged;
+            }
+
+            subscribedStartNodeViewModel = null;
+            subscribedEndNodeViewModel = null;
+
+            if (!subscribeToCurrentNodes)
+            {
+                return;
+            }
+
+            subscribedStartNodeViewModel = Nodevm;
+            subscribedEndNodeViewModel = NodeEnd;
+
+            if (subscribedStartNodeViewModel != null)
+            {
+                subscribedStartNodeViewModel.PropertyChanged += nodeViewModel_PropertyChanged;
+            }
+
+            if (subscribedEndNodeViewModel != null)
+            {
+                subscribedEndNodeViewModel.PropertyChanged += nodeEndViewModel_PropertyChanged;
             }
         }
         private void ConnectorPinModelCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -1222,22 +1288,10 @@ namespace Dynamo.ViewModels
             {
                 model.PropertyChanged -= HandleConnectorPropertyChanged;
 
-                model.Start.PropertyChanged -= StartPortModel_PropertyChanged;
-                model.End.PropertyChanged -= EndPortModel_PropertyChanged;
-
-                model.Start.Owner.PropertyChanged -= StartOwner_PropertyChanged;
-                model.End.Owner.PropertyChanged -= EndOwner_PropertyChanged;
+                UpdatePortSubscriptions(null, null);
                 model.ConnectorPinModels.CollectionChanged -= ConnectorPinModelCollectionChanged;
 
-                // Nodevm and NodeEnd props are found via model
-                if (Nodevm != null)
-                {
-                    Nodevm.PropertyChanged -= nodeViewModel_PropertyChanged;
-                }
-                if (NodeEnd != null)
-                {
-                    NodeEnd.PropertyChanged -= nodeEndViewModel_PropertyChanged;
-                }
+                UpdateNodeViewModelSubscriptions(false);
             }
 
             workspaceViewModel.PropertyChanged -= WorkspaceViewModel_PropertyChanged;

--- a/test/DynamoCoreTests/Models/WatchNodeDeletionTests.cs
+++ b/test/DynamoCoreTests/Models/WatchNodeDeletionTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CoreNodeModels;
+using Dynamo.Graph;
+using Dynamo.Graph.Connectors;
+using Dynamo.Graph.Nodes;
+using NUnit.Framework;
+using DynCmd = Dynamo.Models.DynamoModel;
+
+namespace Dynamo.Tests.ModelsTest
+{
+    [TestFixture]
+    class WatchNodeDeletionTests : DynamoModelTestBase
+    {
+        protected override void GetLibrariesToPreload(List<string> libraries)
+        {
+            libraries.Add("ProtoGeometry.dll");
+            libraries.Add("DesignScriptBuiltin.dll");
+            libraries.Add("DSCoreNodes.dll");
+
+            base.GetLibrariesToPreload(libraries);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void DeleteInlineWatchNodeKeepsDownstreamConnections()
+        {
+            var graph = CreateInlineWatchGraph();
+
+            var preservedConnectorGuids = new HashSet<Guid>
+            {
+                graph.DownstreamConnectorA.GUID,
+                graph.DownstreamConnectorB.GUID
+            };
+
+            CurrentDynamoModel.DeleteModelInternal(new List<ModelBase> { graph.WatchNode });
+
+            var workspace = CurrentDynamoModel.CurrentWorkspace;
+            Assert.IsNull(workspace.Nodes.FirstOrDefault(node => node.GUID == graph.WatchNode.GUID));
+
+            var remainingConnectors = workspace.Connectors.ToList();
+            Assert.AreEqual(2, remainingConnectors.Count);
+
+            Assert.IsTrue(remainingConnectors.All(connector => connector.Start.Owner.GUID == graph.UpstreamNode.GUID));
+            Assert.IsTrue(remainingConnectors.Any(connector => connector.End.Owner.GUID == graph.DownstreamNodeA.GUID));
+            Assert.IsTrue(remainingConnectors.Any(connector => connector.End.Owner.GUID == graph.DownstreamNodeB.GUID));
+            CollectionAssert.AreEquivalent(
+                preservedConnectorGuids,
+                remainingConnectors.Select(connector => connector.GUID).ToList());
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void DeleteInlineWatchNodeUndoRedoRestoresAndReappliesRewiring()
+        {
+            var graph = CreateInlineWatchGraph();
+
+            CurrentDynamoModel.DeleteModelInternal(new List<ModelBase> { graph.WatchNode });
+
+            var workspace = CurrentDynamoModel.CurrentWorkspace;
+            Assert.AreEqual(2, workspace.Connectors.Count());
+
+            workspace.Undo();
+
+            var watchAfterUndo = workspace.Nodes.FirstOrDefault(node => node.GUID == graph.WatchNode.GUID);
+            Assert.IsNotNull(watchAfterUndo);
+            Assert.AreEqual(3, workspace.Connectors.Count());
+
+            var connectorsAfterUndo = workspace.Connectors.ToList();
+            Assert.IsTrue(connectorsAfterUndo.Any(connector =>
+                connector.Start.Owner.GUID == graph.UpstreamNode.GUID &&
+                connector.End.Owner.GUID == graph.WatchNode.GUID));
+
+            Assert.IsTrue(connectorsAfterUndo.Any(connector =>
+                connector.GUID == graph.DownstreamConnectorA.GUID &&
+                connector.Start.Owner.GUID == graph.WatchNode.GUID &&
+                connector.End.Owner.GUID == graph.DownstreamNodeA.GUID));
+
+            Assert.IsTrue(connectorsAfterUndo.Any(connector =>
+                connector.GUID == graph.DownstreamConnectorB.GUID &&
+                connector.Start.Owner.GUID == graph.WatchNode.GUID &&
+                connector.End.Owner.GUID == graph.DownstreamNodeB.GUID));
+
+            workspace.Redo();
+
+            var connectorsAfterRedo = workspace.Connectors.ToList();
+            Assert.IsNull(workspace.Nodes.FirstOrDefault(node => node.GUID == graph.WatchNode.GUID));
+            Assert.AreEqual(2, connectorsAfterRedo.Count);
+
+            Assert.IsTrue(connectorsAfterRedo.Any(connector =>
+                connector.GUID == graph.DownstreamConnectorA.GUID &&
+                connector.Start.Owner.GUID == graph.UpstreamNode.GUID &&
+                connector.End.Owner.GUID == graph.DownstreamNodeA.GUID));
+
+            Assert.IsTrue(connectorsAfterRedo.Any(connector =>
+                connector.GUID == graph.DownstreamConnectorB.GUID &&
+                connector.Start.Owner.GUID == graph.UpstreamNode.GUID &&
+                connector.End.Owner.GUID == graph.DownstreamNodeB.GUID));
+        }
+
+        private (NodeModel UpstreamNode, NodeModel DownstreamNodeA, NodeModel DownstreamNodeB, Watch WatchNode, ConnectorModel DownstreamConnectorA, ConnectorModel DownstreamConnectorB)
+            CreateInlineWatchGraph()
+        {
+            var upstreamNode = CreateCodeBlockNode();
+            UpdateCodeBlockNodeContent(upstreamNode, "1;");
+
+            var downstreamNodeA = CreateCodeBlockNode();
+            UpdateCodeBlockNodeContent(downstreamNodeA, "x;");
+
+            var downstreamNodeB = CreateCodeBlockNode();
+            UpdateCodeBlockNodeContent(downstreamNodeB, "y;");
+
+            var watchNode = new Watch();
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.CreateNodeCommand(watchNode, 0, 0, true, false));
+
+            var upstreamToWatch = ConnectorModel.Make(upstreamNode, watchNode, 0, 0);
+            var downstreamConnectorA = ConnectorModel.Make(watchNode, downstreamNodeA, 0, 0);
+            var downstreamConnectorB = ConnectorModel.Make(watchNode, downstreamNodeB, 0, 0);
+
+            Assert.IsNotNull(upstreamToWatch);
+            Assert.IsNotNull(downstreamConnectorA);
+            Assert.IsNotNull(downstreamConnectorB);
+
+            return (upstreamNode, downstreamNodeA, downstreamNodeB, watchNode, downstreamConnectorA, downstreamConnectorB);
+        }
+    }
+}

--- a/test/DynamoCoreTests/Models/WatchNodeDeletionTests.cs
+++ b/test/DynamoCoreTests/Models/WatchNodeDeletionTests.cs
@@ -5,6 +5,8 @@ using CoreNodeModels;
 using Dynamo.Graph;
 using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Workspaces;
+using Dynamo.Models;
 using NUnit.Framework;
 using DynCmd = Dynamo.Models.DynamoModel;
 
@@ -99,6 +101,42 @@ namespace Dynamo.Tests.ModelsTest
                 connector.End.Owner.GUID == graph.DownstreamNodeB.GUID));
         }
 
+        [Test]
+        [Category("UnitTests")]
+        public void DeleteWatchNodeWithoutDownstreamConnectionsDoesNotTriggerAutoRun()
+        {
+            var workspace = GetHomeWorkspace();
+            workspace.RunSettings.RunType = RunType.Manual;
+
+            var graph = CreateWatchSinkGraphWithoutDownstream();
+
+            workspace.RunSettings.RunType = RunType.Automatic;
+            var evaluationCountBeforeDelete = workspace.EvaluationCount;
+
+            CurrentDynamoModel.DeleteModelInternal(new List<ModelBase> { graph.WatchNode });
+
+            Assert.AreEqual(evaluationCountBeforeDelete, workspace.EvaluationCount);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void DeleteWatchNodeWithRewiredDownstreamConnectionsDoesNotTriggerAutoRun()
+        {
+            var workspace = GetHomeWorkspace();
+            workspace.RunSettings.RunType = RunType.Manual;
+
+            var graph = CreateInlineWatchGraph();
+
+            workspace.RunSettings.RunType = RunType.Automatic;
+            var evaluationCountBeforeDelete = workspace.EvaluationCount;
+
+            CurrentDynamoModel.DeleteModelInternal(new List<ModelBase> { graph.WatchNode });
+
+            Assert.AreEqual(evaluationCountBeforeDelete, workspace.EvaluationCount);
+            Assert.IsTrue(graph.DownstreamNodeA.IsModified);
+            Assert.IsTrue(graph.DownstreamNodeB.IsModified);
+        }
+
         private (NodeModel UpstreamNode, NodeModel DownstreamNodeA, NodeModel DownstreamNodeB, Watch WatchNode, ConnectorModel DownstreamConnectorA, ConnectorModel DownstreamConnectorB)
             CreateInlineWatchGraph()
         {
@@ -123,6 +161,27 @@ namespace Dynamo.Tests.ModelsTest
             Assert.IsNotNull(downstreamConnectorB);
 
             return (upstreamNode, downstreamNodeA, downstreamNodeB, watchNode, downstreamConnectorA, downstreamConnectorB);
+        }
+
+        private (NodeModel UpstreamNode, Watch WatchNode) CreateWatchSinkGraphWithoutDownstream()
+        {
+            var upstreamNode = CreateCodeBlockNode();
+            UpdateCodeBlockNodeContent(upstreamNode, "1;");
+
+            var watchNode = new Watch();
+            CurrentDynamoModel.ExecuteCommand(new DynCmd.CreateNodeCommand(watchNode, 0, 0, true, false));
+
+            var upstreamToWatch = ConnectorModel.Make(upstreamNode, watchNode, 0, 0);
+            Assert.IsNotNull(upstreamToWatch);
+
+            return (upstreamNode, watchNode);
+        }
+
+        private HomeWorkspaceModel GetHomeWorkspace()
+        {
+            var homeWorkspace = CurrentDynamoModel.CurrentWorkspace as HomeWorkspaceModel;
+            Assert.IsNotNull(homeWorkspace);
+            return homeWorkspace;
         }
     }
 }


### PR DESCRIPTION
### Purpose

This PR addresses the issue where deleting an inline Watch node (a Watch node with one input and one output) currently breaks its downstream connections. It implements a mechanism to automatically rewire downstream connectors to the Watch node's upstream source when the Watch node is deleted. This is achieved efficiently by retargeting existing connector endpoints rather than deleting and recreating them, preserving connector identity and minimizing performance overhead, especially for graphs with many downstream connections.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Deleting an inline Watch node (a Watch node with one input and one output) will now automatically rewire its downstream connections to the upstream node, preserving graph connectivity.

### Reviewers

(FILL ME IN)

### FYIs

This change optimizes performance for Watch node deletion by retargeting existing connectors, avoiding the overhead of creating new ones, which is more efficient for large graphs.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-264db5d9-ca0a-4ef8-b15a-31ea836b08c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-264db5d9-ca0a-4ef8-b15a-31ea836b08c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

