### PR TITLE
Connector pin reconnection behavior

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -43,6 +43,7 @@ namespace Dynamo.Models
 
         private PortModel[] activeStartPorts;
         private PortModel firstStartPort;
+        private Dictionary<Guid, List<(double X, double Y)>> reconnectionPinLocationsByStartPortId;
 
         protected virtual void OpenFileImpl(OpenFileCommand command)
         {
@@ -373,6 +374,7 @@ namespace Dynamo.Models
         {
             bool isInPort = portType == PortType.Input;
             activeStartPorts = null;
+            reconnectionPinLocationsByStartPortId = null;
 
             if (CurrentWorkspace.GetModelInternal(nodeId) is not NodeModel node)
                 return;
@@ -384,12 +386,13 @@ namespace Dynamo.Models
                 // to somewhere else (we don't allow the grabbing of the start connector).
                 if (portModel.Connectors.Count > 0 && portModel.Connectors[0].Start != portModel)
                 {
-                    activeStartPorts = new PortModel[] { portModel.Connectors[0].Start };
-                    firstStartPort = portModel.Connectors[0].Start;
+                    ConnectorModel connector = portModel.Connectors[0];
+                    activeStartPorts = new PortModel[] { connector.Start };
+                    firstStartPort = connector.Start;
+                    RecordReconnectionPinLocations(connector.Start, connector);
                     // Disconnect the connector model from its start and end ports
                     // and remove it from the connectors collection. This will also
                     // remove the view model.
-                    ConnectorModel connector = portModel.Connectors[0];
                     if (CurrentWorkspace.Connectors.Contains(connector))
                     {
                         var models = new List<ModelBase> { connector };
@@ -411,6 +414,8 @@ namespace Dynamo.Models
 
         private void BeginDuplicateConnection(Guid nodeId, int portIndex, PortType portType)
         {
+            reconnectionPinLocationsByStartPortId = null;
+
             // If the port clicked is an output port, begin connection as per normal
             if (portType == PortType.Output)
             {
@@ -441,6 +446,7 @@ namespace Dynamo.Models
         {
             if (portType == PortType.Input) return; //only handle multiple connections when the port selected is an output port
             if (!(CurrentWorkspace.GetModelInternal(nodeId) is NodeModel node)) return;
+            reconnectionPinLocationsByStartPortId = null;
 
             PortModel selectedPort = node.OutPorts[portIndex];
 
@@ -462,6 +468,7 @@ namespace Dynamo.Models
             {
                 ConnectorModel connector = selectedConnectors[i];
                 activeStartPorts[i] = connector.End;
+                RecordReconnectionPinLocations(connector.End, connector);
             }
             CurrentWorkspace.SaveAndDeleteModels(selectedConnectors.ToList<ModelBase>());
             return;
@@ -481,11 +488,15 @@ namespace Dynamo.Models
             
             PortModel portModel = isInPort ? node.InPorts[portIndex] : node.OutPorts[portIndex];
 
-            var models = GetConnectorsToAddAndDelete(portModel, activeStartPorts[0]);
+            var models = GetConnectorsToAddAndDelete(
+                portModel,
+                activeStartPorts[0],
+                ConsumeReconnectionPinLocations(activeStartPorts[0]));
 
             WorkspaceModel.RecordModelsForUndo(models, CurrentWorkspace.UndoRecorder);
             activeStartPorts = null;
             firstStartPort = null;
+            reconnectionPinLocationsByStartPortId = null;
         }
 
         private void EndShiftReconnections(Guid nodeId, int portIndex, PortType portType)
@@ -496,10 +507,16 @@ namespace Dynamo.Models
             if (!(CurrentWorkspace.GetModelInternal(nodeId) is NodeModel node)) return;
             PortModel selectedPort = node.OutPorts[portIndex];
             
-            var firstModel = GetConnectorsToAddAndDelete(selectedPort, activeStartPorts[0]);
+            var firstModel = GetConnectorsToAddAndDelete(
+                selectedPort,
+                activeStartPorts[0],
+                ConsumeReconnectionPinLocations(activeStartPorts[0]));
             for (int i = 1; i < activeStartPorts.Count(); i++)
             {
-                var models = GetConnectorsToAddAndDelete(selectedPort, activeStartPorts[i]);
+                var models = GetConnectorsToAddAndDelete(
+                    selectedPort,
+                    activeStartPorts[i],
+                    ConsumeReconnectionPinLocations(activeStartPorts[i]));
                 foreach (var m in models)
                 {
                     firstModel.Add(m.Key, m.Value);
@@ -507,6 +524,7 @@ namespace Dynamo.Models
             }
             WorkspaceModel.RecordModelsForUndo(firstModel, CurrentWorkspace.UndoRecorder);
             activeStartPorts = null;
+            reconnectionPinLocationsByStartPortId = null;
             return;
         }
 
@@ -528,11 +546,14 @@ namespace Dynamo.Models
             CurrentWorkspace.DeleteSavedModels();
             activeStartPorts = null;
             firstStartPort = null;
+            reconnectionPinLocationsByStartPortId = null;
             return;
         }
 
         private static Dictionary<ModelBase, UndoRedoRecorder.UserAction> GetConnectorsToAddAndDelete(
-            PortModel endPort, PortModel startPort)
+            PortModel endPort,
+            PortModel startPort,
+            IEnumerable<(double X, double Y)> pinLocations = null)
         {
             ConnectorModel connectorToRemove = null;
 
@@ -573,8 +594,52 @@ namespace Dynamo.Models
             if (newConnectorModel != null)
             {
                 models.Add(newConnectorModel, UndoRedoRecorder.UserAction.Creation);
+
+                if (pinLocations != null)
+                {
+                    foreach (var pinLocation in pinLocations)
+                    {
+                        var connectorPinModel = new ConnectorPinModel(
+                            pinLocation.X,
+                            pinLocation.Y,
+                            Guid.NewGuid(),
+                            newConnectorModel.GUID);
+
+                        newConnectorModel.AddPin(connectorPinModel);
+                        models.Add(connectorPinModel, UndoRedoRecorder.UserAction.Creation);
+                    }
+                }
             }
             return models;
+        }
+
+        private void RecordReconnectionPinLocations(PortModel activeStartPort, ConnectorModel connector)
+        {
+            if (activeStartPort == null || connector == null)
+            {
+                return;
+            }
+
+            reconnectionPinLocationsByStartPortId ??= new Dictionary<Guid, List<(double X, double Y)>>();
+            reconnectionPinLocationsByStartPortId[activeStartPort.GUID] = connector.ConnectorPinModels
+                .Select(pin => (pin.X, pin.Y))
+                .ToList();
+        }
+
+        private IEnumerable<(double X, double Y)> ConsumeReconnectionPinLocations(PortModel activeStartPort)
+        {
+            if (activeStartPort == null || reconnectionPinLocationsByStartPortId == null)
+            {
+                return null;
+            }
+
+            if (!reconnectionPinLocationsByStartPortId.TryGetValue(activeStartPort.GUID, out var pinLocations))
+            {
+                return null;
+            }
+
+            reconnectionPinLocationsByStartPortId.Remove(activeStartPort.GUID);
+            return pinLocations;
         }
 
         private void DeleteModelImpl(DeleteModelCommand command)

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -492,6 +492,11 @@ namespace Dynamo.ViewModels
         {
             get
             {
+                if (model?.Start?.Owner == null)
+                {
+                    return null;
+                }
+
                 return workspaceViewModel.Nodes?.FirstOrDefault(x => x.NodeLogic.GUID == model.Start.Owner.GUID);
             }
         }
@@ -500,6 +505,11 @@ namespace Dynamo.ViewModels
         {
             get
             {
+                if (model?.End?.Owner == null)
+                {
+                    return null;
+                }
+
                 return workspaceViewModel.Nodes?.FirstOrDefault(x => x.NodeLogic.GUID == model.End.Owner.GUID);
             }
         }
@@ -1135,7 +1145,7 @@ namespace Dynamo.ViewModels
         /// View model adding method only- given a model
         /// </summary>
         /// <param name="pinModel"></param>
-        private void AddConnectorPinViewModel(ConnectorPinModel pinModel)
+        private void AddConnectorPinViewModel(ConnectorPinModel pinModel, bool isTransientPin = false)
         {
             var pinViewModel = new ConnectorPinViewModel(this.workspaceViewModel, pinModel)
             {
@@ -1146,7 +1156,10 @@ namespace Dynamo.ViewModels
 
             pinViewModel.RequestSelect += HandleRequestSelected;
             pinViewModel.RequestRedraw += HandlerRedrawRequest;
-            pinViewModel.RequestRemove += HandleConnectorPinViewModelRemove;
+            if (!isTransientPin)
+            {
+                pinViewModel.RequestRemove += HandleConnectorPinViewModelRemove;
+            }
 
             workspaceViewModel.Pins.Add(pinViewModel);
             ConnectorPinViewCollection.Add(pinViewModel);
@@ -1184,6 +1197,12 @@ namespace Dynamo.ViewModels
         private void HandleConnectorPinViewModelRemove(object sender, EventArgs e)
         {
             if (!(sender is ConnectorPinViewModel viewModelSender)) return;
+
+            if (ConnectorModel is null)
+            {
+                RemoveConnectorPinModelViewModel(viewModelSender);
+                return;
+            }
 
             workspaceViewModel.Model.RecordAndDeleteModels(
                 new List<ModelBase>() { viewModelSender.Model });
@@ -1438,9 +1457,9 @@ namespace Dynamo.ViewModels
             foreach (var pin in ConnectorPinViewCollection)
             {
                 workspaceViewModel.Pins.Remove(pin);
-                ConnectorModel.RemovePin(pin.Model);
+                ConnectorModel?.RemovePin(pin.Model);
 
-                if(allDeletedModels != null)
+                if (ConnectorModel != null && allDeletedModels != null)
                 {
                     allDeletedModels.Add(pin.Model);
                 }
@@ -1468,6 +1487,30 @@ namespace Dynamo.ViewModels
             return points;
         }
 
+        /// <summary>
+        /// Creates transient pin visuals for a temporary connector (ConnectorModel == null).
+        /// </summary>
+        /// <param name="pinLocations">Pin top-left canvas coordinates.</param>
+        internal void SetTransientConnectorPinPositions(IEnumerable<Point> pinLocations)
+        {
+            if (ConnectorModel != null || pinLocations == null)
+            {
+                return;
+            }
+
+            DiscardAllConnectorPinModels();
+            foreach (var pinLocation in pinLocations)
+            {
+                var transientPinModel = new ConnectorPinModel(
+                    pinLocation.X,
+                    pinLocation.Y,
+                    Guid.NewGuid(),
+                    Guid.Empty);
+
+                AddConnectorPinViewModel(transientPinModel, true);
+            }
+        }
+
         #region ConnectorRedraw
 
         /// <summary>
@@ -1477,16 +1520,20 @@ namespace Dynamo.ViewModels
         {
             try
             {
-                if (this.ConnectorModel != null && ConnectorPinViewCollection != null)
+                if (ConnectorPinViewCollection?.Count > 0)
                 {
-                    if (this.ConnectorModel?.End != null && ConnectorPinViewCollection?.Count > 0)
+                    if (this.ConnectorModel?.End != null)
                     {
-                        RedrawBezierManyPoints();
+                        RedrawBezierManyPoints(this.ConnectorModel.End.Center);
                     }
-                    else if (this.ConnectorModel?.End != null)
+                    else
                     {
-                        this.Redraw(this.ConnectorModel.End.Center);
+                        RedrawBezierManyPoints(CurvePoint3);
                     }
+                }
+                else if (this.ConnectorModel?.End != null)
+                {
+                    this.Redraw(this.ConnectorModel.End.Center);
                 }
 
                 this.SetCollapsedByNodeViewModel();
@@ -1506,6 +1553,11 @@ namespace Dynamo.ViewModels
         /// </summary>
         private void SetCollapsedByNodeViewModel()
         {
+            if (ConnectorModel?.Start == null || ConnectorModel?.End == null)
+            {
+                return;
+            }
+
             // Check if the connector is between two proxy ports. 
             // Connectors between proxy ports should not be collapsed.
             bool bothEndsAreProxyPorts = ConnectorModel.Start.IsProxyPort && ConnectorModel.End.IsProxyPort;
@@ -1522,15 +1574,15 @@ namespace Dynamo.ViewModels
         /// <param name="parameter">The position of the end point</param>
         public void Redraw(object parameter)
         {
-            var p2 = new Point();
-
-            if (parameter is Point point)
+            if (ConnectorPinViewCollection?.Count > 0)
             {
-                p2 = point;
+                RedrawBezierManyPoints(parameter);
+                return;
             }
-            else if (parameter is Point2D d)
+
+            if (!TryGetEndPoint(parameter, out var p2))
             {
-                p2 = d.AsWindowsType();
+                return;
             }
 
             CurvePoint3 = p2;
@@ -1604,25 +1656,34 @@ namespace Dynamo.ViewModels
             return pathFigure;
         }
 
-        private void RedrawBezierManyPoints()
+        private bool TryGetEndPoint(object parameter, out Point point)
         {
-            var parameter = this.ConnectorModel.End.Center;
-            var param = parameter as object;
+            point = new Point();
+            if (parameter is Point windowsPoint)
+            {
+                point = windowsPoint;
+                return true;
+            }
+
+            if (parameter is Point2D dynamoPoint)
+            {
+                point = dynamoPoint.AsWindowsType();
+                return true;
+            }
+
+            return false;
+        }
+
+        private void RedrawBezierManyPoints(object parameter)
+        {
+            if (!TryGetEndPoint(parameter, out var p2))
+            {
+                return;
+            }
 
             var controlPoints = new List<Point[]>();
             try
             {
-                var p2 = new Point();
-
-                if (parameter is Point)
-                {
-                    p2 = (Point)param;
-                }
-                else if (parameter is Point2D)
-                {
-                    p2 = ((Point2D)param).AsWindowsType();
-                }
-
                 CurvePoint3 = p2;
 
                 var offset = 0.0;

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using System.Windows.Input;
 using Dynamo.Graph;
 using Dynamo.Graph.Annotations;
+using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Notes;
 using Dynamo.Graph.Workspaces;
@@ -200,10 +201,15 @@ namespace Dynamo.ViewModels
             // to somewhere else (we don't allow the grabbing of the start connector).
             if (portModel.Connectors.Count > 0 && portModel.Connectors[0].Start != portModel)
             {
+                var existingConnector = portModel.Connectors[0];
+
                 // Define the new active connector
-                var c = new ConnectorViewModel[] { new ConnectorViewModel(this, portModel.Connectors[0].Start) };
+                var activeConnector = new ConnectorViewModel(this, existingConnector.Start);
+                activeConnector.SetTransientConnectorPinPositions(CollectConnectorPinPositions(existingConnector));
+                activeConnector.Redraw(existingConnector.End.Center);
+                var c = new ConnectorViewModel[] { activeConnector };
                 this.SetActiveConnectors(c);
-                firstStartPort = portModel.Connectors[0].Start;
+                firstStartPort = existingConnector.Start;
             }
             else
             {
@@ -230,23 +236,38 @@ namespace Dynamo.ViewModels
             if (portModel.Connectors.Count <= 0) return;
 
             // Try to obtain connectors for selected nodes
-            var selected = portModel.Connectors.Where(x => x.End.Owner.IsSelected).Select(y => y.End);
+            var selectedConnectors = portModel.Connectors.Where(x => x.End.Owner.IsSelected).ToList();
 
             // If there are no selected nodes, obtain all the associated connectors
-            if (selected.Count() <= 0)
+            if (selectedConnectors.Count <= 0)
             {
-                selected = portModel.Connectors.Select(y => y.End);
+                selectedConnectors = portModel.Connectors.ToList();
             }
 
-            var connectorsAr = new ConnectorViewModel[selected.Count()];
-            for (int i = 0; i < selected.Count(); i++)
+            var connectorsAr = new ConnectorViewModel[selectedConnectors.Count];
+            for (int i = 0; i < selectedConnectors.Count; i++)
             {
-                var c = new ConnectorViewModel(this, selected.ElementAt(i));
+                var selectedConnector = selectedConnectors[i];
+                var c = new ConnectorViewModel(this, selectedConnector.End);
+                c.SetTransientConnectorPinPositions(CollectConnectorPinPositions(selectedConnector));
+                c.Redraw(selectedConnector.Start.Center);
                 connectorsAr[i] = c;
             }
 
             this.SetActiveConnectors(connectorsAr);
             return;
+        }
+
+        private static IEnumerable<Point> CollectConnectorPinPositions(ConnectorModel connectorModel)
+        {
+            if (connectorModel?.ConnectorPinModels == null || connectorModel.ConnectorPinModels.Count == 0)
+            {
+                return Enumerable.Empty<Point>();
+            }
+
+            return connectorModel.ConnectorPinModels
+                .Select(pin => new Point(pin.X, pin.Y))
+                .ToList();
         }
 
         internal void EndConnection(Guid nodeId, int portIndex, PortType portType)

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.Selection;
@@ -506,15 +507,26 @@ namespace DynamoCoreWpfTests
                 new DynamoModel.MakeConnectionCommand(startNode.GUID, startPortIndex, PortType.Output,
                 MakeConnectionCommand.Mode.BeginShiftReconnections));
 
+            // During reconnect drag, the active dashed connector should retain and route through pin data.
+            var activeConnector = this.ViewModel.CurrentSpaceViewModel.WorkspaceElements
+                .OfType<ConnectorViewModel>()
+                .FirstOrDefault(c => c.IsConnecting);
+            Assert.IsNotNull(activeConnector);
+            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
+
+            activeConnector.Redraw(new Point2D(650, 350));
+            Assert.IsNotNull(activeConnector.ComputedBezierPathGeometry);
+            Assert.Greater(activeConnector.ComputedBezierPathGeometry.Figures.Count, 1);
+
             // Execute the second part of the workflow - simulate placing the connectors over the new port
             this.ViewModel.ExecuteCommand(
                 new DynamoModel.MakeConnectionCommand(codeblock.GUID, 0, PortType.Output,
                 MakeConnectionCommand.Mode.EndShiftReconnections));
 
-            // Validate that the pin does not exists anymore
+            // Validate that the newly reconnected connector persists equivalent pins.
             var connectorAfterReconnect = this.ViewModel.CurrentSpaceViewModel.Connectors;
             Assert.AreEqual(1, connectorAfterReconnect.Count());
-            Assert.AreEqual(0, connectorAfterReconnect.First().ConnectorPinViewCollection.Count());
+            Assert.AreEqual(initialConnectorPinCount + 1, connectorAfterReconnect.First().ConnectorPinViewCollection.Count());
 
             // --- Undo ---
             Model.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));


### PR DESCRIPTION
### Purpose

This PR addresses an issue where connector pins would disappear during wire reconnection. It ensures that when a user "unplugs" and drags a connected wire, the interim dashed connector visually routes through the previous pin locations, pins remain visible during the drag, and after reconnection, pins persist on the newly created real connector. It also includes null-safety fixes to prevent crashes from transient connector redraw/collapse logic.

### Declarations

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Fixes an issue where connector pins would disappear during wire reconnection and the interim dashed connector would not follow the original pin path. Now, when a wire is reconnected, the dashed connector visually routes through the previous pin locations, pins remain visible during the drag, and the new solid connector retains the pins. Includes null-safety fixes for transient connector redraw/collapse logic.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

---
<p><a href="https://cursor.com/background-agent?bcId=bc-3e3184f7-65a9-43c6-a7f1-e128ed96c94d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3e3184f7-65a9-43c6-a7f1-e128ed96c94d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

