### PR TITLE
Connector pin recreation

### DIFF
--- a/src/DynamoCore/Core/UndoRedoRecorder.cs
+++ b/src/DynamoCore/Core/UndoRedoRecorder.cs
@@ -290,7 +290,7 @@ namespace Dynamo.Core
         /// <param name="model">The model to check against.</param>
         /// <returns>Returns true if the model has already been recorded in the
         /// current action group, or false otherwise.</returns>
-        private bool IsRecordedInActionGroup(XmlElement group, ModelBase model)
+        private bool IsRecordedInActionGroup(XmlElement group, ModelBase model, UserAction action)
         {
             if (null == group)
                 throw new ArgumentNullException("group");
@@ -306,7 +306,18 @@ namespace Dynamo.Core
                 // 
                 XmlAttribute guidAttribute = childNode.Attributes["guid"];
                 if (null != guidAttribute && (guid == Guid.Parse(guidAttribute.Value)))
-                    return true; // This model was found to be recorded.
+                {
+                    // Allow the same model to be recorded with a different action
+                    // in the same group (e.g., pin transfer during reconnection).
+                    var actionAttribute = childNode.Attributes[UserActionAttrib];
+                    if (actionAttribute == null)
+                        return true;
+
+                    var existingAction =
+                        (UserAction)Enum.Parse(typeof(UserAction), actionAttribute.Value);
+                    if (existingAction == action)
+                        return true; // This model was found to be recorded with same action.
+                }
             }
 
             return false;
@@ -343,7 +354,7 @@ namespace Dynamo.Core
 
         private void RecordActionInternal(XmlElement group, ModelBase model, UserAction action)
         {
-            if (IsRecordedInActionGroup(group, model))
+            if (IsRecordedInActionGroup(group, model, action))
                 return;
 
             // Serialize the affected model into xml representation

--- a/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
+++ b/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
@@ -62,6 +62,12 @@ namespace Dynamo.Graph.Connectors
                 RaisePropertyChanged(nameof(IsTransient));
             }
         }
+
+        /// <summary>
+        /// Indicates that connector pins should not be deleted when this connector
+        /// is being removed as part of a reconnection operation.
+        /// </summary>
+        internal bool PreservePinsOnDeleteForReconnection { get; set; } = false;
         
         /// <summary>
         /// Returns start port model.
@@ -136,6 +142,19 @@ namespace Dynamo.Graph.Connectors
             return ConnectorPinModels
                 .Select(pin => (pin.X, pin.Y))
                 .ToList();
+        }
+
+        /// <summary>
+        /// Returns a snapshot of connector pins currently attached to this connector.
+        /// </summary>
+        internal IReadOnlyList<ConnectorPinModel> GetPinsSnapshot()
+        {
+            if (ConnectorPinModels == null || ConnectorPinModels.Count == 0)
+            {
+                return new List<ConnectorPinModel>();
+            }
+
+            return ConnectorPinModels.ToList();
         }
 
         #endregion 

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -157,7 +157,7 @@ namespace Dynamo.Graph.Workspaces
                     }
                     savedModels = null;
                 }
-                foreach (var modelPair in models)
+                foreach (var modelPair in GetUndoRecordingOrder(models))
                 {
                     switch (modelPair.Value)
                     {
@@ -173,6 +173,38 @@ namespace Dynamo.Graph.Workspaces
                     }
                 }
             }
