### PR TITLE
Pin model caching

### DIFF
--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -43,7 +43,7 @@ namespace Dynamo.Models
 
         private PortModel[] activeStartPorts;
         private PortModel firstStartPort;
-        private Dictionary<Guid, List<(double X, double Y)>> reconnectionPinLocationsByStartPortId;
+        private Dictionary<Guid, List<ConnectorPinModel>> reconnectionPinModelsByStartPortId;
 
         protected virtual void OpenFileImpl(OpenFileCommand command)
         {
@@ -374,7 +374,7 @@ namespace Dynamo.Models
         {
             bool isInPort = portType == PortType.Input;
             activeStartPorts = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinModelsByStartPortId = null;
 
             if (CurrentWorkspace.GetModelInternal(nodeId) is not NodeModel node)
                 return;
@@ -414,7 +414,7 @@ namespace Dynamo.Models
 
         private void BeginDuplicateConnection(Guid nodeId, int portIndex, PortType portType)
         {
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinModelsByStartPortId = null;
 
             // If the port clicked is an output port, begin connection as per normal
             if (portType == PortType.Output)
@@ -446,7 +446,7 @@ namespace Dynamo.Models
         {
             if (portType == PortType.Input) return; //only handle multiple connections when the port selected is an output port
             if (!(CurrentWorkspace.GetModelInternal(nodeId) is NodeModel node)) return;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinModelsByStartPortId = null;
 
             PortModel selectedPort = node.OutPorts[portIndex];
 
@@ -491,12 +491,12 @@ namespace Dynamo.Models
             var models = GetConnectorsToAddAndDelete(
                 portModel,
                 activeStartPorts[0],
-                ConsumeReconnectionPinLocations(activeStartPorts[0]));
+                ConsumeReconnectionPinModels(activeStartPorts[0]));
 
             WorkspaceModel.RecordModelsForUndo(models, CurrentWorkspace.UndoRecorder);
             activeStartPorts = null;
             firstStartPort = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinModelsByStartPortId = null;
         }
 
         private void EndShiftReconnections(Guid nodeId, int portIndex, PortType portType)
@@ -510,13 +510,13 @@ namespace Dynamo.Models
             var firstModel = GetConnectorsToAddAndDelete(
                 selectedPort,
                 activeStartPorts[0],
-                ConsumeReconnectionPinLocations(activeStartPorts[0]));
+                ConsumeReconnectionPinModels(activeStartPorts[0]));
             for (int i = 1; i < activeStartPorts.Count(); i++)
             {
                 var models = GetConnectorsToAddAndDelete(
                     selectedPort,
                     activeStartPorts[i],
-                    ConsumeReconnectionPinLocations(activeStartPorts[i]));
+                    ConsumeReconnectionPinModels(activeStartPorts[i]));
                 foreach (var m in models)
                 {
                     firstModel.Add(m.Key, m.Value);
@@ -524,7 +524,7 @@ namespace Dynamo.Models
             }
             WorkspaceModel.RecordModelsForUndo(firstModel, CurrentWorkspace.UndoRecorder);
             activeStartPorts = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinModelsByStartPortId = null;
             return;
         }
 
