### PR TITLE
Connector pin persistence

### DIFF
--- a/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
+++ b/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
@@ -62,6 +62,12 @@ namespace Dynamo.Graph.Connectors
                 RaisePropertyChanged(nameof(IsTransient));
             }
         }
+
+        /// <summary>
+        /// Indicates that this connector is being temporarily removed for reconnection.
+        /// In this mode pin view models are preserved and rebound to the replacement connector.
+        /// </summary>
+        internal bool PreservePinsDuringReconnection { get; set; } = false;
         
         /// <summary>
         /// Returns start port model.

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -286,7 +286,7 @@ namespace Dynamo.Graph.Workspaces
                     }
                     else if (model is ConnectorModel conn)
                     {
-                        if (conn.ConnectorPinModels.Count > 0)
+                        if (!conn.PreservePinsDuringReconnection && conn.ConnectorPinModels.Count > 0)
                         {
                             foreach (var connectorPin in conn.ConnectorPinModels.ToList())
                             {
@@ -323,6 +323,7 @@ namespace Dynamo.Graph.Workspaces
                 // Add connector pins if any
                 var allPins = models
                     .OfType<ConnectorModel>()
+                    .Where(connector => !connector.PreservePinsDuringReconnection)
                     .SelectMany(connector => connector.ConnectorPinModels)
                     .Cast<ModelBase>()
                     .ToList();

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -149,14 +149,6 @@ namespace Dynamo.Graph.Workspaces
 
             using (recorder.BeginActionGroup())
             {
-                if (null != savedModels)
-                {
-                    foreach (var modelPair in savedModels)
-                    {
-                        recorder.RecordDeletionForUndo(modelPair);
-                    }
-                    savedModels = null;
-                }
                 foreach (var modelPair in models)
                 {
                     switch (modelPair.Value)
@@ -171,6 +163,15 @@ namespace Dynamo.Graph.Workspaces
                             recorder.RecordModificationForUndo(modelPair.Key);
                             break;
                     }
+                }
+
+                if (null != savedModels)
+                {
+                    foreach (var modelPair in savedModels)
+                    {
+                        recorder.RecordDeletionForUndo(modelPair);
+                    }
+                    savedModels = null;
                 }
             }
         }
@@ -455,6 +456,33 @@ namespace Dynamo.Graph.Workspaces
         public void ReloadModel(XmlElement modelData)
         {
             ModelBase model = GetModelForElement(modelData);
+            if (model is ConnectorPinModel connectorPinModel)
+            {
+                var helper = new XmlElementHelper(modelData);
+                var targetConnectorId = helper.ReadGuid("connectorId");
+                var currentConnector = Connectors.FirstOrDefault(
+                    connector => connector.ConnectorPinModels.Contains(connectorPinModel));
+                var targetConnector = Connectors.FirstOrDefault(
+                    connector => connector.GUID == targetConnectorId);
+
+                model.Deserialize(modelData, SaveContext.Undo);
+
+                if (currentConnector != null &&
+                    targetConnector != null &&
+                    currentConnector.GUID != targetConnectorId)
+                {
+                    currentConnector.RemovePin(connectorPinModel);
+                }
+
+                if (targetConnector != null &&
+                    !targetConnector.ConnectorPinModels.Contains(connectorPinModel))
+                {
+                    targetConnector.AddPin(connectorPinModel);
+                }
+
+                return;
+            }
+
             if (model != null)
             {
                 model.Deserialize(modelData, SaveContext.Undo);

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -650,6 +650,7 @@ namespace Dynamo.Models
                 return;
             }
 
+            connector.PreservePinsDuringReconnection = true;
             reconnectionPinsByActivePortId ??= new Dictionary<Guid, List<ConnectorPinModel>>();
             reconnectionPinsByActivePortId[activeStartPort.GUID] = connector.ConnectorPinModels.ToList();
         }

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -43,7 +43,7 @@ namespace Dynamo.Models
 
         private PortModel[] activeStartPorts;
         private PortModel firstStartPort;
-        private Dictionary<Guid, List<(double X, double Y)>> reconnectionPinLocationsByStartPortId;
+        private Dictionary<Guid, List<ConnectorPinModel>> reconnectionPinsByActivePortId;
 
         protected virtual void OpenFileImpl(OpenFileCommand command)
         {
@@ -150,7 +150,7 @@ namespace Dynamo.Models
                 inPortModel = existingNode.InPorts[command.InputPortIndex];
             }
 
-            var models = GetConnectorsToAddAndDelete(inPortModel, outPortModel);
+            var models = GetConnectorsToAddAndDelete(inPortModel, outPortModel, null, out _);
 
             foreach (var modelPair in models)
             {
@@ -374,7 +374,7 @@ namespace Dynamo.Models
         {
             bool isInPort = portType == PortType.Input;
             activeStartPorts = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByActivePortId = null;
 
             if (CurrentWorkspace.GetModelInternal(nodeId) is not NodeModel node)
                 return;
@@ -389,7 +389,7 @@ namespace Dynamo.Models
                     ConnectorModel connector = portModel.Connectors[0];
                     activeStartPorts = new PortModel[] { connector.Start };
                     firstStartPort = connector.Start;
-                    RecordReconnectionPinLocations(connector.Start, connector);
+                    RecordReconnectionPins(connector.Start, connector);
                     // Disconnect the connector model from its start and end ports
                     // and remove it from the connectors collection. This will also
                     // remove the view model.
@@ -414,7 +414,7 @@ namespace Dynamo.Models
 
         private void BeginDuplicateConnection(Guid nodeId, int portIndex, PortType portType)
         {
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByActivePortId = null;
 
             // If the port clicked is an output port, begin connection as per normal
             if (portType == PortType.Output)
@@ -446,7 +446,7 @@ namespace Dynamo.Models
         {
             if (portType == PortType.Input) return; //only handle multiple connections when the port selected is an output port
             if (!(CurrentWorkspace.GetModelInternal(nodeId) is NodeModel node)) return;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByActivePortId = null;
 
             PortModel selectedPort = node.OutPorts[portIndex];
 
@@ -468,7 +468,7 @@ namespace Dynamo.Models
             {
                 ConnectorModel connector = selectedConnectors[i];
                 activeStartPorts[i] = connector.End;
-                RecordReconnectionPinLocations(connector.End, connector);
+                RecordReconnectionPins(connector.End, connector);
             }
             CurrentWorkspace.SaveAndDeleteModels(selectedConnectors.ToList<ModelBase>());
             return;
@@ -487,16 +487,19 @@ namespace Dynamo.Models
             bool isInPort = portType == PortType.Input;
             
             PortModel portModel = isInPort ? node.InPorts[portIndex] : node.OutPorts[portIndex];
+            var reconnectionPins = ConsumeReconnectionPins(activeStartPorts[0]).ToList();
 
             var models = GetConnectorsToAddAndDelete(
                 portModel,
                 activeStartPorts[0],
-                ConsumeReconnectionPinLocations(activeStartPorts[0]));
+                reconnectionPins,
+                out var newConnectorModel);
 
             WorkspaceModel.RecordModelsForUndo(models, CurrentWorkspace.UndoRecorder);
+            AttachReconnectionPins(newConnectorModel, reconnectionPins);
             activeStartPorts = null;
             firstStartPort = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByActivePortId = null;
         }
 
         private void EndShiftReconnections(Guid nodeId, int portIndex, PortType portType)
@@ -506,25 +509,37 @@ namespace Dynamo.Models
 
             if (!(CurrentWorkspace.GetModelInternal(nodeId) is NodeModel node)) return;
             PortModel selectedPort = node.OutPorts[portIndex];
+
+            var connectorsAndPinsToAttach = new List<(ConnectorModel Connector, List<ConnectorPinModel> Pins)>();
+            var firstPins = ConsumeReconnectionPins(activeStartPorts[0]).ToList();
             
             var firstModel = GetConnectorsToAddAndDelete(
                 selectedPort,
                 activeStartPorts[0],
-                ConsumeReconnectionPinLocations(activeStartPorts[0]));
+                firstPins,
+                out var firstConnectorModel);
+            connectorsAndPinsToAttach.Add((firstConnectorModel, firstPins));
             for (int i = 1; i < activeStartPorts.Count(); i++)
             {
+                var reconnectionPins = ConsumeReconnectionPins(activeStartPorts[i]).ToList();
                 var models = GetConnectorsToAddAndDelete(
                     selectedPort,
                     activeStartPorts[i],
-                    ConsumeReconnectionPinLocations(activeStartPorts[i]));
+                    reconnectionPins,
+                    out var newConnectorModel);
+                connectorsAndPinsToAttach.Add((newConnectorModel, reconnectionPins));
                 foreach (var m in models)
                 {
                     firstModel.Add(m.Key, m.Value);
                 }
             }
             WorkspaceModel.RecordModelsForUndo(firstModel, CurrentWorkspace.UndoRecorder);
+            foreach (var connectorAndPins in connectorsAndPinsToAttach)
+            {
+                AttachReconnectionPins(connectorAndPins.Connector, connectorAndPins.Pins);
+            }
             activeStartPorts = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByActivePortId = null;
             return;
         }
 
