### PR TITLE
SonarCube issue review

### DIFF
--- a/src/DynamoCore/Graph/Nodes/NodeModel.cs
+++ b/src/DynamoCore/Graph/Nodes/NodeModel.cs
@@ -2770,6 +2770,15 @@ namespace Dynamo.Graph.Nodes
         }
 
         /// <summary>
+        /// Restores node-specific cached value state from runtime data.
+        /// The base implementation is a no-op and specialized nodes can override.
+        /// </summary>
+        /// <param name="data">Runtime data used to restore node cache state.</param>
+        internal virtual void RestoreCachedValueFromEngine(object data)
+        {
+        }
+
+        /// <summary>
         /// Call this method to asynchronously regenerate render package for
         /// this node. This method accesses core properties of a NodeModel and
         /// therefore is typically called on the main/UI thread.

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -12,14 +12,12 @@ using Dynamo.Graph.Nodes.NodeLoaders;
 using Dynamo.Graph.Notes;
 using Dynamo.Graph.Presets;
 using Dynamo.Utilities;
-using System.Reflection;
 
 namespace Dynamo.Graph.Workspaces
 {
     public partial class WorkspaceModel
     {
         private const string WatchNodeTypeName = "CoreNodeModels.Watch";
-        private const string WatchEvaluationCompleteMethodName = "OnEvaluationComplete";
 
         /// <summary>
         /// Returns the current UndoRedoRecorder that is associated with the current
@@ -747,20 +745,16 @@ namespace Dynamo.Graph.Workspaces
         {
             if (nodeModel == null || nodeModel.OutPorts.Count == 0) return;
 
+            if (!string.Equals(nodeModel.GetType().FullName, WatchNodeTypeName, StringComparison.Ordinal))
+            {
+                return;
+            }
+
             var engineController = (this as HomeWorkspaceModel)?.EngineController;
             if (engineController == null) return;
 
-            // Watch nodes expose their UI cache through a private callback method.
             // If execution was intentionally skipped, pull the current mirror value
-            // and invoke that callback so the restored node regains its displayed data.
-            var onEvaluationComplete = nodeModel.GetType().GetMethod(
-                WatchEvaluationCompleteMethodName,
-                BindingFlags.Instance | BindingFlags.NonPublic,
-                null,
-                new[] { typeof(object) },
-                null);
-
-            if (onEvaluationComplete == null) return;
+            // and restore the watch-specific cache so the node regains its displayed data.
 
             var outputIdentifier = nodeModel.GetAstIdentifierForOutputIndex(0)?.Value;
             if (string.IsNullOrEmpty(outputIdentifier)) return;
@@ -770,13 +764,7 @@ namespace Dynamo.Graph.Workspaces
 
             try
             {
-                onEvaluationComplete.Invoke(nodeModel, new object[] { mirrorData.Data });
-            }
-            catch (TargetInvocationException ex)
-            {
-                this.Log(
-                    $"Failed restoring watch cache for node '{nodeModel.GUID}': {ex.InnerException?.Message ?? ex.Message}",
-                    Logging.WarningLevel.Moderate);
+                nodeModel.RestoreCachedValueFromEngine(mirrorData.Data);
             }
             catch (Exception ex)
             {

--- a/src/Libraries/CoreNodeModels/Watch.cs
+++ b/src/Libraries/CoreNodeModels/Watch.cs
@@ -95,6 +95,11 @@ namespace CoreNodeModels
             }
         }
 
+        internal override void RestoreCachedValueFromEngine(object data)
+        {
+            OnEvaluationComplete(data);
+        }
+
         public override IEnumerable<AssociativeNode> BuildOutputAst(
             List<AssociativeNode> inputAstNodes)
         {


### PR DESCRIPTION
### Purpose

This PR addresses a SonarCube S3011 warning by refactoring how `UndoRedo` restores cached values for `Watch` nodes. Previously, `UndoRedo` used reflection with `BindingFlags.NonPublic` to call the private `OnEvaluationComplete` method on `Watch` nodes. This change replaces the reflection call with a new `internal virtual` method on `NodeModel` that `Watch` nodes override, improving code safety and maintainability.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
  *(Note: An internal virtual method was added to `NodeModel`, which is not a public API change.)*

### Release Notes

N/A

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

---
<p><a href="https://cursor.com/background-agent?bcId=bc-b7455bb1-d236-43b8-bf40-2e9199a1536b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b7455bb1-d236-43b8-bf40-2e9199a1536b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