+        }
+
+        private static IEnumerable<KeyValuePair<ModelBase, UndoRedoRecorder.UserAction>> GetUndoRecordingOrder(
+            Dictionary<ModelBase, UndoRedoRecorder.UserAction> models)
+        {
+            return models
+                .OrderBy(modelPair => GetActionRank(modelPair.Value))
+                .ThenBy(modelPair => GetModelRank(modelPair.Key, modelPair.Value))
+                .ThenBy(modelPair => modelPair.Key.GUID);
+        }
+
+        private static int GetActionRank(UndoRedoRecorder.UserAction action)
+        {
+            return action switch
+            {
+                UndoRedoRecorder.UserAction.Deletion => 0,
+                UndoRedoRecorder.UserAction.Modification => 1,
+                UndoRedoRecorder.UserAction.Creation => 2,
+                _ => 3
+            };
+        }
+
+        private static int GetModelRank(ModelBase model, UndoRedoRecorder.UserAction action)
+        {
+            return action switch
+            {
+                UndoRedoRecorder.UserAction.Creation when model is ConnectorModel => 0,
+                UndoRedoRecorder.UserAction.Creation when model is ConnectorPinModel => 1,
+                UndoRedoRecorder.UserAction.Deletion when model is ConnectorPinModel => 0,
+                UndoRedoRecorder.UserAction.Deletion when model is ConnectorModel => 1,
+                _ => 2
+            };
         }
 
         internal void RecordCreatedModel(ModelBase model)
@@ -411,13 +443,6 @@ namespace Dynamo.Graph.Workspaces
             else if (model is ConnectorModel)
             {
                 var connector = model as ConnectorModel;
-                if (connector.ConnectorPinModels.Count > 0)
-                {
-                    // Connector deletions coming through undo/redo should detach
-                    // pins in the view first, then let the corresponding pin
-                    // actions in the same undo group reconcile final ownership.
-                    connector.PreservePinsOnDeleteForReconnection = true;
-                }
                 connector.Delete();
             }
             else if (model is ConnectorPinModel connectorPin)

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -411,6 +411,13 @@ namespace Dynamo.Graph.Workspaces
             else if (model is ConnectorModel)
             {
                 var connector = model as ConnectorModel;
+                if (connector.ConnectorPinModels.Count > 0)
+                {
+                    // Connector deletions coming through undo/redo should detach
+                    // pins in the view first, then let the corresponding pin
+                    // actions in the same undo group reconcile final ownership.
+                    connector.PreservePinsOnDeleteForReconnection = true;
+                }
                 connector.Delete();
             }
             else if (model is ConnectorPinModel connectorPin)

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -197,7 +197,7 @@ namespace Dynamo.Graph.Workspaces
             }
         }
 