@@ -546,14 +546,14 @@ namespace Dynamo.Models
             CurrentWorkspace.DeleteSavedModels();
             activeStartPorts = null;
             firstStartPort = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinModelsByStartPortId = null;
             return;
         }
 
         private static Dictionary<ModelBase, UndoRedoRecorder.UserAction> GetConnectorsToAddAndDelete(
             PortModel endPort,
             PortModel startPort,
-            IEnumerable<(double X, double Y)> pinLocations = null)
+            IEnumerable<ConnectorPinModel> pinModels = null)
         {
             ConnectorModel connectorToRemove = null;
 
@@ -595,16 +595,11 @@ namespace Dynamo.Models
             {
                 models.Add(newConnectorModel, UndoRedoRecorder.UserAction.Creation);
 
-                if (pinLocations != null)
+                if (pinModels != null)
                 {
-                    foreach (var pinLocation in pinLocations)
+                    foreach (var connectorPinModel in pinModels.Where(pin => pin != null).Distinct())
                     {
-                        var connectorPinModel = new ConnectorPinModel(
-                            pinLocation.X,
-                            pinLocation.Y,
-                            Guid.NewGuid(),
-                            newConnectorModel.GUID);
-
+                        connectorPinModel.ConnectorId = newConnectorModel.GUID;
                         newConnectorModel.AddPin(connectorPinModel);
                         models.Add(connectorPinModel, UndoRedoRecorder.UserAction.Creation);
                     }
@@ -620,24 +615,24 @@ namespace Dynamo.Models
                 return;
             }
 
-            reconnectionPinLocationsByStartPortId ??= new Dictionary<Guid, List<(double X, double Y)>>();
-            reconnectionPinLocationsByStartPortId[activeStartPort.GUID] = connector.GetPinLocations().ToList();
+            reconnectionPinModelsByStartPortId ??= new Dictionary<Guid, List<ConnectorPinModel>>();
+            reconnectionPinModelsByStartPortId[activeStartPort.GUID] = connector.ConnectorPinModels.ToList();
         }
 
-        private IEnumerable<(double X, double Y)> ConsumeReconnectionPinLocations(PortModel activeStartPort)
+        private IEnumerable<ConnectorPinModel> ConsumeReconnectionPinModels(PortModel activeStartPort)
         {
-            if (activeStartPort == null || reconnectionPinLocationsByStartPortId == null)
+            if (activeStartPort == null || reconnectionPinModelsByStartPortId == null)
             {
-                return Array.Empty<(double X, double Y)>();
+                return Array.Empty<ConnectorPinModel>();
             }
 
-            if (!reconnectionPinLocationsByStartPortId.TryGetValue(activeStartPort.GUID, out var pinLocations))
+            if (!reconnectionPinModelsByStartPortId.TryGetValue(activeStartPort.GUID, out var pinModels))
             {
-                return Array.Empty<(double X, double Y)>();
+                return Array.Empty<ConnectorPinModel>();
             }
 
-            reconnectionPinLocationsByStartPortId.Remove(activeStartPort.GUID);
-            return pinLocations;
+            reconnectionPinModelsByStartPortId.Remove(activeStartPort.GUID);
+            return pinModels;
         }
 
         private void DeleteModelImpl(DeleteModelCommand command)

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Text;
+using System.Windows;
 using System.Windows.Media;
 using System.Windows.Shapes;
 using System.Windows.Threading;
@@ -57,6 +58,9 @@ namespace Dynamo.ViewModels
         private Point curvePoint3;
         private List<Point> transientConnectorPinPositions = new List<Point>();
         private Guid? reconnectionPinCacheKey;
+        private bool suppressConnectorPinCollectionRedraw;
+        private bool connectorPinRedrawScheduled;
+        private bool isDisposed;
 
         /// <summary>
         /// Required timer for desired delay prior to ' connector anchor' display.
@@ -1047,9 +1051,17 @@ namespace Dynamo.ViewModels
 
             if (connectorModel.ConnectorPinModels != null)
             {
-                foreach (var p in connectorModel.ConnectorPinModels)
+                suppressConnectorPinCollectionRedraw = true;
+                try
                 {
-                    AddConnectorPinViewModel(p);
+                    foreach (var p in connectorModel.ConnectorPinModels)
+                    {
+                        AddConnectorPinViewModel(p);
+                    }
+                }
+                finally
+                {
+                    suppressConnectorPinCollectionRedraw = false;
                 }
             }
 
@@ -1286,7 +1298,33 @@ namespace Dynamo.ViewModels
 
         private void HandleCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            Redraw();
+            if (suppressConnectorPinCollectionRedraw)
+            {
+                return;
+            }
+
+            QueueConnectorPinRedraw();
+        }
+
+        private void QueueConnectorPinRedraw()
+        {
+            if (connectorPinRedrawScheduled)
+            {
+                return;
+            }
+
+            connectorPinRedrawScheduled = true;
+            var dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+            dispatcher.BeginInvoke(DispatcherPriority.Render, new Action(() =>
+            {
+                connectorPinRedrawScheduled = false;
+                if (isDisposed)
+                {
+                    return;
+                }
+
+                Redraw();
+            }));
         }
 
         private void WorkspaceViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -1312,6 +1350,9 @@ namespace Dynamo.ViewModels
         /// </summary>
         public override void Dispose()
         {
+            isDisposed = true;
+            connectorPinRedrawScheduled = false;
+
             if (model != null)
             {
                 model.PropertyChanged -= HandleConnectorPropertyChanged;

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -55,6 +55,8 @@ namespace Dynamo.ViewModels
         private Point curvePoint1;
         private Point curvePoint2;
         private Point curvePoint3;
+        private List<Point> transientConnectorPinPositions = new List<Point>();
+        private Guid? reconnectionPinCacheKey;
 
         /// <summary>
         /// Required timer for desired delay prior to ' connector anchor' display.
@@ -1105,7 +1107,10 @@ namespace Dynamo.ViewModels
                 case NotifyCollectionChangedAction.Remove:
                     foreach (ConnectorPinModel oldItem in e.OldItems)
                     {
-                        RemoveConnectorPinModelViewModel(oldItem);
+                        if (!TryCacheConnectorPinViewModelForReconnection(oldItem))
+                        {
+                            RemoveConnectorPinModelViewModel(oldItem);
+                        }
                     }
                     break;
                 default: break;
@@ -1117,7 +1122,7 @@ namespace Dynamo.ViewModels
         /// <param name="connectorPin"></param>
         private void RemoveConnectorPinModelViewModel(ConnectorPinModel connectorPin)
         {
-            var matchingConnectorPinViewModel = this.workspaceViewModel.Pins.FirstOrDefault(x => x.Model.GUID == connectorPin.GUID);
+            var matchingConnectorPinViewModel = ConnectorPinViewCollection.FirstOrDefault(x => x.Model.GUID == connectorPin.GUID);
             if (matchingConnectorPinViewModel is null) return;
             RemoveConnectorPinModelViewModel(matchingConnectorPinViewModel);
         }
@@ -1128,10 +1133,7 @@ namespace Dynamo.ViewModels
         /// <param name="connectorPinViewModel"></param>
         private void RemoveConnectorPinModelViewModel(ConnectorPinViewModel connectorPinViewModel)
         {
-            connectorPinViewModel.PropertyChanged -= PinViewModelPropertyChanged;
-            connectorPinViewModel.RequestSelect -= HandleRequestSelected;
-            connectorPinViewModel.RequestRedraw -= HandlerRedrawRequest;
-            connectorPinViewModel.RequestRemove -= HandleConnectorPinViewModelRemove;
+            DetachConnectorPinViewModelEvents(connectorPinViewModel);
             workspaceViewModel.Pins.Remove(connectorPinViewModel);
             ConnectorPinViewCollection.Remove(connectorPinViewModel);
 
@@ -1147,23 +1149,95 @@ namespace Dynamo.ViewModels
         /// <param name="pinModel"></param>
         private void AddConnectorPinViewModel(ConnectorPinModel pinModel, bool isTransientPin = false)
         {
-            var pinViewModel = new ConnectorPinViewModel(this.workspaceViewModel, pinModel)
+            ConnectorPinViewModel pinViewModel = null;
+            if (workspaceViewModel.TryConsumeCachedConnectorPinViewModel(pinModel.GUID, out var cachedPinViewModel))
             {
-                IsHidden = this.IsHidden,
-                IsTemporarilyVisible = isTemporarilyVisible,
-                IsInteractive = !isTransientPin
-            };
-            pinViewModel.PropertyChanged += PinViewModelPropertyChanged;
+                if (ReferenceEquals(cachedPinViewModel.Model, pinModel))
+                {
+                    pinViewModel = cachedPinViewModel;
+                }
+                else
+                {
+                    workspaceViewModel.Pins.Remove(cachedPinViewModel);
+                    cachedPinViewModel.Model?.Dispose();
+                    cachedPinViewModel.Dispose();
+                }
+            }
 
+            if (pinViewModel == null)
+            {
+                pinViewModel = new ConnectorPinViewModel(this.workspaceViewModel, pinModel);
+            }
+
+            pinViewModel.IsHidden = this.IsHidden;
+            pinViewModel.IsTemporarilyVisible = isTemporarilyVisible;
+            pinViewModel.IsInteractive = !isTransientPin;
+            AttachConnectorPinViewModelEvents(pinViewModel, isTransientPin);
+
+            if (!workspaceViewModel.Pins.Contains(pinViewModel))
+            {
+                workspaceViewModel.Pins.Add(pinViewModel);
+            }
+
+            if (!ConnectorPinViewCollection.Contains(pinViewModel))
+            {
+                ConnectorPinViewCollection.Add(pinViewModel);
+            }
+        }
+
+        private void AttachConnectorPinViewModelEvents(ConnectorPinViewModel pinViewModel, bool isTransientPin)
+        {
+            pinViewModel.PropertyChanged -= PinViewModelPropertyChanged;
+            pinViewModel.RequestSelect -= HandleRequestSelected;
+            pinViewModel.RequestRedraw -= HandlerRedrawRequest;
+            pinViewModel.RequestRemove -= HandleConnectorPinViewModelRemove;
+
+            pinViewModel.PropertyChanged += PinViewModelPropertyChanged;
             pinViewModel.RequestSelect += HandleRequestSelected;
             pinViewModel.RequestRedraw += HandlerRedrawRequest;
             if (!isTransientPin)
             {
                 pinViewModel.RequestRemove += HandleConnectorPinViewModelRemove;
             }
+        }
 
-            workspaceViewModel.Pins.Add(pinViewModel);
-            ConnectorPinViewCollection.Add(pinViewModel);
+        private void DetachConnectorPinViewModelEvents(ConnectorPinViewModel pinViewModel)
+        {
+            pinViewModel.PropertyChanged -= PinViewModelPropertyChanged;
+            pinViewModel.RequestSelect -= HandleRequestSelected;
+            pinViewModel.RequestRedraw -= HandlerRedrawRequest;
+            pinViewModel.RequestRemove -= HandleConnectorPinViewModelRemove;
+        }
+
+        private bool TryCacheConnectorPinViewModelForReconnection(ConnectorPinModel connectorPin)
+        {
+            if (!reconnectionPinCacheKey.HasValue)
+            {
+                return false;
+            }
+
+            var matchingConnectorPinViewModel = ConnectorPinViewCollection.FirstOrDefault(x => x.Model.GUID == connectorPin.GUID);
+            if (matchingConnectorPinViewModel == null)
+            {
+                return false;
+            }
+
+            DetachConnectorPinViewModelEvents(matchingConnectorPinViewModel);
+            ConnectorPinViewCollection.Remove(matchingConnectorPinViewModel);
+
+            if (ConnectorPinViewCollection.Count == 0)
+            {
+                BezierControlPoints = null;
+            }
+
+            matchingConnectorPinViewModel.IsInteractive = false;
+            workspaceViewModel.CacheConnectorPinViewModelForReconnection(reconnectionPinCacheKey.Value, matchingConnectorPinViewModel);
+            return true;
+        }
+
+        internal void BeginReconnectionPinCaching(Guid cacheKey)
+        {
+            reconnectionPinCacheKey = cacheKey;
         }
 
         /// <summary>
@@ -1271,8 +1345,7 @@ namespace Dynamo.ViewModels
 
                 foreach (var pin in ConnectorPinViewCollection.ToList())
                 {
-                    pin.RequestRedraw -= HandlerRedrawRequest;
-                    pin.RequestSelect -= HandleRequestSelected;
+                    DetachConnectorPinViewModelEvents(pin);
                 }
             }
 
@@ -1287,6 +1360,9 @@ namespace Dynamo.ViewModels
             {
                 ConnectorAnchorViewModel.Dispose();
             }
+
+            reconnectionPinCacheKey = null;
+            transientConnectorPinPositions.Clear();
             base.Dispose();
         }
 
