### PR TITLE
Connector pin movement logic

### DIFF
--- a/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
+++ b/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Xml;
 using Dynamo.Configuration;
 using Dynamo.Graph.Nodes;
@@ -103,6 +104,21 @@ namespace Dynamo.Graph.Connectors
         internal void RemovePin(ConnectorPinModel connectorPinModel)
         {
             ConnectorPinModels.Remove(connectorPinModel);
+        }
+
+        /// <summary>
+        /// Returns a snapshot of pin top-left canvas coordinates for this connector.
+        /// </summary>
+        internal IEnumerable<(double X, double Y)> GetPinLocations()
+        {
+            if (ConnectorPinModels == null || ConnectorPinModels.Count == 0)
+            {
+                return Enumerable.Empty<(double X, double Y)>();
+            }
+
+            return ConnectorPinModels
+                .Select(pin => (pin.X, pin.Y))
+                .ToList();
         }
 
         /// <summary>

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -374,7 +374,7 @@ namespace Dynamo.Models
         {
             bool isInPort = portType == PortType.Input;
             activeStartPorts = null;
-            reconnectionPinLocationsByStartPortId = null;
+            ClearReconnectionPinLocations();
 
             if (CurrentWorkspace.GetModelInternal(nodeId) is not NodeModel node)
                 return;
@@ -414,7 +414,7 @@ namespace Dynamo.Models
 
         private void BeginDuplicateConnection(Guid nodeId, int portIndex, PortType portType)
         {
-            reconnectionPinLocationsByStartPortId = null;
+            ClearReconnectionPinLocations();
 
             // If the port clicked is an output port, begin connection as per normal
             if (portType == PortType.Output)
@@ -446,7 +446,7 @@ namespace Dynamo.Models
         {
             if (portType == PortType.Input) return; //only handle multiple connections when the port selected is an output port
             if (!(CurrentWorkspace.GetModelInternal(nodeId) is NodeModel node)) return;
-            reconnectionPinLocationsByStartPortId = null;
+            ClearReconnectionPinLocations();
 
             PortModel selectedPort = node.OutPorts[portIndex];
 
@@ -496,7 +496,7 @@ namespace Dynamo.Models
             WorkspaceModel.RecordModelsForUndo(models, CurrentWorkspace.UndoRecorder);
             activeStartPorts = null;
             firstStartPort = null;
-            reconnectionPinLocationsByStartPortId = null;
+            ClearReconnectionPinLocations();
         }
 
         private void EndShiftReconnections(Guid nodeId, int portIndex, PortType portType)
@@ -524,7 +524,7 @@ namespace Dynamo.Models
             }
             WorkspaceModel.RecordModelsForUndo(firstModel, CurrentWorkspace.UndoRecorder);
             activeStartPorts = null;
-            reconnectionPinLocationsByStartPortId = null;
+            ClearReconnectionPinLocations();
             return;
         }
 
@@ -546,7 +546,7 @@ namespace Dynamo.Models
             CurrentWorkspace.DeleteSavedModels();
             activeStartPorts = null;
             firstStartPort = null;
-            reconnectionPinLocationsByStartPortId = null;
+            ClearReconnectionPinLocations();
             return;
         }
 
@@ -621,9 +621,12 @@ namespace Dynamo.Models
             }
 
             reconnectionPinLocationsByStartPortId ??= new Dictionary<Guid, List<(double X, double Y)>>();
-            reconnectionPinLocationsByStartPortId[activeStartPort.GUID] = connector.ConnectorPinModels
-                .Select(pin => (pin.X, pin.Y))
-                .ToList();
+            reconnectionPinLocationsByStartPortId[activeStartPort.GUID] = connector.GetPinLocations().ToList();
+        }
+
+        private void ClearReconnectionPinLocations()
+        {
+            reconnectionPinLocationsByStartPortId = null;
         }
 
         private IEnumerable<(double X, double Y)> ConsumeReconnectionPinLocations(PortModel activeStartPort)

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Dynamo.Configuration;
 using Dynamo.Graph;
@@ -45,7 +45,7 @@ namespace Dynamo.ViewModels
         public event EventHandler RequestRemove;
         public virtual void OnRequestRemove(Object sender, EventArgs e)
         {
-            RequestRemove(this, e);
+            RequestRemove?.Invoke(this, e);
         }
         /// <summary>
         /// Raises a 'remove from group' event for this ConnectorPinViewModel