-        internal void RecordAndDeleteModels(List<ModelBase> models)
+        internal void RecordAndDeleteModels(List<ModelBase> models, bool preserveConnectorPins = false)
 
         {
             if (!ShouldProceedWithRecording(models))
@@ -285,7 +285,9 @@ namespace Dynamo.Graph.Workspaces
                     }
                     else if (model is ConnectorModel conn)
                     {
-                        if (conn.ConnectorPinModels.Count > 0)
+                        if (!preserveConnectorPins &&
+                            !conn.PreservePinsOnDeleteForReconnection &&
+                            conn.ConnectorPinModels.Count > 0)
                         {
                             foreach (var connectorPin in conn.ConnectorPinModels.ToList())
                             {
@@ -317,15 +319,35 @@ namespace Dynamo.Graph.Workspaces
 
         internal void SaveAndDeleteModels(List<ModelBase> models)
         {
+            SaveAndDeleteModels(models, preserveConnectorPins: false);
+        }
+
+        internal void SaveAndDeleteModels(List<ModelBase> models, bool preserveConnectorPins)
+        {
             if (null != models)
             {
-                // Add connector pins if any
-                var allPins = models
-                    .OfType<ConnectorModel>()
-                    .SelectMany(connector => connector.ConnectorPinModels)
-                    .Cast<ModelBase>()
-                    .ToList();
-                var fullSet = allPins.Concat(models).ToList();
+                List<ModelBase> fullSet;
+                if (preserveConnectorPins)
+                {
+                    // Capture pre-transfer pin snapshots so undo can recreate
+                    // the original pin-to-connector mapping if needed.
+                    var pinSnapshots = models
+                        .OfType<ConnectorModel>()
+                        .SelectMany(connector => connector.ConnectorPinModels)
+                        .Select(pin => (ModelBase)new ConnectorPinModel(pin.X, pin.Y, pin.GUID, pin.ConnectorId))
+                        .ToList();
+                    fullSet = pinSnapshots.Concat(models).ToList();
+                }
+                else
+                {
+                    // Add connector pins if any
+                    var allPins = models
+                        .OfType<ConnectorModel>()
+                        .SelectMany(connector => connector.ConnectorPinModels)
+                        .Cast<ModelBase>()
+                        .ToList();
+                    fullSet = allPins.Concat(models).ToList();
+                }
 
                 // If an existing connector/pin set is grabbed (to be reconnected), save the 
                 // models for deletion later in one action group.
@@ -333,7 +355,7 @@ namespace Dynamo.Graph.Workspaces
 
                 // After saving the models, delete them from the workspace
                 // in one action group.
-                RecordAndDeleteModels(models);
+                RecordAndDeleteModels(models, preserveConnectorPins);
             }
         }
 

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -43,7 +43,8 @@ namespace Dynamo.Models
 
         private PortModel[] activeStartPorts;
         private PortModel firstStartPort;
-        private Dictionary<Guid, List<(double X, double Y)>> reconnectionPinLocationsByStartPortId;
+        private Dictionary<Guid, (List<ConnectorPinModel> Pins, List<(double X, double Y)> Locations)>
+            reconnectionPinsByStartPortId;
 
         protected virtual void OpenFileImpl(OpenFileCommand command)
         {
@@ -374,7 +375,7 @@ namespace Dynamo.Models
         {
             bool isInPort = portType == PortType.Input;
             activeStartPorts = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByStartPortId = null;
 
             if (CurrentWorkspace.GetModelInternal(nodeId) is not NodeModel node)
                 return;
@@ -396,7 +397,7 @@ namespace Dynamo.Models
                     if (CurrentWorkspace.Connectors.Contains(connector))
                     {
                         var models = new List<ModelBase> { connector };
-                        CurrentWorkspace.SaveAndDeleteModels(models);
+                        CurrentWorkspace.SaveAndDeleteModels(models, preserveConnectorPins: true);
                         connector.Delete();
                     }
                 }
@@ -414,7 +415,7 @@ namespace Dynamo.Models
 
         private void BeginDuplicateConnection(Guid nodeId, int portIndex, PortType portType)
         {
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByStartPortId = null;
 
             // If the port clicked is an output port, begin connection as per normal
             if (portType == PortType.Output)
@@ -446,7 +447,7 @@ namespace Dynamo.Models
         {
             if (portType == PortType.Input) return; //only handle multiple connections when the port selected is an output port
             if (!(CurrentWorkspace.GetModelInternal(nodeId) is NodeModel node)) return;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByStartPortId = null;
 
             PortModel selectedPort = node.OutPorts[portIndex];
 
@@ -470,7 +471,7 @@ namespace Dynamo.Models
                 activeStartPorts[i] = connector.End;
                 RecordReconnectionPinLocations(connector.End, connector);
             }
-            CurrentWorkspace.SaveAndDeleteModels(selectedConnectors.ToList<ModelBase>());
+            CurrentWorkspace.SaveAndDeleteModels(selectedConnectors.ToList<ModelBase>(), preserveConnectorPins: true);
             return;
         }
 
@@ -488,15 +489,16 @@ namespace Dynamo.Models
             
             PortModel portModel = isInPort ? node.InPorts[portIndex] : node.OutPorts[portIndex];
 
+            var pinsToTransfer = ConsumeReconnectionPins(activeStartPorts[0]);
             var models = GetConnectorsToAddAndDelete(
                 portModel,
                 activeStartPorts[0],
-                ConsumeReconnectionPinLocations(activeStartPorts[0]));
+                pinsToTransfer);
 
             WorkspaceModel.RecordModelsForUndo(models, CurrentWorkspace.UndoRecorder);
             activeStartPorts = null;
             firstStartPort = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByStartPortId = null;
         }
 
         private void EndShiftReconnections(Guid nodeId, int portIndex, PortType portType)
@@ -507,16 +509,18 @@ namespace Dynamo.Models
             if (!(CurrentWorkspace.GetModelInternal(nodeId) is NodeModel node)) return;
             PortModel selectedPort = node.OutPorts[portIndex];
             
+            var firstPinsToTransfer = ConsumeReconnectionPins(activeStartPorts[0]);
             var firstModel = GetConnectorsToAddAndDelete(
                 selectedPort,
                 activeStartPorts[0],
-                ConsumeReconnectionPinLocations(activeStartPorts[0]));
+                firstPinsToTransfer);
             for (int i = 1; i < activeStartPorts.Count(); i++)
             {
+                var pinsToTransfer = ConsumeReconnectionPins(activeStartPorts[i]);
                 var models = GetConnectorsToAddAndDelete(
                     selectedPort,
                     activeStartPorts[i],
-                    ConsumeReconnectionPinLocations(activeStartPorts[i]));
+                    pinsToTransfer);
                 foreach (var m in models)
                 {
                     firstModel.Add(m.Key, m.Value);
@@ -524,7 +528,7 @@ namespace Dynamo.Models
             }
             WorkspaceModel.RecordModelsForUndo(firstModel, CurrentWorkspace.UndoRecorder);
             activeStartPorts = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByStartPortId = null;
             return;
         }
 
