### PR TITLE
Connector pin persistence

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -43,6 +43,7 @@ namespace Dynamo.Models
 
         private PortModel[] activeStartPorts;
         private PortModel firstStartPort;
+        private List<List<ConnectorPinModel>> activeConnectorPins;
 
         protected virtual void OpenFileImpl(OpenFileCommand command)
         {
@@ -373,6 +374,7 @@ namespace Dynamo.Models
         {
             bool isInPort = portType == PortType.Input;
             activeStartPorts = null;
+            activeConnectorPins = null;
 
             if (CurrentWorkspace.GetModelInternal(nodeId) is not NodeModel node)
                 return;
@@ -384,12 +386,17 @@ namespace Dynamo.Models
                 // to somewhere else (we don't allow the grabbing of the start connector).
                 if (portModel.Connectors.Count > 0 && portModel.Connectors[0].Start != portModel)
                 {
-                    activeStartPorts = new PortModel[] { portModel.Connectors[0].Start };
-                    firstStartPort = portModel.Connectors[0].Start;
+                    ConnectorModel connector = portModel.Connectors[0];
+                    activeStartPorts = new PortModel[] { connector.Start };
+                    firstStartPort = connector.Start;
+                    activeConnectorPins = new List<List<ConnectorPinModel>>
+                    {
+                        CloneConnectorPins(connector.ConnectorPinModels)
+                    };
+
                     // Disconnect the connector model from its start and end ports
                     // and remove it from the connectors collection. This will also
                     // remove the view model.
-                    ConnectorModel connector = portModel.Connectors[0];
                     if (CurrentWorkspace.Connectors.Contains(connector))
                     {
                         var models = new List<ModelBase> { connector };
@@ -411,6 +418,8 @@ namespace Dynamo.Models
 
         private void BeginDuplicateConnection(Guid nodeId, int portIndex, PortType portType)
         {
+            activeConnectorPins = null;
+
             // If the port clicked is an output port, begin connection as per normal
             if (portType == PortType.Output)
             {
@@ -457,11 +466,13 @@ namespace Dynamo.Models
             if (numOfConnectors == 0) return;
             
             activeStartPorts = new PortModel[numOfConnectors];
+            activeConnectorPins = new List<List<ConnectorPinModel>>(numOfConnectors);
 
             for (int i = 0; i < numOfConnectors; i++)
             {
                 ConnectorModel connector = selectedConnectors[i];
                 activeStartPorts[i] = connector.End;
+                activeConnectorPins.Add(CloneConnectorPins(connector.ConnectorPinModels));
             }
             CurrentWorkspace.SaveAndDeleteModels(selectedConnectors.ToList<ModelBase>());
             return;
@@ -481,11 +492,13 @@ namespace Dynamo.Models
             
             PortModel portModel = isInPort ? node.InPorts[portIndex] : node.OutPorts[portIndex];
 
-            var models = GetConnectorsToAddAndDelete(portModel, activeStartPorts[0]);
+            var connectorPins = activeConnectorPins?.FirstOrDefault();
+            var models = GetConnectorsToAddAndDelete(portModel, activeStartPorts[0], connectorPins);
 
             WorkspaceModel.RecordModelsForUndo(models, CurrentWorkspace.UndoRecorder);
             activeStartPorts = null;
             firstStartPort = null;
+            activeConnectorPins = null;
         }
 
         private void EndShiftReconnections(Guid nodeId, int portIndex, PortType portType)
@@ -496,10 +509,18 @@ namespace Dynamo.Models
             if (!(CurrentWorkspace.GetModelInternal(nodeId) is NodeModel node)) return;
             PortModel selectedPort = node.OutPorts[portIndex];
             
-            var firstModel = GetConnectorsToAddAndDelete(selectedPort, activeStartPorts[0]);
+            var firstModel = GetConnectorsToAddAndDelete(
+                selectedPort,
+                activeStartPorts[0],
+                activeConnectorPins?.ElementAtOrDefault(0));
+
             for (int i = 1; i < activeStartPorts.Count(); i++)
             {
-                var models = GetConnectorsToAddAndDelete(selectedPort, activeStartPorts[i]);
+                var models = GetConnectorsToAddAndDelete(
+                    selectedPort,
+                    activeStartPorts[i],
+                    activeConnectorPins?.ElementAtOrDefault(i));
+
                 foreach (var m in models)
                 {
                     firstModel.Add(m.Key, m.Value);
@@ -507,6 +528,7 @@ namespace Dynamo.Models
             }
             WorkspaceModel.RecordModelsForUndo(firstModel, CurrentWorkspace.UndoRecorder);
             activeStartPorts = null;
+            activeConnectorPins = null;
             return;
         }
 
@@ -517,10 +539,15 @@ namespace Dynamo.Models
             if (!(CurrentWorkspace.GetModelInternal(nodeId) is NodeModel node)) return;
 
             PortModel portModel = node.InPorts[portIndex];
-            var models = GetConnectorsToAddAndDelete(portModel, activeStartPorts[0]);
+            var models = GetConnectorsToAddAndDelete(
+                portModel,
+                activeStartPorts[0],
+                activeConnectorPins?.FirstOrDefault());
+
             WorkspaceModel.RecordModelsForUndo(models, CurrentWorkspace.UndoRecorder);
             
             activeStartPorts = new PortModel[] { firstStartPort };
+            activeConnectorPins = null;
         }
 
         private void CancelConnections()
@@ -528,18 +555,41 @@ namespace Dynamo.Models
             CurrentWorkspace.DeleteSavedModels();
             activeStartPorts = null;
             firstStartPort = null;
+            activeConnectorPins = null;
             return;
         }
 
+        private static List<ConnectorPinModel> CloneConnectorPins(IEnumerable<ConnectorPinModel> connectorPins)
+        {
+            if (connectorPins is null)
+            {
+                return new List<ConnectorPinModel>();
+            }
+
+            return connectorPins
+                .Select(pin => new ConnectorPinModel(pin.X, pin.Y, Guid.NewGuid(), Guid.Empty))
+                .ToList();
+        }
+
         private static Dictionary<ModelBase, UndoRedoRecorder.UserAction> GetConnectorsToAddAndDelete(
-            PortModel endPort, PortModel startPort)
+            PortModel endPort,
+            PortModel startPort,
+            IEnumerable<ConnectorPinModel> connectorPins = null)
         {
             ConnectorModel connectorToRemove = null;
+            var models = new Dictionary<ModelBase, UndoRedoRecorder.UserAction>();
 
             // Remove connector if one already exists
             if (endPort.Connectors.Count > 0 && endPort.PortType == PortType.Input)
             {
                 connectorToRemove = endPort.Connectors[0];
+
+                foreach (var existingPin in connectorToRemove.ConnectorPinModels.ToList())
+                {
+                    connectorToRemove.RemovePin(existingPin);
+                    models.Add(existingPin, UndoRedoRecorder.UserAction.Deletion);
+                }
+
                 connectorToRemove.Delete();
             }
 
@@ -565,7 +615,6 @@ namespace Dynamo.Models
                 secondPort.Index);
 
             // Record the creation of connector in the undo recorder.
-            var models = new Dictionary<ModelBase, UndoRedoRecorder.UserAction>();
             if (connectorToRemove != null)
             {
                 models.Add(connectorToRemove, UndoRedoRecorder.UserAction.Deletion);
@@ -573,6 +622,21 @@ namespace Dynamo.Models
             if (newConnectorModel != null)
             {
                 models.Add(newConnectorModel, UndoRedoRecorder.UserAction.Creation);
+
+                if (connectorPins != null)
+                {
+                    foreach (var connectorPin in connectorPins)
+                    {
+                        var persistedPin = new ConnectorPinModel(
+                            connectorPin.X,
+                            connectorPin.Y,
+                            Guid.NewGuid(),
+                            newConnectorModel.GUID);
+
+                        newConnectorModel.AddPin(persistedPin);
+                        models.Add(persistedPin, UndoRedoRecorder.UserAction.Creation);
+                    }
+                }
             }
             return models;
         }

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1153,6 +1153,34 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Adds non-model-backed pin view models to an in-progress connector so
+        /// pins remain visible while reconnecting an existing wire.
+        /// </summary>
+        /// <param name="connectorPins">Pins from the connector being reconnected.</param>
+        internal void AddTransientConnectorPins(IEnumerable<ConnectorPinModel> connectorPins)
+        {
+            if (connectorPins is null) { return; }
+
+            foreach (var connectorPin in connectorPins)
+            {
+                var transientPinModel = new ConnectorPinModel(
+                    connectorPin.X,
+                    connectorPin.Y,
+                    Guid.NewGuid(),
+                    Guid.Empty);
+
+                var transientPinViewModel = new ConnectorPinViewModel(this.workspaceViewModel, transientPinModel)
+                {
+                    IsCollapsed = this.IsCollapsed,
+                    IsHidden = this.IsHidden,
+                    IsTemporarilyVisible = isTemporarilyVisible
+                };
+
+                ConnectorPinViewCollection.Add(transientPinViewModel);
+            }
+        }
+
+        /// <summary>
         /// Checking to see if any connector pin is selected, if so
         /// global 'AnyPinSelected' is set to true and wire Preview State is set to 'Selected'
         /// </summary>
@@ -1435,14 +1463,18 @@ namespace Dynamo.ViewModels
         /// to all previous pins is required for undo/redo recorder.</param>
         internal void DiscardAllConnectorPinModels(List<ModelBase> allDeletedModels = null)
         {
-            foreach (var pin in ConnectorPinViewCollection)
+            foreach (var pin in ConnectorPinViewCollection.ToList())
             {
                 workspaceViewModel.Pins.Remove(pin);
-                ConnectorModel.RemovePin(pin.Model);
 
-                if(allDeletedModels != null)
+                if (ConnectorModel != null)
                 {
-                    allDeletedModels.Add(pin.Model);
+                    ConnectorModel.RemovePin(pin.Model);
+
+                    if (allDeletedModels != null)
+                    {
+                        allDeletedModels.Add(pin.Model);
+                    }
                 }
                 pin.Model.Dispose();
                 pin.Dispose();

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -200,10 +200,15 @@ namespace Dynamo.ViewModels
             // to somewhere else (we don't allow the grabbing of the start connector).
             if (portModel.Connectors.Count > 0 && portModel.Connectors[0].Start != portModel)
             {
+                var connectorToReconnect = portModel.Connectors[0];
+
                 // Define the new active connector
-                var c = new ConnectorViewModel[] { new ConnectorViewModel(this, portModel.Connectors[0].Start) };
+                var activeConnector = new ConnectorViewModel(this, connectorToReconnect.Start);
+                activeConnector.AddTransientConnectorPins(connectorToReconnect.ConnectorPinModels);
+
+                var c = new ConnectorViewModel[] { activeConnector };
                 this.SetActiveConnectors(c);
-                firstStartPort = portModel.Connectors[0].Start;
+                firstStartPort = connectorToReconnect.Start;
             }
             else
             {
@@ -230,18 +235,20 @@ namespace Dynamo.ViewModels
             if (portModel.Connectors.Count <= 0) return;
 
             // Try to obtain connectors for selected nodes
-            var selected = portModel.Connectors.Where(x => x.End.Owner.IsSelected).Select(y => y.End);
+            var selectedConnectors = portModel.Connectors.Where(x => x.End.Owner.IsSelected).ToList();
 
             // If there are no selected nodes, obtain all the associated connectors
-            if (selected.Count() <= 0)
+            if (selectedConnectors.Count <= 0)
             {
-                selected = portModel.Connectors.Select(y => y.End);
+                selectedConnectors = portModel.Connectors.ToList();
             }
 
-            var connectorsAr = new ConnectorViewModel[selected.Count()];
-            for (int i = 0; i < selected.Count(); i++)
+            var connectorsAr = new ConnectorViewModel[selectedConnectors.Count];
+            for (int i = 0; i < selectedConnectors.Count; i++)
             {
-                var c = new ConnectorViewModel(this, selected.ElementAt(i));
+                var selectedConnector = selectedConnectors[i];
+                var c = new ConnectorViewModel(this, selectedConnector.End);
+                c.AddTransientConnectorPins(selectedConnector.ConnectorPinModels);
                 connectorsAr[i] = c;
             }
 

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -506,15 +506,23 @@ namespace DynamoCoreWpfTests
                 new DynamoModel.MakeConnectionCommand(startNode.GUID, startPortIndex, PortType.Output,
                 MakeConnectionCommand.Mode.BeginShiftReconnections));
 
+            // While moving the wire, pins should stay visible on the transient connector.
+            Assert.IsNotNull(this.ViewModel.CurrentSpaceViewModel.FirstActiveConnector);
+            Assert.AreEqual(
+                initialConnectorPinCount + 1,
+                this.ViewModel.CurrentSpaceViewModel.FirstActiveConnector.ConnectorPinViewCollection.Count);
+
             // Execute the second part of the workflow - simulate placing the connectors over the new port
             this.ViewModel.ExecuteCommand(
                 new DynamoModel.MakeConnectionCommand(codeblock.GUID, 0, PortType.Output,
                 MakeConnectionCommand.Mode.EndShiftReconnections));
 
-            // Validate that the pin does not exists anymore
+            // Validate that the pin persists after reconnection
             var connectorAfterReconnect = this.ViewModel.CurrentSpaceViewModel.Connectors;
             Assert.AreEqual(1, connectorAfterReconnect.Count());
-            Assert.AreEqual(0, connectorAfterReconnect.First().ConnectorPinViewCollection.Count());
+            Assert.AreEqual(
+                initialConnectorPinCount + 1,
+                connectorAfterReconnect.First().ConnectorPinViewCollection.Count());
 
             // --- Undo ---
             Model.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));


### PR DESCRIPTION
### Purpose

This PR addresses the issue where connector pins disappear immediately when a wire is being moved or reconnected. The changes ensure that pins remain visible during the drag operation and persist on the new connector after a successful reconnection, improving the user experience for wire manipulation.

### Declarations

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Connector pins now remain visible while a wire is being dragged and persist on the connector after it has been reconnected to a new port. This improves the visual continuity and user experience when manipulating wires with pins.

### Reviewers

(FILL ME IN)

### FYIs

N/A

---
<p><a href="https://cursor.com/background-agent?bcId=bc-9e86bb16-9f12-435f-82cc-fc6dd67652cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9e86bb16-9f12-435f-82cc-fc6dd67652cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