@@ -222,6 +222,23 @@ namespace Dynamo.ViewModels
             {
                 isTemporarilyVisible = value;
                 RaisePropertyChanged(nameof(IsTemporarilyVisible));
+            }
+        }
+
+        private bool isInteractive = true;
+        [JsonIgnore]
+        public bool IsInteractive
+        {
+            get => isInteractive;
+            set
+            {
+                if (isInteractive == value)
+                {
+                    return;
+                }
+
+                isInteractive = value;
+                RaisePropertyChanged(nameof(IsInteractive));
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1150,7 +1150,8 @@ namespace Dynamo.ViewModels
             var pinViewModel = new ConnectorPinViewModel(this.workspaceViewModel, pinModel)
             {
                 IsHidden = this.IsHidden,
-                IsTemporarilyVisible = isTemporarilyVisible
+                IsTemporarilyVisible = isTemporarilyVisible,
+                IsInteractive = !isTransientPin
             };
             pinViewModel.PropertyChanged += PinViewModelPropertyChanged;
 
@@ -1491,7 +1492,7 @@ namespace Dynamo.ViewModels
         /// Creates transient pin visuals for a temporary connector (ConnectorModel == null).
         /// </summary>
         /// <param name="pinLocations">Pin top-left canvas coordinates.</param>
-        internal void SetTransientConnectorPinPositions(IEnumerable<Point> pinLocations)
+        internal void SetTransientConnectorPinPositions(IEnumerable<(double X, double Y)> pinLocations)
         {
             if (ConnectorModel != null || pinLocations == null)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -5,7 +5,6 @@ using System.Windows;
 using System.Windows.Input;
 using Dynamo.Graph;
 using Dynamo.Graph.Annotations;
-using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Notes;
 using Dynamo.Graph.Workspaces;
@@ -205,7 +204,7 @@ namespace Dynamo.ViewModels
 
                 // Define the new active connector
                 var activeConnector = new ConnectorViewModel(this, existingConnector.Start);
-                activeConnector.SetTransientConnectorPinPositions(CollectConnectorPinPositions(existingConnector));
+                activeConnector.SetTransientConnectorPinPositions(existingConnector.GetPinLocations());
                 activeConnector.Redraw(existingConnector.End.Center);
                 var c = new ConnectorViewModel[] { activeConnector };
                 this.SetActiveConnectors(c);
@@ -249,25 +248,13 @@ namespace Dynamo.ViewModels
             {
                 var selectedConnector = selectedConnectors[i];
                 var c = new ConnectorViewModel(this, selectedConnector.End);
-                c.SetTransientConnectorPinPositions(CollectConnectorPinPositions(selectedConnector));
+                c.SetTransientConnectorPinPositions(selectedConnector.GetPinLocations());
                 c.Redraw(selectedConnector.Start.Center);
                 connectorsAr[i] = c;
             }
 
             this.SetActiveConnectors(connectorsAr);
             return;
-        }
-
-        private static IEnumerable<Point> CollectConnectorPinPositions(ConnectorModel connectorModel)
-        {
-            if (connectorModel?.ConnectorPinModels == null || connectorModel.ConnectorPinModels.Count == 0)
-            {
-                return Enumerable.Empty<Point>();
-            }
-
-            return connectorModel.ConnectorPinModels
-                .Select(pin => new Point(pin.X, pin.Y))
-                .ToList();
         }
 
         internal void EndConnection(Guid nodeId, int portIndex, PortType portType)

--- a/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/ConnectorPinView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Dynamo.Nodes.ConnectorPinView"
+<UserControl x:Class="Dynamo.Nodes.ConnectorPinView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -18,7 +18,9 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Canvas Left="{Binding Left, Mode=TwoWay}" Top="{Binding Top, Mode=TwoWay}">
+    <Canvas Left="{Binding Left, Mode=TwoWay}"
+            Top="{Binding Top, Mode=TwoWay}"
+            IsHitTestVisible="{Binding IsInteractive}">
         <Canvas.ContextMenu>
             <ContextMenu Style="{StaticResource ContextMenuStyle}" Background="{StaticResource NodeContextMenuBackground}">
                 <MenuItem Header="{x:Static props:Resources.ConnectorContextMenuHeaderUnpinConnector}" Command="{Binding UnpinConnectorCommand}"/>

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.Selection;
@@ -507,26 +506,14 @@ namespace DynamoCoreWpfTests
                 new DynamoModel.MakeConnectionCommand(startNode.GUID, startPortIndex, PortType.Output,
                 MakeConnectionCommand.Mode.BeginShiftReconnections));
 
-            // During reconnect drag, the active dashed connector should retain and route through pin data.
-            var activeConnector = this.ViewModel.CurrentSpaceViewModel.WorkspaceElements
-                .OfType<ConnectorViewModel>()
-                .FirstOrDefault(c => c.IsConnecting);
-            Assert.IsNotNull(activeConnector);
-            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
-
-            activeConnector.Redraw(new Point2D(650, 350));
-            Assert.IsNotNull(activeConnector.ComputedBezierPathGeometry);
-            Assert.Greater(activeConnector.ComputedBezierPathGeometry.Figures.Count, 1);
-
             // Execute the second part of the workflow - simulate placing the connectors over the new port
             this.ViewModel.ExecuteCommand(
                 new DynamoModel.MakeConnectionCommand(codeblock.GUID, 0, PortType.Output,
                 MakeConnectionCommand.Mode.EndShiftReconnections));
 
-            // Validate that the newly reconnected connector persists equivalent pins.
+            // Validate that a reconnected connector exists.
             var connectorAfterReconnect = this.ViewModel.CurrentSpaceViewModel.Connectors;
             Assert.AreEqual(1, connectorAfterReconnect.Count());
-            Assert.AreEqual(initialConnectorPinCount + 1, connectorAfterReconnect.First().ConnectorPinViewCollection.Count());
 
             // --- Undo ---
             Model.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));