@@ -546,14 +550,14 @@ namespace Dynamo.Models
             CurrentWorkspace.DeleteSavedModels();
             activeStartPorts = null;
             firstStartPort = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByStartPortId = null;
             return;
         }
 
         private static Dictionary<ModelBase, UndoRedoRecorder.UserAction> GetConnectorsToAddAndDelete(
             PortModel endPort,
             PortModel startPort,
-            IEnumerable<(double X, double Y)> pinLocations = null)
+            IEnumerable<ConnectorPinModel> pinsToTransfer = null)
         {
             ConnectorModel connectorToRemove = null;
 
@@ -595,16 +599,11 @@ namespace Dynamo.Models
             {
                 models.Add(newConnectorModel, UndoRedoRecorder.UserAction.Creation);
 
-                if (pinLocations != null)
+                if (pinsToTransfer != null)
                 {
-                    foreach (var pinLocation in pinLocations)
+                    foreach (var connectorPinModel in pinsToTransfer)
                     {
-                        var connectorPinModel = new ConnectorPinModel(
-                            pinLocation.X,
-                            pinLocation.Y,
-                            Guid.NewGuid(),
-                            newConnectorModel.GUID);
-
+                        connectorPinModel.ConnectorId = newConnectorModel.GUID;
                         newConnectorModel.AddPin(connectorPinModel);
                         models.Add(connectorPinModel, UndoRedoRecorder.UserAction.Creation);
                     }
@@ -620,24 +619,49 @@ namespace Dynamo.Models
                 return;
             }
 
-            reconnectionPinLocationsByStartPortId ??= new Dictionary<Guid, List<(double X, double Y)>>();
-            reconnectionPinLocationsByStartPortId[activeStartPort.GUID] = connector.GetPinLocations().ToList();
+            var pins = connector.GetPinsSnapshot().ToList();
+            var pinLocations = pins.Select(pin => (pin.X, pin.Y)).ToList();
+
+            reconnectionPinsByStartPortId ??=
+                new Dictionary<Guid, (List<ConnectorPinModel> Pins, List<(double X, double Y)> Locations)>();
+            reconnectionPinsByStartPortId[activeStartPort.GUID] = (pins, pinLocations);
+
+            if (pins.Count > 0)
+            {
+                connector.PreservePinsOnDeleteForReconnection = true;
+            }
         }
 
         private IEnumerable<(double X, double Y)> ConsumeReconnectionPinLocations(PortModel activeStartPort)
         {
-            if (activeStartPort == null || reconnectionPinLocationsByStartPortId == null)
+            if (activeStartPort == null || reconnectionPinsByStartPortId == null)
             {
-                return Array.Empty<(double X, double Y)>();
+                return Enumerable.Empty<(double X, double Y)>();
             }
 
-            if (!reconnectionPinLocationsByStartPortId.TryGetValue(activeStartPort.GUID, out var pinLocations))
+            if (!reconnectionPinsByStartPortId.TryGetValue(activeStartPort.GUID, out var pinState))
             {
-                return Array.Empty<(double X, double Y)>();
+                return Enumerable.Empty<(double X, double Y)>();
             }
 
-            reconnectionPinLocationsByStartPortId.Remove(activeStartPort.GUID);
-            return pinLocations;
+            reconnectionPinsByStartPortId.Remove(activeStartPort.GUID);
+            return pinState.Locations?.AsEnumerable() ?? Enumerable.Empty<(double X, double Y)>();
+        }
+
+        private IEnumerable<ConnectorPinModel> ConsumeReconnectionPins(PortModel activeStartPort)
+        {
+            if (activeStartPort == null || reconnectionPinsByStartPortId == null)
+            {
+                return Enumerable.Empty<ConnectorPinModel>();
+            }
+
+            if (!reconnectionPinsByStartPortId.TryGetValue(activeStartPort.GUID, out var pinState))
+            {
+                return Enumerable.Empty<ConnectorPinModel>();
+            }
+
+            reconnectionPinsByStartPortId.Remove(activeStartPort.GUID);
+            return pinState.Pins?.AsEnumerable() ?? Enumerable.Empty<ConnectorPinModel>();
         }
 
         private void DeleteModelImpl(DeleteModelCommand command)

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -55,6 +55,7 @@ namespace Dynamo.ViewModels
         private Point curvePoint1;
         private Point curvePoint2;
         private Point curvePoint3;
+        private List<(double X, double Y)> transientPinLocations;
 
         /// <summary>
         /// Required timer for desired delay prior to ' connector anchor' display.
@@ -1147,23 +1148,41 @@ namespace Dynamo.ViewModels
         /// <param name="pinModel"></param>
         private void AddConnectorPinViewModel(ConnectorPinModel pinModel, bool isTransientPin = false)
         {
-            var pinViewModel = new ConnectorPinViewModel(this.workspaceViewModel, pinModel)
+            var pinViewModel = workspaceViewModel.Pins.FirstOrDefault(pin => pin.Model.GUID == pinModel.GUID);
+            if (pinViewModel != null && !ReferenceEquals(pinViewModel.Model, pinModel))
             {
-                IsHidden = this.IsHidden,
-                IsTemporarilyVisible = isTemporarilyVisible,
-                IsInteractive = !isTransientPin
-            };
+                workspaceViewModel.Pins.Remove(pinViewModel);
+                pinViewModel.Dispose();
+                pinViewModel = null;
+            }
+
+            if (pinViewModel == null)
+            {
+                pinViewModel = new ConnectorPinViewModel(this.workspaceViewModel, pinModel);
+                workspaceViewModel.Pins.Add(pinViewModel);
+            }
+
+            pinViewModel.IsHidden = this.IsHidden;
+            pinViewModel.IsTemporarilyVisible = isTemporarilyVisible;
+            pinViewModel.IsInteractive = !isTransientPin;
+
+            pinViewModel.PropertyChanged -= PinViewModelPropertyChanged;
             pinViewModel.PropertyChanged += PinViewModelPropertyChanged;
 
+            pinViewModel.RequestSelect -= HandleRequestSelected;
             pinViewModel.RequestSelect += HandleRequestSelected;
+            pinViewModel.RequestRedraw -= HandlerRedrawRequest;
             pinViewModel.RequestRedraw += HandlerRedrawRequest;
+            pinViewModel.RequestRemove -= HandleConnectorPinViewModelRemove;
             if (!isTransientPin)
             {
                 pinViewModel.RequestRemove += HandleConnectorPinViewModelRemove;
             }
 
-            workspaceViewModel.Pins.Add(pinViewModel);
-            ConnectorPinViewCollection.Add(pinViewModel);
+            if (!ConnectorPinViewCollection.Contains(pinViewModel))
+            {
+                ConnectorPinViewCollection.Add(pinViewModel);
+            }
         }
 
         /// <summary>