@@ -535,7 +550,7 @@ namespace Dynamo.Models
             if (!(CurrentWorkspace.GetModelInternal(nodeId) is NodeModel node)) return;
 
             PortModel portModel = node.InPorts[portIndex];
-            var models = GetConnectorsToAddAndDelete(portModel, activeStartPorts[0]);
+            var models = GetConnectorsToAddAndDelete(portModel, activeStartPorts[0], null, out _);
             WorkspaceModel.RecordModelsForUndo(models, CurrentWorkspace.UndoRecorder);
             
             activeStartPorts = new PortModel[] { firstStartPort };
@@ -546,14 +561,15 @@ namespace Dynamo.Models
             CurrentWorkspace.DeleteSavedModels();
             activeStartPorts = null;
             firstStartPort = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByActivePortId = null;
             return;
         }
 
         private static Dictionary<ModelBase, UndoRedoRecorder.UserAction> GetConnectorsToAddAndDelete(
             PortModel endPort,
             PortModel startPort,
-            IEnumerable<(double X, double Y)> pinLocations = null)
+            IEnumerable<ConnectorPinModel> reconnectionPins,
+            out ConnectorModel newConnectorModel)
         {
             ConnectorModel connectorToRemove = null;
 
@@ -579,7 +595,7 @@ namespace Dynamo.Models
                 secondPort = endPort;
             }
 
