### PR TITLE
Connector pin logic

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -51,7 +51,7 @@ namespace Dynamo.ViewModels
         private double endDotSize = 6;
         private double zIndex = 3;
         private double dynamicStrokeThickness;
-        private List<Point> transientConnectorPinRoutingPoints;
+        private List<Point> transientConnectorPinCanvasPoints;
 
         private Point curvePoint1;
         private Point curvePoint2;
@@ -1501,8 +1501,27 @@ namespace Dynamo.ViewModels
                 return;
             }
 
-            transientConnectorPinRoutingPoints = pinLocations?
-                .Select(pinLocation => ConvertModelPinLocationToBezierPoint(pinLocation.X, pinLocation.Y))
+            transientConnectorPinCanvasPoints = pinLocations?
+                .Select(pinLocation => new Point(pinLocation.X, pinLocation.Y - ConnectorPinViewModel.OneThirdWidth))
+                .OrderBy(pinLocation => pinLocation.X)
+                .ToList()
+                ?? new List<Point>();
+        }
+
+        /// <summary>
+        /// Caches transient pin canvas points directly from connector view-model pin positions.
+        /// This avoids model/view coordinate conversion drift and preserves anchor routing.
+        /// </summary>
+        /// <param name="pinCanvasLocations">Pin top-left canvas coordinates.</param>
+        internal void SetTransientConnectorPinCanvasPositions(IEnumerable<Point> pinCanvasLocations)
+        {
+            if (ConnectorModel != null)
+            {
+                return;
+            }
+
+            transientConnectorPinCanvasPoints = pinCanvasLocations?
+                .OrderBy(pinLocation => pinLocation.X)
                 .ToList()
                 ?? new List<Point>();
         }
@@ -1510,13 +1529,6 @@ namespace Dynamo.ViewModels
         private static Point ConvertConnectorPinViewToBezierPoint(ConnectorPinViewModel wirePin)
         {
             return ConvertPinCanvasPointToBezierPoint(wirePin.Left, wirePin.Top);
-        }
-
-        private static Point ConvertModelPinLocationToBezierPoint(double x, double y)
-        {
-            // ConnectorPinModel.Y is offset from Canvas.Top by OneThirdWidth.
-            var top = y - ConnectorPinViewModel.OneThirdWidth;
-            return ConvertPinCanvasPointToBezierPoint(x, top);
         }
 
         private static Point ConvertPinCanvasPointToBezierPoint(double left, double top)
@@ -1529,19 +1541,24 @@ namespace Dynamo.ViewModels
         private bool HasRoutingPoints()
         {
             return (ConnectorPinViewCollection?.Count > 0)
-                || (transientConnectorPinRoutingPoints?.Count > 0);
+                || (transientConnectorPinCanvasPoints?.Count > 0);
         }
 
-        private List<Point> GetRoutingPoints()
+        private List<Point> GetRoutingPoints(out bool areTransientCachedPoints)
         {
             if (ConnectorPinViewCollection?.Count > 0)
             {
+                areTransientCachedPoints = false;
                 return ConnectorPinViewCollection
                     .Select(ConvertConnectorPinViewToBezierPoint)
                     .ToList();
             }
 
-            return transientConnectorPinRoutingPoints?.ToList() ?? new List<Point>();
+            areTransientCachedPoints = transientConnectorPinCanvasPoints?.Count > 0;
+            return transientConnectorPinCanvasPoints?
+                .Select(pinCanvasPoint => ConvertPinCanvasPointToBezierPoint(pinCanvasPoint.X, pinCanvasPoint.Y))
+                .ToList()
+                ?? new List<Point>();
         }
 
         #region ConnectorRedraw
@@ -1747,10 +1764,14 @@ namespace Dynamo.ViewModels
                 dotLeft = CurvePoint3.X - EndDotSize / 2;
 
                 var isInputStartReconnection = ActiveStartPort?.PortType == PortType.Input;
-                var routingPoints = GetRoutingPoints();
-                var orderedPoints = isInputStartReconnection
-                    ? routingPoints.OrderByDescending(p => p.X).ToList()
-                    : routingPoints.OrderBy(p => p.X).ToList();
+                var routingPoints = GetRoutingPoints(out var areTransientCachedPoints);
+                var orderedPoints = areTransientCachedPoints
+                    ? (isInputStartReconnection
+                        ? routingPoints.AsEnumerable().Reverse().ToList()
+                        : routingPoints.ToList())
+                    : (isInputStartReconnection
+                        ? routingPoints.OrderByDescending(p => p.X).ToList()
+                        : routingPoints.OrderBy(p => p.X).ToList());
 
                 orderedPoints.Insert(0, CurvePoint0);
                 orderedPoints.Insert(orderedPoints.Count, CurvePoint3);

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -51,6 +51,7 @@ namespace Dynamo.ViewModels
         private double endDotSize = 6;
         private double zIndex = 3;
         private double dynamicStrokeThickness;