@@ -1472,6 +1491,26 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Keeps existing pin visuals alive while detaching them from this connector
+        /// so they can be reused by a replacement connector during reconnection.
+        /// </summary>
+        internal void DetachPinsForReconnection()
+        {
+            foreach (var pin in ConnectorPinViewCollection.ToList())
+            {
+                pin.PropertyChanged -= PinViewModelPropertyChanged;
+                pin.RequestRedraw -= HandlerRedrawRequest;
+                pin.RequestSelect -= HandleRequestSelected;
+                pin.RequestRemove -= HandleConnectorPinViewModelRemove;
+                pin.IsInteractive = false;
+            }
+
+            ConnectorPinViewCollection.Clear();
+            AnyPinSelected = false;
+            BezierControlPoints = null;
+        }
+
+        /// <summary>
         /// Collects pin locations of a connector. These are needed to reconstruct
         /// pins when new connectors are constructed. Specifically when a Watch node is 
         /// placed on a connector, thereby creating new connectors.
@@ -1489,9 +1528,10 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Creates transient pin visuals for a temporary connector (ConnectorModel == null).
+        /// Stores transient pin location hints for a temporary connector (ConnectorModel == null)
+        /// so the transient bezier path matches the original connector shape.
         /// </summary>
-        /// <param name="pinLocations">Pin top-left canvas coordinates.</param>
+        /// <param name="pinLocations">Pin model coordinates.</param>
         internal void SetTransientConnectorPinPositions(IEnumerable<(double X, double Y)> pinLocations)
         {
             if (ConnectorModel != null || pinLocations == null)
@@ -1499,17 +1539,7 @@ namespace Dynamo.ViewModels
                 return;
             }
 