@@ -1455,8 +1531,9 @@ namespace Dynamo.ViewModels
         /// to all previous pins is required for undo/redo recorder.</param>
         internal void DiscardAllConnectorPinModels(List<ModelBase> allDeletedModels = null)
         {
-            foreach (var pin in ConnectorPinViewCollection)
+            foreach (var pin in ConnectorPinViewCollection.ToList())
             {
+                DetachConnectorPinViewModelEvents(pin);
                 workspaceViewModel.Pins.Remove(pin);
                 ConnectorModel?.RemovePin(pin.Model);
 
@@ -1489,9 +1566,10 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Creates transient pin visuals for a temporary connector (ConnectorModel == null).
+        /// Caches pin positions for a temporary connector (ConnectorModel == null),
+        /// preserving the original pin view models while still routing through the same points.
         /// </summary>
-        /// <param name="pinLocations">Pin top-left canvas coordinates.</param>
+        /// <param name="pinLocations">Pin model canvas coordinates.</param>
         internal void SetTransientConnectorPinPositions(IEnumerable<(double X, double Y)> pinLocations)
         {
             if (ConnectorModel != null || pinLocations == null)
@@ -1499,17 +1577,42 @@ namespace Dynamo.ViewModels
                 return;
             }
 
-            DiscardAllConnectorPinModels();
-            foreach (var pinLocation in pinLocations)
-            {
-                var transientPinModel = new ConnectorPinModel(
-                    pinLocation.X,
-                    pinLocation.Y,
-                    Guid.NewGuid(),
-                    Guid.Empty);
+            transientConnectorPinPositions = pinLocations
+                .Select(pinLocation => new Point(pinLocation.X, pinLocation.Y))
+                .ToList();
+        }
 
-                AddConnectorPinViewModel(transientPinModel, true);
+        private bool HasConnectorPinRoutingData()
+        {
+            return (ConnectorPinViewCollection?.Count > 0) ||
+                (ConnectorModel == null && transientConnectorPinPositions.Count > 0);
+        }
+
+        private List<Point> CollectPinRoutingPoints()
+        {
+            if (ConnectorPinViewCollection?.Count > 0)
+            {
+                return ConnectorPinViewCollection
+                    .Select(wirePin => new Point(
+                        wirePin.Left + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5),
+                        wirePin.Top + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5)))
+                    .ToList();
             }
+
+            if (ConnectorModel == null && transientConnectorPinPositions.Count > 0)
+            {
+                return transientConnectorPinPositions
+                    .Select(pinPosition =>
+                    {
+                        var pinTop = pinPosition.Y - ConnectorPinViewModel.OneThirdWidth;
+                        return new Point(
+                            pinPosition.X + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5),
+                            pinTop + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5));
+                    })
+                    .ToList();
+            }
+
+            return new List<Point>();
         }
 
         #region ConnectorRedraw
