### PR TITLE
SonarQube issue resolution

### DIFF
--- a/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
+++ b/src/DynamoCoreWpf/UI/GuidedTour/GuidesManager.cs
@@ -537,8 +537,8 @@ namespace Dynamo.Wpf.UI.GuidedTour
             // Close sidebar extension tabs
             var extensionsToClose = dynamoViewModel.SideBarTabItems
                 .OfType<TabItem>()
-                .Where(t => t.Tag is IViewExtension)
-                .Select(t => (IViewExtension)t.Tag)
+                .Select(t => t.Tag)
+                .OfType<IViewExtension>()
                 .GroupBy(e => e.UniqueId)
                 .Select(g => g.First())
                 .ToList();


### PR DESCRIPTION
### Purpose

This PR addresses a SonarQube S1944 warning by refactoring an explicit cast in `GuidesManager.CloseAllViewExtensions`. The original pattern `Where(t => t.Tag is IViewExtension).Select(t => (IViewExtension)t.Tag)` was flagged as a potential invalid cast, even though logically safe. This change replaces it with a safer `OfType<IViewExtension>()` LINQ pipeline to avoid the explicit cast.

### Declarations

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A (Internal code quality improvement)

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of

---
<p><a href="https://cursor.com/background-agent?bcId=bc-9e1a6a87-ddf6-4bc8-84d2-4fe9fc74ecae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9e1a6a87-ddf6-4bc8-84d2-4fe9fc74ecae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