-            ConnectorModel newConnectorModel = ConnectorModel.Make(
+            newConnectorModel = ConnectorModel.Make(
                 firstPort.Owner,
                 secondPort.Owner,
                 firstPort.Index,
@@ -595,49 +611,63 @@ namespace Dynamo.Models
             {
                 models.Add(newConnectorModel, UndoRedoRecorder.UserAction.Creation);
 
-                if (pinLocations != null)
+                if (reconnectionPins != null)
                 {
-                    foreach (var pinLocation in pinLocations)
+                    foreach (var connectorPinModel in reconnectionPins)
                     {
-                        var connectorPinModel = new ConnectorPinModel(
-                            pinLocation.X,
-                            pinLocation.Y,
-                            Guid.NewGuid(),
-                            newConnectorModel.GUID);
-
-                        newConnectorModel.AddPin(connectorPinModel);
-                        models.Add(connectorPinModel, UndoRedoRecorder.UserAction.Creation);
+                        models[connectorPinModel] = UndoRedoRecorder.UserAction.Modification;
                     }
                 }
             }
             return models;
         }
 
-        private void RecordReconnectionPinLocations(PortModel activeStartPort, ConnectorModel connector)
+        private static void AttachReconnectionPins(
+            ConnectorModel connectorModel,
+            IEnumerable<ConnectorPinModel> reconnectionPins)
+        {
+            if (connectorModel == null || reconnectionPins == null)
+            {
+                return;
+            }
+
+            foreach (var connectorPinModel in reconnectionPins)
+            {
+                if (connectorPinModel == null)
+                {
+                    continue;
+                }
+
+                connectorPinModel.ConnectorId = connectorModel.GUID;
+                connectorModel.AddPin(connectorPinModel);
+            }
+        }
+
+        private void RecordReconnectionPins(PortModel activeStartPort, ConnectorModel connector)
         {
             if (activeStartPort == null || connector == null)
             {
                 return;
             }
 
-            reconnectionPinLocationsByStartPortId ??= new Dictionary<Guid, List<(double X, double Y)>>();
-            reconnectionPinLocationsByStartPortId[activeStartPort.GUID] = connector.GetPinLocations().ToList();
+            reconnectionPinsByActivePortId ??= new Dictionary<Guid, List<ConnectorPinModel>>();
+            reconnectionPinsByActivePortId[activeStartPort.GUID] = connector.ConnectorPinModels.ToList();
         }
 
-        private IEnumerable<(double X, double Y)> ConsumeReconnectionPinLocations(PortModel activeStartPort)
+        private IEnumerable<ConnectorPinModel> ConsumeReconnectionPins(PortModel activeStartPort)
         {
-            if (activeStartPort == null || reconnectionPinLocationsByStartPortId == null)
+            if (activeStartPort == null || reconnectionPinsByActivePortId == null)
             {
-                return Array.Empty<(double X, double Y)>();
+                return Enumerable.Empty<ConnectorPinModel>();
             }
 
-            if (!reconnectionPinLocationsByStartPortId.TryGetValue(activeStartPort.GUID, out var pinLocations))
+            if (!reconnectionPinsByActivePortId.TryGetValue(activeStartPort.GUID, out var connectorPins))
             {
-                return Array.Empty<(double X, double Y)>();
+                return Enumerable.Empty<ConnectorPinModel>();
             }
 
-            reconnectionPinLocationsByStartPortId.Remove(activeStartPort.GUID);
-            return pinLocations;
+            reconnectionPinsByActivePortId.Remove(activeStartPort.GUID);
+            return connectorPins;
         }
 
         private void DeleteModelImpl(DeleteModelCommand command)

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -55,6 +55,7 @@ namespace Dynamo.ViewModels
         private Point curvePoint1;
         private Point curvePoint2;
         private Point curvePoint3;
+        private List<Point> transientConnectorPinLocations;
 
         /// <summary>
         /// Required timer for desired delay prior to ' connector anchor' display.
@@ -1489,27 +1490,20 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Creates transient pin visuals for a temporary connector (ConnectorModel == null).
+        /// Stores transient pin locations for routing the temporary connector bezier.
+        /// No transient pin visuals are created.
         /// </summary>
         /// <param name="pinLocations">Pin top-left canvas coordinates.</param>
         internal void SetTransientConnectorPinPositions(IEnumerable<(double X, double Y)> pinLocations)
         {
-            if (ConnectorModel != null || pinLocations == null)
+            if (ConnectorModel != null)
             {
                 return;
             }
 
-            DiscardAllConnectorPinModels();
-            foreach (var pinLocation in pinLocations)
-            {
-                var transientPinModel = new ConnectorPinModel(
-                    pinLocation.X,
-                    pinLocation.Y,
-                    Guid.NewGuid(),
-                    Guid.Empty);
-
-                AddConnectorPinViewModel(transientPinModel, true);
-            }
+            transientConnectorPinLocations = pinLocations?
+                .Select(pinLocation => new Point(pinLocation.X, pinLocation.Y))
+                .ToList();
         }
 
         #region ConnectorRedraw
@@ -1521,7 +1515,7 @@ namespace Dynamo.ViewModels
         {
             try
             {
-                if (ConnectorPinViewCollection?.Count > 0)
+                if (HasBezierRoutingPoints())
                 {
                     if (this.ConnectorModel?.End != null)
                     {
@@ -1575,7 +1569,7 @@ namespace Dynamo.ViewModels
         /// <param name="parameter">The position of the end point</param>
         public void Redraw(object parameter)
         {
-            if (ConnectorPinViewCollection?.Count > 0)
+            if (HasBezierRoutingPoints())
             {
                 RedrawBezierManyPoints(parameter);
                 return;
@@ -1683,6 +1677,35 @@ namespace Dynamo.ViewModels
             return false;
         }
 
+        private bool HasBezierRoutingPoints()
+        {
+            return (ConnectorPinViewCollection?.Count > 0)
+                || (transientConnectorPinLocations?.Count > 0);
+        }
+
+        private List<Point> GetBezierRoutingPoints()
+        {
+            if (ConnectorPinViewCollection?.Count > 0)
+            {
+                return ConnectorPinViewCollection
+                    .Select(wirePin => new Point(
+                        wirePin.Left + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5),
+                        wirePin.Top + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5)))
+                    .ToList();
+            }
+
+            if (transientConnectorPinLocations?.Count > 0)
+            {
+                return transientConnectorPinLocations
+                    .Select(pinLocation => new Point(
+                        pinLocation.X + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5),
+                        pinLocation.Y + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5)))
+                    .ToList();
+            }
+
+            return new List<Point>();
+        }
+
         private void RedrawBezierManyPoints(object parameter)
         {
             if (!TryGetEndPoint(parameter, out var p2))
@@ -1714,19 +1737,16 @@ namespace Dynamo.ViewModels
                 dotTop = CurvePoint3.Y - EndDotSize / 2;
                 dotLeft = CurvePoint3.X - EndDotSize / 2;
 
-                // Add chain of points including start/end
-                Point[] points = new Point[ConnectorPinViewCollection.Count];
-                int count = 0;
-                foreach (var wirePin in ConnectorPinViewCollection)
+                var routingPoints = GetBezierRoutingPoints();
+                if (routingPoints.Count == 0)
                 {
-                    points[count] = new Point(wirePin.Left+ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5), wirePin.Top+ ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5));
-                    count++;
+                    return;
                 }
 
                 var isInputStartReconnection = ActiveStartPort?.PortType == PortType.Input;
                 var orderedPoints = isInputStartReconnection
-                    ? points.OrderByDescending(p => p.X).ToList()
-                    : points.OrderBy(p => p.X).ToList();
+                    ? routingPoints.OrderByDescending(p => p.X).ToList()
+                    : routingPoints.OrderBy(p => p.X).ToList();
 
                 orderedPoints.Insert(0, CurvePoint0);
                 orderedPoints.Insert(orderedPoints.Count, CurvePoint3);

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1118,7 +1118,9 @@ namespace Dynamo.ViewModels
         /// <param name="connectorPin"></param>
         private void RemoveConnectorPinModelViewModel(ConnectorPinModel connectorPin)
         {
-            var matchingConnectorPinViewModel = this.workspaceViewModel.Pins.FirstOrDefault(x => x.Model.GUID == connectorPin.GUID);
+            var matchingConnectorPinViewModel =
+                this.workspaceViewModel.Pins.FirstOrDefault(x => x.Model.GUID == connectorPin.GUID) ??
+                ConnectorPinViewCollection.FirstOrDefault(x => x.Model.GUID == connectorPin.GUID);
             if (matchingConnectorPinViewModel is null) return;
             RemoveConnectorPinModelViewModel(matchingConnectorPinViewModel);
         }
@@ -1494,16 +1496,27 @@ namespace Dynamo.ViewModels
         /// to all previous pins is required for undo/redo recorder.</param>
         internal void DiscardAllConnectorPinModels(List<ModelBase> allDeletedModels = null)
         {
-            foreach (var pin in ConnectorPinViewCollection)
+            foreach (var pin in ConnectorPinViewCollection.ToList())
             {
                 workspaceViewModel.Pins.Remove(pin);
-                ConnectorModel?.RemovePin(pin.Model);
+                var pinStillBelongsToThisConnector =
+                    ConnectorModel != null &&
+                    pin.Model != null &&
+                    pin.Model.ConnectorId == ConnectorModel.GUID;
 
-                if (ConnectorModel != null && allDeletedModels != null)
+                // Only dispose the pin model when this connector still owns it.
+                // During undo/redo a stale pin view can transiently remain while the
+                // pin model has already been moved to a different connector.
+                if (pinStillBelongsToThisConnector)
                 {
-                    allDeletedModels.Add(pin.Model);
+                    ConnectorModel.RemovePin(pin.Model);
+
+                    if (allDeletedModels != null)
+                    {
+                        allDeletedModels.Add(pin.Model);
+                    }
+                    pin.Model.Dispose();
                 }
-                pin.Model.Dispose();
                 pin.Dispose();
             }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1148,12 +1148,25 @@ namespace Dynamo.ViewModels
         /// <param name="pinModel"></param>
         private void AddConnectorPinViewModel(ConnectorPinModel pinModel, bool isTransientPin = false)
         {
-            var pinViewModel = new ConnectorPinViewModel(this.workspaceViewModel, pinModel)
+            ConnectorPinViewModel pinViewModel;
+            if (!isTransientPin &&
+                workspaceViewModel.TryTakePreservedConnectorPinViewModel(pinModel.GUID, out var preservedPinViewModel))
             {
-                IsHidden = this.IsHidden,
-                IsTemporarilyVisible = isTemporarilyVisible,
-                IsInteractive = !isTransientPin
-            };
+                pinViewModel = preservedPinViewModel;
+                pinViewModel.IsHidden = this.IsHidden;
+                pinViewModel.IsTemporarilyVisible = isTemporarilyVisible;
+                pinViewModel.IsInteractive = true;
+            }
+            else
+            {
+                pinViewModel = new ConnectorPinViewModel(this.workspaceViewModel, pinModel)
+                {
+                    IsHidden = this.IsHidden,
+                    IsTemporarilyVisible = isTemporarilyVisible,
+                    IsInteractive = !isTransientPin
+                };
+            }
+
             pinViewModel.PropertyChanged += PinViewModelPropertyChanged;
 
             pinViewModel.RequestSelect += HandleRequestSelected;
@@ -1163,7 +1176,10 @@ namespace Dynamo.ViewModels
                 pinViewModel.RequestRemove += HandleConnectorPinViewModelRemove;
             }
 
-            workspaceViewModel.Pins.Add(pinViewModel);
+            if (!workspaceViewModel.Pins.Contains(pinViewModel))
+            {
+                workspaceViewModel.Pins.Add(pinViewModel);
+            }
             ConnectorPinViewCollection.Add(pinViewModel);
         }
 