@@ -540,6 +527,55 @@ namespace DynamoCoreWpfTests
 
             var restoredPin = restoredConnector.ConnectorModel.ConnectorPinModels.FirstOrDefault(p => p.GUID == pinModelGuid);
             Assert.IsNotNull(restoredPin, "Expected pin model not found after undo.");
+        }
+
+        [Test]
+        public void ShiftReconnectionUsesNonInteractiveTransientPinsAndPersistsPins()
+        {
+            Open(@"UI/ConnectorPinTests.dyn");
+
+            var id = Guid.Parse("90cd0dca-45c7-456b-bb63-726d2193dbb4");
+            var codeblock = this.ViewModel.Model.CurrentWorkspace.GetModelInternal(id);
+
+            var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
+            var initialConnectorPinCount = connectorViewModel.ConnectorPinViewCollection.Count;
+
+            // Add one pin before starting shift reconnection.
+            connectorViewModel.PanelX = 292.66666;
+            connectorViewModel.PanelY = 278;
+            connectorViewModel.FlipOnConnectorAnchor();
+            connectorViewModel.PinConnectorCommand.Execute(null);
+            Assert.AreEqual(initialConnectorPinCount + 1, connectorViewModel.ConnectorPinViewCollection.Count);
+
+            var startPort = connectorViewModel.ConnectorModel.Start;
+            var startNode = startPort.Owner;
+            var startPortIndex = startNode.OutPorts.IndexOf(startPort);
+
+            this.ViewModel.ExecuteCommand(
+                new DynamoModel.MakeConnectionCommand(startNode.GUID, startPortIndex, PortType.Output,
+                MakeConnectionCommand.Mode.BeginShiftReconnections));
+
+            var activeConnector = this.ViewModel.CurrentSpaceViewModel.WorkspaceElements
+                .OfType<ConnectorViewModel>()
+                .FirstOrDefault(c => c.IsConnecting);
+            Assert.IsNotNull(activeConnector);
+            Assert.IsNull(activeConnector.ConnectorModel, "Expected active connector to be transient during drag.");
+            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
+            Assert.IsTrue(activeConnector.ConnectorPinViewCollection.All(pin => !pin.IsInteractive));
+
+            // Transient pins are non-interactive: remove event is not wired and should not throw.
+            var transientPin = activeConnector.ConnectorPinViewCollection.First();
+            Assert.DoesNotThrow(() => transientPin.OnRequestRemove(transientPin, EventArgs.Empty));
+            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
+
+            this.ViewModel.ExecuteCommand(
+                new DynamoModel.MakeConnectionCommand(codeblock.GUID, 0, PortType.Output,
+                MakeConnectionCommand.Mode.EndShiftReconnections));
+
+            var connectorAfterReconnect = this.ViewModel.CurrentSpaceViewModel.Connectors;
+            Assert.AreEqual(1, connectorAfterReconnect.Count());
+            Assert.AreEqual(initialConnectorPinCount + 1, connectorAfterReconnect.First().ConnectorPinViewCollection.Count);
+            Assert.IsTrue(connectorAfterReconnect.First().ConnectorPinViewCollection.All(pin => pin.IsInteractive));
         }
         #endregion
     }


### PR DESCRIPTION
### Purpose

This PR improves the stability and maintainability of the transient pin reconnection feature. It addresses a potential `NullReferenceException` by making temporary pins non-interactive during connector drag and unifies the logic for capturing and clearing pin locations. This ensures a more robust and predictable user experience when moving or reconnecting wires.

### Declarations

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

When moving or reconnecting wires, the temporary pins that appear during the drag operation are now non-interactive, preventing accidental unpinning or modification. This improves stability and user experience during connector manipulation. Internal code for managing these temporary pins has also been refactored for better maintainability.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

---
<p><a href="https://cursor.com/agents?id=bc-07d09d84-7255-43c8-9a94-0088a931bdb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07d09d84-7255-43c8-9a94-0088a931bdb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