@@ -1521,7 +1624,7 @@ namespace Dynamo.ViewModels
         {
             try
             {
-                if (ConnectorPinViewCollection?.Count > 0)
+                if (HasConnectorPinRoutingData())
                 {
                     if (this.ConnectorModel?.End != null)
                     {
@@ -1575,7 +1678,7 @@ namespace Dynamo.ViewModels
         /// <param name="parameter">The position of the end point</param>
         public void Redraw(object parameter)
         {
-            if (ConnectorPinViewCollection?.Count > 0)
+            if (HasConnectorPinRoutingData())
             {
                 RedrawBezierManyPoints(parameter);
                 return;
@@ -1714,13 +1817,10 @@ namespace Dynamo.ViewModels
                 dotTop = CurvePoint3.Y - EndDotSize / 2;
                 dotLeft = CurvePoint3.X - EndDotSize / 2;
 
-                // Add chain of points including start/end
-                Point[] points = new Point[ConnectorPinViewCollection.Count];
-                int count = 0;
-                foreach (var wirePin in ConnectorPinViewCollection)
+                var points = CollectPinRoutingPoints().ToArray();
+                if (points.Length == 0)
                 {
-                    points[count] = new Point(wirePin.Left+ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5), wirePin.Top+ ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5));
-                    count++;
+                    return;
                 }
 
                 var isInputStartReconnection = ActiveStartPort?.PortType == PortType.Input;

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -61,6 +61,8 @@ namespace Dynamo.ViewModels
         private bool suppressConnectorPinCollectionRedraw;
         private bool connectorPinRedrawScheduled;
         private bool isDisposed;
+        private bool cachedPinAttachmentScheduled;
+        private readonly List<ConnectorPinModel> queuedCachedPinsToAttach = new List<ConnectorPinModel>();
 
         /// <summary>
         /// Required timer for desired delay prior to ' connector anchor' display.
@@ -1113,12 +1115,20 @@ namespace Dynamo.ViewModels
                 case NotifyCollectionChangedAction.Add:
                     foreach (ConnectorPinModel newItem in e.NewItems)
                     {
-                        AddConnectorPinViewModel(newItem);
+                        if (workspaceViewModel.HasCachedConnectorPinViewModel(newItem.GUID))
+                        {
+                            QueueCachedPinAttachment(newItem);
+                        }
+                        else
+                        {
+                            AddConnectorPinViewModel(newItem);
+                        }
                     }
                     break;
                 case NotifyCollectionChangedAction.Remove:
                     foreach (ConnectorPinModel oldItem in e.OldItems)
                     {
+                        queuedCachedPinsToAttach.RemoveAll(pin => pin.GUID == oldItem.GUID);
                         if (!TryCacheConnectorPinViewModelForReconnection(oldItem))
                         {
                             RemoveConnectorPinModelViewModel(oldItem);
@@ -1127,6 +1137,54 @@ namespace Dynamo.ViewModels
                     break;
                 default: break;
             }
+        }
+
+        private void QueueCachedPinAttachment(ConnectorPinModel pinModel)
+        {
+            if (pinModel == null)
+            {
+                return;
+            }
+
+            if (queuedCachedPinsToAttach.All(pin => pin.GUID != pinModel.GUID))
+            {
+                queuedCachedPinsToAttach.Add(pinModel);
+            }
+
+            if (cachedPinAttachmentScheduled)
+            {
+                return;
+            }
+
+            cachedPinAttachmentScheduled = true;
+            var dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+            dispatcher.BeginInvoke(DispatcherPriority.Render, new Action(FlushQueuedCachedPinAttachments));
+        }
+
+        private void FlushQueuedCachedPinAttachments()
+        {
+            cachedPinAttachmentScheduled = false;
+            if (isDisposed || queuedCachedPinsToAttach.Count == 0)
+            {
+                queuedCachedPinsToAttach.Clear();
+                return;
+            }
+
+            suppressConnectorPinCollectionRedraw = true;
+            try
+            {
+                foreach (var pinModel in queuedCachedPinsToAttach.ToList())
+                {
+                    AddConnectorPinViewModel(pinModel);
+                }
+            }
+            finally
+            {
+                queuedCachedPinsToAttach.Clear();
+                suppressConnectorPinCollectionRedraw = false;
+            }
+
+            QueueConnectorPinRedraw();
         }
         /// <summary>
         /// Removes connectorPinViewModel, given a model
@@ -1352,6 +1410,8 @@ namespace Dynamo.ViewModels
         {
             isDisposed = true;
             connectorPinRedrawScheduled = false;
+            cachedPinAttachmentScheduled = false;
+            queuedCachedPinsToAttach.Clear();
 
             if (model != null)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -202,6 +202,8 @@ namespace Dynamo.ViewModels
             if (portModel.Connectors.Count > 0 && portModel.Connectors[0].Start != portModel)
             {
                 var existingConnector = portModel.Connectors[0];
+                var existingConnectorViewModel = Connectors.FirstOrDefault(c => c.ConnectorModel == existingConnector);
+                existingConnectorViewModel?.BeginReconnectionPinCaching(existingConnector.Start.GUID);
 
                 // Define the new active connector
                 var activeConnector = new ConnectorViewModel(this, existingConnector.Start);
@@ -248,6 +250,8 @@ namespace Dynamo.ViewModels
             for (int i = 0; i < selectedConnectors.Count; i++)
             {
                 var selectedConnector = selectedConnectors[i];
+                var selectedConnectorViewModel = Connectors.FirstOrDefault(c => c.ConnectorModel == selectedConnector);
+                selectedConnectorViewModel?.BeginReconnectionPinCaching(selectedConnector.End.GUID);
                 var c = new ConnectorViewModel(this, selectedConnector.End);
                 c.SetTransientConnectorPinPositions(selectedConnector.GetPinLocations());
                 c.Redraw(selectedConnector.Start.Center);
@@ -319,6 +323,7 @@ namespace Dynamo.ViewModels
         {
             multipleConnections = false;
             this.SetActiveConnectors(null);
+            DiscardCachedConnectorPinViewModels();
             firstStartPort = null;
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -961,6 +961,11 @@ namespace Dynamo.ViewModels
             return true;
         }
 
+        internal bool HasCachedConnectorPinViewModel(Guid pinGuid)
+        {
+            return cachedConnectorPinsByPinGuid.ContainsKey(pinGuid);
+        }
+
         internal void DiscardCachedConnectorPinViewModels()
         {
             var cachedPins = cachedConnectorPinsByPinGuid.Values.Distinct().ToList();

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -303,6 +303,10 @@ namespace Dynamo.ViewModels
         [JsonIgnore]
         public ObservableCollection<ConnectorPinViewModel> Pins { get; } = new ObservableCollection<ConnectorPinViewModel>();
 
+        // Stores detached pin view models while connector reconnection is in flight.
+        private readonly Dictionary<Guid, ConnectorPinViewModel> cachedConnectorPinsByPinGuid = new();
+        private readonly Dictionary<Guid, HashSet<Guid>> cachedPinGuidsByReconnectionKey = new();
+
         [JsonIgnore]
         public ObservableCollection<InfoBubbleViewModel> Errors { get; } = new ObservableCollection<InfoBubbleViewModel>();
         public ObservableCollection<AnnotationViewModel> Annotations { get; } = new ObservableCollection<AnnotationViewModel>();
@@ -753,6 +757,7 @@ namespace Dynamo.ViewModels
             Annotations.ToList().ForEach(AnnotationViewModel => AnnotationViewModel.Dispose());
             Nodes.Clear();
             Notes.Clear();
+            DiscardCachedConnectorPinViewModels();
             Pins.Clear();
             Connectors.Clear();
             Errors.Clear();
@@ -920,6 +925,53 @@ namespace Dynamo.ViewModels
             {
                 Connectors.Remove(connector);
                 connector.Dispose();
+            }
+        }
+
+        internal void CacheConnectorPinViewModelForReconnection(Guid reconnectionKey, ConnectorPinViewModel pinViewModel)
+        {
+            if (pinViewModel == null)
+            {
+                return;
+            }
+
+            cachedConnectorPinsByPinGuid[pinViewModel.Model.GUID] = pinViewModel;
+            if (!cachedPinGuidsByReconnectionKey.TryGetValue(reconnectionKey, out var pinGuids))
+            {
+                pinGuids = new HashSet<Guid>();
+                cachedPinGuidsByReconnectionKey[reconnectionKey] = pinGuids;
+            }
+
+            pinGuids.Add(pinViewModel.Model.GUID);
+        }
+
+        internal bool TryConsumeCachedConnectorPinViewModel(Guid pinGuid, out ConnectorPinViewModel pinViewModel)
+        {
+            if (!cachedConnectorPinsByPinGuid.TryGetValue(pinGuid, out pinViewModel))
+            {
+                return false;
+            }
+
+            cachedConnectorPinsByPinGuid.Remove(pinGuid);
+            foreach (var pinGuids in cachedPinGuidsByReconnectionKey.Values)
+            {
+                pinGuids.Remove(pinGuid);
+            }
+
+            return true;
+        }
+
+        internal void DiscardCachedConnectorPinViewModels()
+        {
+            var cachedPins = cachedConnectorPinsByPinGuid.Values.Distinct().ToList();
+            cachedConnectorPinsByPinGuid.Clear();
+            cachedPinGuidsByReconnectionKey.Clear();
+
+            foreach (var pinViewModel in cachedPins)
+            {
+                Pins.Remove(pinViewModel);
+                pinViewModel.Model?.Dispose();
+                pinViewModel.Dispose();
             }
         }
 

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -6,6 +6,7 @@ using Dynamo.Models;
 using Dynamo.Selection;
 using Dynamo.Utilities;
 using Dynamo.ViewModels;
+using DynamoCoreWpfTests.Utility;
 using NUnit.Framework;
 using static Dynamo.Models.DynamoModel;
 
@@ -352,6 +353,7 @@ namespace DynamoCoreWpfTests
             this.ViewModel.ExecuteCommand(
                 new DynamoModel.MakeConnectionCommand(codeblock.GUID, 0, PortType.Output,
                 MakeConnectionCommand.Mode.EndShiftReconnections));
+            DispatcherUtil.DoEvents();
 
             // Assert that after reconnection, the new connector has the same number of pins and they are interactive
             var connectorAfterReconnect = this.ViewModel.CurrentSpaceViewModel.Connectors;
@@ -580,6 +582,7 @@ namespace DynamoCoreWpfTests
             this.ViewModel.ExecuteCommand(
                 new DynamoModel.MakeConnectionCommand(codeblock.GUID, 0, PortType.Output,
                 MakeConnectionCommand.Mode.EndShiftReconnections));
+            DispatcherUtil.DoEvents();
 
             // Validate that the newly reconnected connector persists equivalent pins.
             var connectorAfterReconnect = this.ViewModel.CurrentSpaceViewModel.Connectors;

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -325,6 +325,8 @@ namespace DynamoCoreWpfTests
 
             // Assert that the pin was added
             Assert.AreEqual(initialConnectorPinCount + 1, connectorViewModel.ConnectorPinViewCollection.Count);
+            var cachedPinViewModel = connectorViewModel.ConnectorPinViewCollection.First();
+            var cachedPinModel = cachedPinViewModel.Model;
 
             // Begin reconnection – simulate grabbing the connector and starting a shift drag
             var startPort = connectorViewModel.ConnectorModel.Start;
@@ -342,8 +344,9 @@ namespace DynamoCoreWpfTests
             // Assert that during shift reconnection, a transient connector is created that has the same number of pins
             Assert.IsNotNull(activeConnector);
             Assert.IsNull(activeConnector.ConnectorModel, "Expected active connector to be transient during drag.");
-            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
-            Assert.IsTrue(activeConnector.ConnectorPinViewCollection.All(pin => !pin.IsInteractive));
+            Assert.AreEqual(0, activeConnector.ConnectorPinViewCollection.Count);
+            Assert.IsTrue(this.ViewModel.CurrentSpaceViewModel.Pins.Contains(cachedPinViewModel));
+            Assert.IsFalse(cachedPinViewModel.IsInteractive);
 
             // Execute the second part of the workflow - simulate placing the connectors over the new port
             this.ViewModel.ExecuteCommand(
@@ -355,6 +358,8 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, connectorAfterReconnect.Count());
             Assert.AreEqual(initialConnectorPinCount + 1, connectorAfterReconnect.First().ConnectorPinViewCollection.Count);
             Assert.IsTrue(connectorAfterReconnect.First().ConnectorPinViewCollection.All(pin => pin.IsInteractive));
+            Assert.AreSame(cachedPinModel, connectorAfterReconnect.First().ConnectorModel.ConnectorPinModels.First());
+            Assert.AreSame(cachedPinViewModel, connectorAfterReconnect.First().ConnectorPinViewCollection.First());
         }
         #endregion
 
@@ -545,6 +550,7 @@ namespace DynamoCoreWpfTests
 
             // Sanity check: we added 1 pin
             Assert.AreEqual(initialConnectorPinCount + 1, connectorViewModel.ConnectorPinViewCollection.Count);
+            var pinViewModelBeforeReconnect = connectorViewModel.ConnectorPinViewCollection.First();
             var pinModelGuid = connectorViewModel.ConnectorModel.ConnectorPinModels.First().GUID;
 
             // Begin reconnection – simulate grabbing the connector and starting a shift drag
@@ -562,7 +568,9 @@ namespace DynamoCoreWpfTests
                 .OfType<ConnectorViewModel>()
                 .FirstOrDefault(c => c.IsConnecting);
             Assert.IsNotNull(activeConnector);
-            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
+            Assert.AreEqual(0, activeConnector.ConnectorPinViewCollection.Count);
+            Assert.IsTrue(this.ViewModel.CurrentSpaceViewModel.Pins.Contains(pinViewModelBeforeReconnect));
+            Assert.IsFalse(pinViewModelBeforeReconnect.IsInteractive);
 
             activeConnector.Redraw(new Point2D(650, 350));
             Assert.IsNotNull(activeConnector.ComputedBezierPathGeometry);
@@ -577,6 +585,7 @@ namespace DynamoCoreWpfTests
             var connectorAfterReconnect = this.ViewModel.CurrentSpaceViewModel.Connectors;
             Assert.AreEqual(1, connectorAfterReconnect.Count());
             Assert.AreEqual(initialConnectorPinCount + 1, connectorAfterReconnect.First().ConnectorPinViewCollection.Count());
+            Assert.AreSame(pinViewModelBeforeReconnect, connectorAfterReconnect.First().ConnectorPinViewCollection.First());
 
             // --- Undo ---
             Model.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));


### PR DESCRIPTION
### Purpose

This PR implements an alternative approach to handling connector pins during disconnection and reconnection. Instead of disposing and recreating `ConnectorPinModel` and `ConnectorPinViewModel` instances, this change introduces a caching mechanism to reuse these instances, aiming for improved performance and a smoother user experience. This builds upon the previous work in commits dbe33edc8f, f677a45ff6, 3061668618, 133fe25b59, and dc3c36366a by preventing pin recreation.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Refactored connector reconnection logic to reuse existing pin models and view models instead of recreating them. This change aims to provide a smoother and more consistent visual experience when disconnecting and reconnecting connectors, as pin behavior is now preserved across the operation.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

*   **Cache PinModels instead of recreating them:** `DynamoModelCommands.cs` now caches `ConnectorPinModel` instances and reattaches them to new connectors, eliminating recreation.
*   **Cache transient routing positions separately:** `ConnectorViewModel.cs` now stores transient connector pin positions in memory for Bezier curve rendering, avoiding the creation of temporary pin models/viewmodels.
*   **Keep pin viewmodels alive during connector disposal/reconnection:** `ConnectorViewModel.cs`, `WorkspaceViewModel.cs`, and `StateMachine.cs` implement a workspace-level cache for detached pin VMs, preventing their disposal during reconnection and keeping them visible.
*   **Rebind cached pin VMs to new permanent connector:** `ConnectorViewModel.cs` reuses cached `ConnectorPinViewModel` instances, reattaching event handlers and restoring interactivity.
*   **State-machine wiring:** `StateMachine.cs` manages the reconnection pin caching mode for source connector VMs and handles cleanup on cancel.
*   **Tests updated for new behavior:** `ConnectorViewModelTests.cs` has been updated to validate pin model and view model instance reuse.

---
<p><a href="https://cursor.com/agents/bc-79fe02e1-d111-4cc3-958c-450a53c6d1b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79fe02e1-d111-4cc3-958c-450a53c6d1b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