@@ -1239,6 +1255,8 @@ namespace Dynamo.ViewModels
         /// </summary>
         public override void Dispose()
         {
+            var preservePinsForReconnection = model?.PreservePinsDuringReconnection == true;
+
             if (model != null)
             {
                 model.PropertyChanged -= HandleConnectorPropertyChanged;
@@ -1272,13 +1290,24 @@ namespace Dynamo.ViewModels
 
                 foreach (var pin in ConnectorPinViewCollection.ToList())
                 {
+                    pin.PropertyChanged -= PinViewModelPropertyChanged;
                     pin.RequestRedraw -= HandlerRedrawRequest;
                     pin.RequestSelect -= HandleRequestSelected;
+                    pin.RequestRemove -= HandleConnectorPinViewModelRemove;
+
+                    if (preservePinsForReconnection)
+                    {
+                        workspaceViewModel.PreserveConnectorPinViewModelForReconnection(pin);
+                        ConnectorPinViewCollection.Remove(pin);
+                    }
                 }
             }
 
             this.PropertyChanged -= ConnectorViewModelPropertyChanged;
-            DiscardAllConnectorPinModels();
+            if (!preservePinsForReconnection)
+            {
+                DiscardAllConnectorPinModels();
+            }
 
             if (ConnectorContextMenuViewModel != null)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1255,7 +1255,16 @@ namespace Dynamo.ViewModels
         /// </summary>
         public override void Dispose()
         {
-            var preservePinsForReconnection = model?.PreservePinsDuringReconnection == true;
+            var connectorDetachedFromPorts =
+                model != null &&
+                !(model.Start?.Connectors.Contains(model) ?? false) &&
+                !(model.End?.Connectors.Contains(model) ?? false);
+
+            var preservePinsForReconnection =
+                model?.PreservePinsDuringReconnection == true ||
+                (model != null &&
+                 connectorDetachedFromPorts &&
+                 model.ConnectorPinModels.Count > 0);
 
             if (model != null)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -320,6 +320,7 @@ namespace Dynamo.ViewModels
             multipleConnections = false;
             this.SetActiveConnectors(null);
             firstStartPort = null;
+            DiscardPreservedConnectorPinViewModels();
         }
 
         internal void UpdateActiveConnector(System.Windows.Point mouseCursor)

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -303,6 +303,8 @@ namespace Dynamo.ViewModels
         [JsonIgnore]
         public ObservableCollection<ConnectorPinViewModel> Pins { get; } = new ObservableCollection<ConnectorPinViewModel>();
 
+        private readonly Dictionary<Guid, ConnectorPinViewModel> preservedConnectorPinViewModels = new Dictionary<Guid, ConnectorPinViewModel>();
+
         [JsonIgnore]
         public ObservableCollection<InfoBubbleViewModel> Errors { get; } = new ObservableCollection<InfoBubbleViewModel>();
         public ObservableCollection<AnnotationViewModel> Annotations { get; } = new ObservableCollection<AnnotationViewModel>();
@@ -751,6 +753,7 @@ namespace Dynamo.ViewModels
             Notes.ToList().ForEach(noteViewModel => noteViewModel.Dispose());
             Connectors.ToList().ForEach(connectorViewmModel => connectorViewmModel.Dispose());
             Annotations.ToList().ForEach(AnnotationViewModel => AnnotationViewModel.Dispose());
+            DiscardPreservedConnectorPinViewModels();
             Nodes.Clear();
             Notes.Clear();
             Pins.Clear();
@@ -763,6 +766,45 @@ namespace Dynamo.ViewModels
 
             DelayNodePreviewControl?.Dispose();
             DelayNodePreviewControl = null;
+        }
+
+        internal void PreserveConnectorPinViewModelForReconnection(ConnectorPinViewModel pinViewModel)
+        {
+            if (pinViewModel?.Model == null)
+            {
+                return;
+            }
+
+            preservedConnectorPinViewModels[pinViewModel.Model.GUID] = pinViewModel;
+            Pins.Remove(pinViewModel);
+        }
+
+        internal bool TryTakePreservedConnectorPinViewModel(Guid pinModelGuid, out ConnectorPinViewModel pinViewModel)
+        {
+            if (!preservedConnectorPinViewModels.TryGetValue(pinModelGuid, out pinViewModel))
+            {
+                return false;
+            }
+
+            preservedConnectorPinViewModels.Remove(pinModelGuid);
+            if (!Pins.Contains(pinViewModel))
+            {
+                Pins.Add(pinViewModel);
+            }
+
+            return true;
+        }
+
+        internal void DiscardPreservedConnectorPinViewModels()
+        {
+            foreach (var pinViewModel in preservedConnectorPinViewModels.Values.ToList())
+            {
+                Pins.Remove(pinViewModel);
+                pinViewModel.Model?.Dispose();
+                pinViewModel.Dispose();
+            }
+
+            preservedConnectorPinViewModels.Clear();
         }
 
         internal void ZoomInInternal()

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -306,7 +306,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        public void ShiftReconnectionUsesNonInteractiveTransientPinsAndPersistsPins()
+        public void ShiftReconnectionUsesTransientRoutingPointsAndPersistsPins()
         {
             // Open a test graph with at least two connected nodes
             Open(@"UI/ConnectorPinTests.dyn");
@@ -325,6 +325,7 @@ namespace DynamoCoreWpfTests
 
             // Assert that the pin was added
             Assert.AreEqual(initialConnectorPinCount + 1, connectorViewModel.ConnectorPinViewCollection.Count);
+            var pinModelGuid = connectorViewModel.ConnectorModel.ConnectorPinModels.First().GUID;
 
             // Begin reconnection – simulate grabbing the connector and starting a shift drag
             var startPort = connectorViewModel.ConnectorModel.Start;
@@ -339,11 +340,14 @@ namespace DynamoCoreWpfTests
                 .OfType<ConnectorViewModel>()
                 .FirstOrDefault(c => c.IsConnecting);
 
-            // Assert that during shift reconnection, a transient connector is created that has the same number of pins
+            // Assert that during shift reconnection, the transient connector has no pins but still routes through pin positions.
             Assert.IsNotNull(activeConnector);
             Assert.IsNull(activeConnector.ConnectorModel, "Expected active connector to be transient during drag.");
-            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
-            Assert.IsTrue(activeConnector.ConnectorPinViewCollection.All(pin => !pin.IsInteractive));
+            Assert.AreEqual(0, activeConnector.ConnectorPinViewCollection.Count);
+
+            activeConnector.Redraw(new Point2D(650, 350));
+            Assert.IsNotNull(activeConnector.ComputedBezierPathGeometry);
+            Assert.Greater(activeConnector.ComputedBezierPathGeometry.Figures.Count, 1);
 
             // Execute the second part of the workflow - simulate placing the connectors over the new port
             this.ViewModel.ExecuteCommand(
@@ -355,6 +359,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, connectorAfterReconnect.Count());
             Assert.AreEqual(initialConnectorPinCount + 1, connectorAfterReconnect.First().ConnectorPinViewCollection.Count);
             Assert.IsTrue(connectorAfterReconnect.First().ConnectorPinViewCollection.All(pin => pin.IsInteractive));
+            Assert.IsTrue(connectorAfterReconnect.First().ConnectorModel.ConnectorPinModels.Any(pin => pin.GUID == pinModelGuid));
         }
         #endregion
 