+        private List<Point> transientConnectorPinRoutingPoints;
 
         private Point curvePoint1;
         private Point curvePoint2;
@@ -1489,27 +1490,58 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Creates transient pin visuals for a temporary connector (ConnectorModel == null).
+        /// Stores cached transient pin routing points for a temporary connector (ConnectorModel == null).
+        /// No transient pin view-models are created to keep reconnection start responsive.
         /// </summary>
         /// <param name="pinLocations">Pin top-left canvas coordinates.</param>
         internal void SetTransientConnectorPinPositions(IEnumerable<(double X, double Y)> pinLocations)
         {
-            if (ConnectorModel != null || pinLocations == null)
+            if (ConnectorModel != null)
             {
                 return;
             }
 
-            DiscardAllConnectorPinModels();
-            foreach (var pinLocation in pinLocations)
-            {
-                var transientPinModel = new ConnectorPinModel(
-                    pinLocation.X,
-                    pinLocation.Y,
-                    Guid.NewGuid(),
-                    Guid.Empty);
+            transientConnectorPinRoutingPoints = pinLocations?
+                .Select(pinLocation => ConvertModelPinLocationToBezierPoint(pinLocation.X, pinLocation.Y))
+                .ToList()
+                ?? new List<Point>();
+        }
 
-                AddConnectorPinViewModel(transientPinModel, true);
+        private static Point ConvertConnectorPinViewToBezierPoint(ConnectorPinViewModel wirePin)
+        {
+            return ConvertPinCanvasPointToBezierPoint(wirePin.Left, wirePin.Top);
+        }
+
+        private static Point ConvertModelPinLocationToBezierPoint(double x, double y)
+        {
+            // ConnectorPinModel.Y is offset from Canvas.Top by OneThirdWidth.
+            var top = y - ConnectorPinViewModel.OneThirdWidth;
+            return ConvertPinCanvasPointToBezierPoint(x, top);
+        }
+
+        private static Point ConvertPinCanvasPointToBezierPoint(double left, double top)
+        {
+            return new Point(
+                left + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5),
+                top + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5));
+        }
+
+        private bool HasRoutingPoints()
+        {
+            return (ConnectorPinViewCollection?.Count > 0)
+                || (transientConnectorPinRoutingPoints?.Count > 0);
+        }
+
+        private List<Point> GetRoutingPoints()
+        {
+            if (ConnectorPinViewCollection?.Count > 0)
+            {
+                return ConnectorPinViewCollection
+                    .Select(ConvertConnectorPinViewToBezierPoint)
+                    .ToList();
             }
+
+            return transientConnectorPinRoutingPoints?.ToList() ?? new List<Point>();
         }
 
         #region ConnectorRedraw