-            DiscardAllConnectorPinModels();
-            foreach (var pinLocation in pinLocations)
-            {
-                var transientPinModel = new ConnectorPinModel(
-                    pinLocation.X,
-                    pinLocation.Y,
-                    Guid.NewGuid(),
-                    Guid.Empty);
-
-                AddConnectorPinViewModel(transientPinModel, true);
-            }
+            transientPinLocations = pinLocations.ToList();
         }
 
         #region ConnectorRedraw
@@ -1521,7 +1551,7 @@ namespace Dynamo.ViewModels
         {
             try
             {
-                if (ConnectorPinViewCollection?.Count > 0)
+                if (ConnectorPinViewCollection?.Count > 0 || HasTransientPinHints())
                 {
                     if (this.ConnectorModel?.End != null)
                     {
@@ -1575,7 +1605,7 @@ namespace Dynamo.ViewModels
         /// <param name="parameter">The position of the end point</param>
         public void Redraw(object parameter)
         {
-            if (ConnectorPinViewCollection?.Count > 0)
+            if (ConnectorPinViewCollection?.Count > 0 || HasTransientPinHints())
             {
                 RedrawBezierManyPoints(parameter);
                 return;
@@ -1683,6 +1713,18 @@ namespace Dynamo.ViewModels
             return false;
         }
 
+        private bool HasTransientPinHints()
+        {
+            return transientPinLocations != null && transientPinLocations.Count > 0;
+        }
+
+        private static Point ConvertPinModelLocationToBezierPoint(double x, double y)
+        {
+            return new Point(
+                x + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5),
+                y + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 1.5));
+        }
+
         private void RedrawBezierManyPoints(object parameter)
         {
             if (!TryGetEndPoint(parameter, out var p2))
@@ -1715,12 +1757,28 @@ namespace Dynamo.ViewModels
                 dotLeft = CurvePoint3.X - EndDotSize / 2;
 
                 // Add chain of points including start/end
-                Point[] points = new Point[ConnectorPinViewCollection.Count];
-                int count = 0;
-                foreach (var wirePin in ConnectorPinViewCollection)
+                Point[] points;
+                if (ConnectorPinViewCollection?.Count > 0)
                 {
-                    points[count] = new Point(wirePin.Left+ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5), wirePin.Top+ ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5));
-                    count++;
+                    points = new Point[ConnectorPinViewCollection.Count];
+                    int count = 0;
+                    foreach (var wirePin in ConnectorPinViewCollection)
+                    {
+                        points[count] = new Point(
+                            wirePin.Left + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5),
+                            wirePin.Top + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5));
+                        count++;
+                    }
+                }
+                else if (HasTransientPinHints())
+                {
+                    points = transientPinLocations
+                        .Select(pinLocation => ConvertPinModelLocationToBezierPoint(pinLocation.X, pinLocation.Y))
+                        .ToArray();
+                }
+                else
+                {
+                    return;
                 }
 
                 var isInputStartReconnection = ActiveStartPort?.PortType == PortType.Input;

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -320,6 +320,21 @@ namespace Dynamo.ViewModels
             multipleConnections = false;
             this.SetActiveConnectors(null);
             firstStartPort = null;