@@ -562,7 +567,7 @@ namespace DynamoCoreWpfTests
                 .OfType<ConnectorViewModel>()
                 .FirstOrDefault(c => c.IsConnecting);
             Assert.IsNotNull(activeConnector);
-            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
+            Assert.AreEqual(0, activeConnector.ConnectorPinViewCollection.Count);
 
             activeConnector.Redraw(new Point2D(650, 350));
             Assert.IsNotNull(activeConnector.ComputedBezierPathGeometry);
@@ -577,6 +582,7 @@ namespace DynamoCoreWpfTests
             var connectorAfterReconnect = this.ViewModel.CurrentSpaceViewModel.Connectors;
             Assert.AreEqual(1, connectorAfterReconnect.Count());
             Assert.AreEqual(initialConnectorPinCount + 1, connectorAfterReconnect.First().ConnectorPinViewCollection.Count());
+            Assert.IsTrue(connectorAfterReconnect.First().ConnectorModel.ConnectorPinModels.Any(p => p.GUID == pinModelGuid));
 
             // --- Undo ---
             Model.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -326,6 +326,7 @@ namespace DynamoCoreWpfTests
             // Assert that the pin was added
             Assert.AreEqual(initialConnectorPinCount + 1, connectorViewModel.ConnectorPinViewCollection.Count);
             var pinModelGuid = connectorViewModel.ConnectorModel.ConnectorPinModels.First().GUID;