@@ -1521,7 +1553,7 @@ namespace Dynamo.ViewModels
         {
             try
             {
-                if (ConnectorPinViewCollection?.Count > 0)
+                if (HasRoutingPoints())
                 {
                     if (this.ConnectorModel?.End != null)
                     {
@@ -1575,7 +1607,7 @@ namespace Dynamo.ViewModels
         /// <param name="parameter">The position of the end point</param>
         public void Redraw(object parameter)
         {
-            if (ConnectorPinViewCollection?.Count > 0)
+            if (HasRoutingPoints())
             {
                 RedrawBezierManyPoints(parameter);
                 return;
@@ -1714,19 +1746,11 @@ namespace Dynamo.ViewModels
                 dotTop = CurvePoint3.Y - EndDotSize / 2;
                 dotLeft = CurvePoint3.X - EndDotSize / 2;
 
-                // Add chain of points including start/end
-                Point[] points = new Point[ConnectorPinViewCollection.Count];
-                int count = 0;
-                foreach (var wirePin in ConnectorPinViewCollection)
-                {
-                    points[count] = new Point(wirePin.Left+ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5), wirePin.Top+ ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5));
-                    count++;
-                }
-
                 var isInputStartReconnection = ActiveStartPort?.PortType == PortType.Input;
+                var routingPoints = GetRoutingPoints();
                 var orderedPoints = isInputStartReconnection
-                    ? points.OrderByDescending(p => p.X).ToList()
-                    : points.OrderBy(p => p.X).ToList();
+                    ? routingPoints.OrderByDescending(p => p.X).ToList()
+                    : routingPoints.OrderBy(p => p.X).ToList();
 
                 orderedPoints.Insert(0, CurvePoint0);
                 orderedPoints.Insert(orderedPoints.Count, CurvePoint3);

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -205,7 +205,15 @@ namespace Dynamo.ViewModels
 
                 // Define the new active connector
                 var activeConnector = new ConnectorViewModel(this, existingConnector.Start);
-                activeConnector.SetTransientConnectorPinPositions(existingConnector.GetPinLocations());
+                var existingConnectorViewModel = Connectors.FirstOrDefault(c => c.ConnectorModel == existingConnector);
+                if (existingConnectorViewModel != null)
+                {
+                    activeConnector.SetTransientConnectorPinCanvasPositions(existingConnectorViewModel.CollectPinLocations());
+                }
+                else
+                {
+                    activeConnector.SetTransientConnectorPinPositions(existingConnector.GetPinLocations());
+                }
                 activeConnector.Redraw(existingConnector.End.Center);
                 var c = new ConnectorViewModel[] { activeConnector };
                 this.SetActiveConnectors(c);
@@ -249,7 +257,15 @@ namespace Dynamo.ViewModels
             {
                 var selectedConnector = selectedConnectors[i];
                 var c = new ConnectorViewModel(this, selectedConnector.End);
-                c.SetTransientConnectorPinPositions(selectedConnector.GetPinLocations());
+                var selectedConnectorViewModel = Connectors.FirstOrDefault(connectorViewModel => connectorViewModel.ConnectorModel == selectedConnector);
+                if (selectedConnectorViewModel != null)
+                {
+                    c.SetTransientConnectorPinCanvasPositions(selectedConnectorViewModel.CollectPinLocations());
+                }
+                else
+                {
+                    c.SetTransientConnectorPinPositions(selectedConnector.GetPinLocations());
+                }
                 c.Redraw(selectedConnector.Start.Center);
                 connectorsAr[i] = c;
             }

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using Dynamo.Graph;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.Selection;
@@ -325,6 +326,12 @@ namespace DynamoCoreWpfTests
 
             // Assert that the pin was added
             Assert.AreEqual(initialConnectorPinCount + 1, connectorViewModel.ConnectorPinViewCollection.Count);
+            var expectedAnchorPoints = connectorViewModel.ConnectorPinViewCollection
+                .Select(pin => (
+                    X: pin.Left + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5),
+                    Y: pin.Top + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5)))
+                .OrderBy(point => point.X)
+                .ToList();
 
             // Begin reconnection – simulate grabbing the connector and starting a shift drag
             var startPort = connectorViewModel.ConnectorModel.Start;
@@ -348,6 +355,18 @@ namespace DynamoCoreWpfTests
             activeConnector.Redraw(new Point2D(650, 350));
             Assert.IsNotNull(activeConnector.ComputedBezierPathGeometry);
             Assert.Greater(activeConnector.ComputedBezierPathGeometry.Figures.Count, 1);
+            var transientSegmentEndPoints = activeConnector.ComputedBezierPathGeometry.Figures
+                .SelectMany(figure => figure.Segments.OfType<System.Windows.Media.BezierSegment>())
+                .Select(segment => segment.Point3)
+                .ToList();
+            foreach (var expected in expectedAnchorPoints)
+            {
+                Assert.IsTrue(
+                    transientSegmentEndPoints.Any(point =>
+                        Math.Abs(point.X - expected.X) < 0.001 &&
+                        Math.Abs(point.Y - expected.Y) < 0.001),
+                    $"Expected transient path to include cached anchor point ({expected.X}, {expected.Y}).");
+            }
 
             // Execute the second part of the workflow - simulate placing the connectors over the new port
             this.ViewModel.ExecuteCommand(
@@ -550,6 +569,12 @@ namespace DynamoCoreWpfTests
             // Sanity check: we added 1 pin
             Assert.AreEqual(initialConnectorPinCount + 1, connectorViewModel.ConnectorPinViewCollection.Count);
             var pinModelGuid = connectorViewModel.ConnectorModel.ConnectorPinModels.First().GUID;
+            var expectedAnchorPoints = connectorViewModel.ConnectorPinViewCollection
+                .Select(pin => (
+                    X: pin.Left + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5),
+                    Y: pin.Top + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5)))
+                .OrderBy(point => point.X)
+                .ToList();
 
             // Begin reconnection – simulate grabbing the connector and starting a shift drag
             var connectorGuid = connectorViewModel.ConnectorModel.GUID;
@@ -571,6 +596,18 @@ namespace DynamoCoreWpfTests
             activeConnector.Redraw(new Point2D(650, 350));
             Assert.IsNotNull(activeConnector.ComputedBezierPathGeometry);
             Assert.Greater(activeConnector.ComputedBezierPathGeometry.Figures.Count, 1);
+            var transientSegmentEndPoints = activeConnector.ComputedBezierPathGeometry.Figures
+                .SelectMany(figure => figure.Segments.OfType<System.Windows.Media.BezierSegment>())
+                .Select(segment => segment.Point3)
+                .ToList();
+            foreach (var expected in expectedAnchorPoints)
+            {
+                Assert.IsTrue(
+                    transientSegmentEndPoints.Any(point =>
+                        Math.Abs(point.X - expected.X) < 0.001 &&
+                        Math.Abs(point.Y - expected.Y) < 0.001),
+                    $"Expected transient path to include cached anchor point ({expected.X}, {expected.Y}).");
+            }
 
             // Execute the second part of the workflow - simulate placing the connectors over the new port
             this.ViewModel.ExecuteCommand(

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -306,7 +306,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        public void ShiftReconnectionUsesNonInteractiveTransientPinsAndPersistsPins()
+        public void ShiftReconnectionUsesCachedTransientPinRoutingAndPersistsPins()
         {
             // Open a test graph with at least two connected nodes
             Open(@"UI/ConnectorPinTests.dyn");
@@ -339,11 +339,15 @@ namespace DynamoCoreWpfTests
                 .OfType<ConnectorViewModel>()
                 .FirstOrDefault(c => c.IsConnecting);
 
-            // Assert that during shift reconnection, a transient connector is created that has the same number of pins
+            // Assert that during shift reconnection, transient connector does not create pin VMs.
             Assert.IsNotNull(activeConnector);
             Assert.IsNull(activeConnector.ConnectorModel, "Expected active connector to be transient during drag.");
-            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
-            Assert.IsTrue(activeConnector.ConnectorPinViewCollection.All(pin => !pin.IsInteractive));
+            Assert.AreEqual(0, activeConnector.ConnectorPinViewCollection.Count);
+
+            // Cached routing points should still produce a multi-segment wire path while dragging.
+            activeConnector.Redraw(new Point2D(650, 350));
+            Assert.IsNotNull(activeConnector.ComputedBezierPathGeometry);
+            Assert.Greater(activeConnector.ComputedBezierPathGeometry.Figures.Count, 1);
 
             // Execute the second part of the workflow - simulate placing the connectors over the new port
             this.ViewModel.ExecuteCommand(
@@ -562,7 +566,7 @@ namespace DynamoCoreWpfTests
                 .OfType<ConnectorViewModel>()
                 .FirstOrDefault(c => c.IsConnecting);
             Assert.IsNotNull(activeConnector);
-            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
+            Assert.AreEqual(0, activeConnector.ConnectorPinViewCollection.Count);
 
             activeConnector.Redraw(new Point2D(650, 350));
             Assert.IsNotNull(activeConnector.ComputedBezierPathGeometry);


### PR DESCRIPTION
### Purpose

This PR addresses a performance lag experienced when disconnecting a connector with a large number of pins. The lag was caused by the synchronous creation and disposal of `ConnectorPinModel` and `ConnectorPinViewModel` objects for the transient connector that appears during the drag operation.

This change implements "Option 2" from the discussion: to eliminate the creation of transient pin view models. Instead, the transient connector now caches the pin routing points and uses these cached points directly to draw the Bezier curve, significantly reducing object churn and improving UI responsiveness during connector reconnection.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Improved UI responsiveness and reduced lag when disconnecting and reconnecting connectors, especially those with many pins. The transient connector no longer creates temporary pin objects, instead drawing its path directly from cached pin positions.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of

---
<p><a href="https://cursor.com/agents/bc-561ca543-6212-443a-9a9e-8a1b58fb082c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-561ca543-6212-443a-9a9e-8a1b58fb082c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