+            CleanupDetachedReconnectionPins();
+        }
+
+        private void CleanupDetachedReconnectionPins()
+        {
+            var orphanedPins = Pins
+                .Where(pin => !pin.IsInteractive && !Model.Connectors.Any(connector => connector.GUID == pin.ConnectorGuid))
+                .ToList();
+
+            foreach (var orphanedPin in orphanedPins)
+            {
+                Pins.Remove(orphanedPin);
+                orphanedPin.Model.Dispose();
+                orphanedPin.Dispose();
+            }
         }
 
         internal void UpdateActiveConnector(System.Windows.Point mouseCursor)

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -918,6 +918,11 @@ namespace Dynamo.ViewModels
             var connector = Connectors.FirstOrDefault(x => x.ConnectorModel == c);
             if (connector != null)
             {
+                if (c.PreservePinsOnDeleteForReconnection)
+                {
+                    connector.DetachPinsForReconnection();
+                }
+
                 Connectors.Remove(connector);
                 connector.Dispose();
             }

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -325,6 +325,9 @@ namespace DynamoCoreWpfTests
 
             // Assert that the pin was added
             Assert.AreEqual(initialConnectorPinCount + 1, connectorViewModel.ConnectorPinViewCollection.Count);
+            var originalPinGuids = connectorViewModel.ConnectorModel.ConnectorPinModels
+                .Select(pin => pin.GUID)
+                .ToList();
 
             // Begin reconnection – simulate grabbing the connector and starting a shift drag
             var startPort = connectorViewModel.ConnectorModel.Start;
@@ -339,11 +342,16 @@ namespace DynamoCoreWpfTests
                 .OfType<ConnectorViewModel>()
                 .FirstOrDefault(c => c.IsConnecting);
 
-            // Assert that during shift reconnection, a transient connector is created that has the same number of pins
+            // Assert that during shift reconnection, a transient connector is created without transient pin VMs.
             Assert.IsNotNull(activeConnector);
             Assert.IsNull(activeConnector.ConnectorModel, "Expected active connector to be transient during drag.");
-            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
-            Assert.IsTrue(activeConnector.ConnectorPinViewCollection.All(pin => !pin.IsInteractive));
+            Assert.AreEqual(0, activeConnector.ConnectorPinViewCollection.Count);
+
+            var retainedPins = this.ViewModel.CurrentSpaceViewModel.Pins
+                .Where(pin => originalPinGuids.Contains(pin.Model.GUID))
+                .ToList();
+            Assert.AreEqual(initialConnectorPinCount + 1, retainedPins.Count);
+            Assert.IsTrue(retainedPins.All(pin => !pin.IsInteractive));
 
             // Execute the second part of the workflow - simulate placing the connectors over the new port
             this.ViewModel.ExecuteCommand(
@@ -355,6 +363,9 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, connectorAfterReconnect.Count());
             Assert.AreEqual(initialConnectorPinCount + 1, connectorAfterReconnect.First().ConnectorPinViewCollection.Count);
             Assert.IsTrue(connectorAfterReconnect.First().ConnectorPinViewCollection.All(pin => pin.IsInteractive));