+            var pinViewModelBeforeReconnect = connectorViewModel.ConnectorPinViewCollection.First();
 
             // Begin reconnection – simulate grabbing the connector and starting a shift drag
             var startPort = connectorViewModel.ConnectorModel.Start;
@@ -360,6 +361,7 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(initialConnectorPinCount + 1, connectorAfterReconnect.First().ConnectorPinViewCollection.Count);
             Assert.IsTrue(connectorAfterReconnect.First().ConnectorPinViewCollection.All(pin => pin.IsInteractive));
             Assert.IsTrue(connectorAfterReconnect.First().ConnectorModel.ConnectorPinModels.Any(pin => pin.GUID == pinModelGuid));
+            Assert.AreSame(pinViewModelBeforeReconnect, connectorAfterReconnect.First().ConnectorPinViewCollection.First());
         }
         #endregion
 

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -599,6 +599,59 @@ namespace DynamoCoreWpfTests
             var restoredPin = restoredConnector.ConnectorModel.ConnectorPinModels.FirstOrDefault(p => p.GUID == pinModelGuid);
             Assert.IsNotNull(restoredPin, "Expected pin model not found after undo.");
         }
+
+        [Test]
+        public void CanUndoInputPortReconnectionWithConnectorPin()
+        {
+            Open(@"UI/ConnectorPinTests.dyn");
+
+            var targetOutputNodeId = Guid.Parse("90cd0dca-45c7-456b-bb63-726d2193dbb4");
+            var targetOutputNode = this.ViewModel.Model.CurrentWorkspace.GetModelInternal(targetOutputNodeId) as NodeModel;
+            Assert.IsNotNull(targetOutputNode);
+
+            var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
+            var initialConnectorPinCount = connectorViewModel.ConnectorPinViewCollection.Count;
+
+            connectorViewModel.PanelX = 292.66666;
+            connectorViewModel.PanelY = 278;
+            connectorViewModel.FlipOnConnectorAnchor();
+            connectorViewModel.PinConnectorCommand.Execute(null);
+
+            Assert.AreEqual(initialConnectorPinCount + 1, connectorViewModel.ConnectorPinViewCollection.Count);
+            var pinModelGuid = connectorViewModel.ConnectorModel.ConnectorPinModels.First().GUID;
+            var originalConnectorGuid = connectorViewModel.ConnectorModel.GUID;
+
+            var endPort = connectorViewModel.ConnectorModel.End;
+            var endNode = endPort.Owner;
+            var endPortIndex = endNode.InPorts.IndexOf(endPort);
+
+            this.ViewModel.ExecuteCommand(
+                new DynamoModel.MakeConnectionCommand(endNode.GUID, endPortIndex, PortType.Input,
+                MakeConnectionCommand.Mode.Begin));
+
+            var activeConnector = this.ViewModel.CurrentSpaceViewModel.WorkspaceElements
+                .OfType<ConnectorViewModel>()
+                .FirstOrDefault(c => c.IsConnecting);
+            Assert.IsNotNull(activeConnector);
+            Assert.AreEqual(0, activeConnector.ConnectorPinViewCollection.Count);
+
+            this.ViewModel.ExecuteCommand(
+                new DynamoModel.MakeConnectionCommand(targetOutputNode.GUID, 0, PortType.Output,
+                MakeConnectionCommand.Mode.End));
+
+            var connectorAfterReconnect = this.ViewModel.CurrentSpaceViewModel.Connectors;
+            Assert.AreEqual(1, connectorAfterReconnect.Count());
+            Assert.IsTrue(connectorAfterReconnect.First().ConnectorModel.ConnectorPinModels.Any(p => p.GUID == pinModelGuid));
+
+            Model.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));
+
+            var restoredConnector = this.ViewModel.CurrentSpaceViewModel.Connectors
+                .FirstOrDefault(c => c.ConnectorModel.GUID == originalConnectorGuid);
+
+            Assert.IsNotNull(restoredConnector);
+            Assert.AreEqual(initialConnectorPinCount + 1, restoredConnector.ConnectorPinViewCollection.Count);
+            Assert.IsTrue(restoredConnector.ConnectorModel.ConnectorPinModels.Any(p => p.GUID == pinModelGuid));
+        }
         #endregion
     }
 }


### PR DESCRIPTION
### Purpose

This PR addresses the issue where connector pins were deleted and recreated during a disconnect and subsequent reconnect operation. The previous behavior resulted in new pin instances and GUIDs. This change ensures that the original `ConnectorPinModel` instances are preserved and reused across disconnect/reconnect cycles, maintaining their identity. Additionally, transient connectors no longer create temporary pins, instead using the original pin positions for bezier curve routing.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Connector pins are now preserved during disconnect and reconnect operations, ensuring their identity (GUIDs) remains consistent. Transient connectors no longer display temporary pins but still use the original pin positions to define their bezier curve.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

---
<p><a href="https://cursor.com/agents/bc-5b3e3741-c6d3-4bf6-be45-2cde7cc730a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b3e3741-c6d3-4bf6-be45-2cde7cc730a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