+            CollectionAssert.AreEquivalent(
+                originalPinGuids,
+                connectorAfterReconnect.First().ConnectorModel.ConnectorPinModels.Select(pin => pin.GUID));
         }
         #endregion
 
@@ -562,7 +573,7 @@ namespace DynamoCoreWpfTests
                 .OfType<ConnectorViewModel>()
                 .FirstOrDefault(c => c.IsConnecting);
             Assert.IsNotNull(activeConnector);
-            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
+            Assert.AreEqual(0, activeConnector.ConnectorPinViewCollection.Count);
 
             activeConnector.Redraw(new Point2D(650, 350));
             Assert.IsNotNull(activeConnector.ComputedBezierPathGeometry);

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -601,6 +601,39 @@ namespace DynamoCoreWpfTests
 
             var restoredPin = restoredConnector.ConnectorModel.ConnectorPinModels.FirstOrDefault(p => p.GUID == pinModelGuid);
             Assert.IsNotNull(restoredPin, "Expected pin model not found after undo.");
+
+            restoredConnector.Redraw();
+            Assert.IsNotNull(restoredConnector.ComputedBezierPathGeometry);
+            Assert.Greater(restoredConnector.ComputedBezierPathGeometry.Figures.Count, 1);
+        }
+
+        [Test]
+        public void CanUndoDeleteConnectorWithPinAndRestorePinAttachment()
+        {
+            Open(@"UI/ConnectorPinTests.dyn");
+            var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
+
+            connectorViewModel.PanelX = 292.66666;
+            connectorViewModel.PanelY = 278;
+            connectorViewModel.FlipOnConnectorAnchor();
+            connectorViewModel.PinConnectorCommand.Execute(null);
+
+            var connectorGuid = connectorViewModel.ConnectorModel.GUID;
+            var pinGuid = connectorViewModel.ConnectorModel.ConnectorPinModels.First().GUID;
+
+            Model.ExecuteCommand(new DeleteModelCommand(connectorGuid));
+            Assert.AreEqual(0, this.ViewModel.CurrentSpaceViewModel.Connectors.Count);
+
+            Model.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));
+
+            var restoredConnector = this.ViewModel.CurrentSpaceViewModel.Connectors
+                .FirstOrDefault(connector => connector.ConnectorModel.GUID == connectorGuid);
+            Assert.IsNotNull(restoredConnector);
+            Assert.IsTrue(restoredConnector.ConnectorModel.ConnectorPinModels.Any(pin => pin.GUID == pinGuid));
+
+            restoredConnector.Redraw();
+            Assert.IsNotNull(restoredConnector.ComputedBezierPathGeometry);
+            Assert.Greater(restoredConnector.ComputedBezierPathGeometry.Figures.Count, 1);
         }
         #endregion
     }


### PR DESCRIPTION
### Purpose

This PR refactors the connector reconnection logic to retain and reuse original connector pins, instead of deleting and recreating them multiple times. This streamlines the reconnection process by keeping the original pins visible and inactive until they are reattached to the new permanent connector.

### Declarations

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Improved connector reconnection experience: When reconnecting a connector with pins, the original pins are now retained and remain visible throughout the process, leading to a smoother visual transition and avoiding unnecessary pin recreation.

### Reviewers

(FILL ME IN)

### FYIs

This change impacts the model, undo/redo, and WPF layers. Key changes include:
- `DynamoModelCommands` now stores `ConnectorPinModel` instances for transfer.
- `ConnectorModel` includes a `PreservePinsOnDeleteForReconnection` flag.
- `UndoRedo` methods are updated to conditionally preserve pins during connector deletion.
- `WorkspaceViewModel` and `ConnectorViewModel` manage the visibility and interactivity of original pins during the transient connection phase, and the transient connector now uses path hints instead of creating temporary pin VMs.

---
<p><a href="https://cursor.com/agents/bc-b046ffcf-1365-4f99-ab0f-18c2ac927090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b046ffcf-1365-4f99-ab0f-18c2ac927090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

