### PR TITLE
Connector pin caching

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
@@ -346,8 +346,15 @@ namespace Dynamo.ViewModels
 
         public override void Dispose()
         {
-            model.PropertyChanged -= OnPinPropertyChanged;
-            DynamoSelection.Instance.Selection.CollectionChanged -= SelectionOnCollectionChanged;
+            if (model != null)
+            {
+                model.PropertyChanged -= OnPinPropertyChanged;
+            }
+
+            if (DynamoSelection.Instance?.Selection != null)
+            {
+                DynamoSelection.Instance.Selection.CollectionChanged -= SelectionOnCollectionChanged;
+            }
             base.Dispose();
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1117,7 +1117,14 @@ namespace Dynamo.ViewModels
         /// <param name="connectorPin"></param>
         private void RemoveConnectorPinModelViewModel(ConnectorPinModel connectorPin)
         {
-            var matchingConnectorPinViewModel = this.workspaceViewModel.Pins.FirstOrDefault(x => x.Model.GUID == connectorPin.GUID);
+            var matchingConnectorPinViewModel = ConnectorPinViewCollection
+                .FirstOrDefault(x => x.Model.GUID == connectorPin.GUID);
+
+            // Fallback to workspace-level lookup for legacy edge cases where the
+            // pin may no longer be tracked in this connector collection.
+            matchingConnectorPinViewModel ??= this.workspaceViewModel.Pins
+                .FirstOrDefault(x => x.Model.GUID == connectorPin.GUID);
+
             if (matchingConnectorPinViewModel is null) return;
             RemoveConnectorPinModelViewModel(matchingConnectorPinViewModel);
         }
@@ -1509,6 +1516,29 @@ namespace Dynamo.ViewModels
                     Guid.Empty);
 
                 AddConnectorPinViewModel(transientPinModel, true);
+            }
+        }
+
+        /// <summary>
+        /// Reuses existing pin models as transient pin visuals for a temporary connector (ConnectorModel == null).
+        /// </summary>
+        /// <param name="pinModels">Existing pin models detached from the original connector.</param>
+        internal void SetTransientConnectorPins(IEnumerable<ConnectorPinModel> pinModels)
+        {
+            if (ConnectorModel != null || pinModels == null)
+            {
+                return;
+            }
+
+            DiscardAllConnectorPinModels();
+            foreach (var pinModel in pinModels)
+            {
+                if (pinModel == null)
+                {
+                    continue;
+                }
+
+                AddConnectorPinViewModel(pinModel, true);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1578,7 +1578,10 @@ namespace Dynamo.ViewModels
         /// bezier routing while the cached pin visuals remain visible.
         /// </summary>
         /// <param name="pinViewModels">Existing pin view models detached from the original connector.</param>
-        internal void SetTransientConnectorPins(IEnumerable<ConnectorPinViewModel> pinViewModels)
+        /// <param name="pinLocations">Optional cached pin model locations used for transient bezier routing.</param>
+        internal void SetTransientConnectorPins(
+            IEnumerable<ConnectorPinViewModel> pinViewModels,
+            IEnumerable<(double X, double Y)> pinLocations = null)
         {
             if (ConnectorModel != null || pinViewModels == null)
             {
@@ -1588,6 +1591,15 @@ namespace Dynamo.ViewModels
             ClearTransientPinCache();
             DiscardAllConnectorPinModels();
 
+            if (pinLocations != null)
+            {
+                foreach (var pinLocation in pinLocations)
+                {
+                    transientCachedPinLocations.Add(new Point(pinLocation.X, pinLocation.Y));
+                }
+            }
+
+            var useViewModelLocations = transientCachedPinLocations.Count == 0;
             foreach (var pinViewModel in pinViewModels)
             {
                 if (pinViewModel == null)
@@ -1600,7 +1612,11 @@ namespace Dynamo.ViewModels
                 pinViewModel.IsCollapsed = this.IsCollapsed;
                 pinViewModel.IsInteractive = false;
 
-                transientCachedPinLocations.Add(new Point(pinViewModel.Left, pinViewModel.Top));
+                if (useViewModelLocations)
+                {
+                    transientCachedPinLocations.Add(new Point(pinViewModel.Left, pinViewModel.Top));
+                }
+
                 if (!workspaceViewModel.Pins.Contains(pinViewModel))
                 {
                     workspaceViewModel.Pins.Add(pinViewModel);

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -56,6 +56,7 @@ namespace Dynamo.ViewModels
         private Point curvePoint2;
         private Point curvePoint3;
         private bool suppressPinViewModelRemovalFromModelCollection;
+        private bool suppressRedrawFromCollectionChanges;
         private readonly List<ConnectorPinViewModel> transientCachedPinVisuals = new List<ConnectorPinViewModel>();
         private readonly List<Point> transientCachedPinLocations = new List<Point>();
 
@@ -1237,6 +1238,11 @@ namespace Dynamo.ViewModels
 
         private void HandleCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
+            if (suppressRedrawFromCollectionChanges)
+            {
+                return;
+            }
+
             Redraw();
         }
 
@@ -1553,15 +1559,23 @@ namespace Dynamo.ViewModels
                 return extractedPins;
             }
 
-            foreach (var pinViewModel in ConnectorPinViewCollection.ToList())
+            suppressRedrawFromCollectionChanges = true;
+            try
             {
-                pinViewModel.PropertyChanged -= PinViewModelPropertyChanged;
-                pinViewModel.RequestSelect -= HandleRequestSelected;
-                pinViewModel.RequestRedraw -= HandlerRedrawRequest;
-                pinViewModel.RequestRemove -= HandleConnectorPinViewModelRemove;
-                ConnectorPinViewCollection.Remove(pinViewModel);
-                pinViewModel.IsInteractive = false;
-                extractedPins.Add(pinViewModel);
+                foreach (var pinViewModel in ConnectorPinViewCollection.ToList())
+                {
+                    pinViewModel.PropertyChanged -= PinViewModelPropertyChanged;
+                    pinViewModel.RequestSelect -= HandleRequestSelected;
+                    pinViewModel.RequestRedraw -= HandlerRedrawRequest;
+                    pinViewModel.RequestRemove -= HandleConnectorPinViewModelRemove;
+                    ConnectorPinViewCollection.Remove(pinViewModel);
+                    pinViewModel.IsInteractive = false;
+                    extractedPins.Add(pinViewModel);
+                }
+            }
+            finally
+            {
+                suppressRedrawFromCollectionChanges = false;
             }
 
             if (ConnectorPinViewCollection.Count == 0)

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1611,14 +1611,22 @@ namespace Dynamo.ViewModels
         /// </summary>
         private void SetCollapsedByNodeViewModel()
         {
-            if (ConnectorModel?.Start == null || ConnectorModel?.End == null)
+            if ((ConnectorPinViewCollection?.Count > 0) || transientCachedPinLocations.Count > 0)
+            {
+                return;
+            }
+
+            var connectorModel = ConnectorModel;
+            if (connectorModel?.Start == null || connectorModel.End == null)
             {
                 return;
             }
 
             // Check if the connector is between two proxy ports. 
             // Connectors between proxy ports should not be collapsed.
-            bool bothEndsAreProxyPorts = ConnectorModel.Start.IsProxyPort && ConnectorModel.End.IsProxyPort;
+            var startPort = connectorModel.Start;
+            var endPort = connectorModel.End;
+            bool bothEndsAreProxyPorts = startPort.IsProxyPort && endPort.IsProxyPort;
 
             if (Nodevm?.IsCollapsed == true && NodeEnd?.IsCollapsed == true && !bothEndsAreProxyPorts)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1601,7 +1601,11 @@ namespace Dynamo.ViewModels
             {
                 foreach (var pinLocation in pinLocations)
                 {
-                    transientCachedPinLocations.Add(new Point(pinLocation.X, pinLocation.Y));
+                    // ConnectorPinModel stores Y in model-space, while the pin view model Top
+                    // is offset by OneThirdWidth. Normalize to the same top-left basis used by
+                    // ConnectorPinViewModel so transient and permanent bezier routing align.
+                    transientCachedPinLocations.Add(
+                        new Point(pinLocation.X, pinLocation.Y - ConnectorPinViewModel.OneThirdWidth));
                 }
             }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -56,7 +56,6 @@ namespace Dynamo.ViewModels
         private Point curvePoint2;
         private Point curvePoint3;
         private bool suppressPinViewModelRemovalFromModelCollection;
-        private bool suppressRedrawFromCollectionChanges;
         private readonly List<ConnectorPinViewModel> transientCachedPinVisuals = new List<ConnectorPinViewModel>();
         private readonly List<Point> transientCachedPinLocations = new List<Point>();
 
@@ -1238,11 +1237,6 @@ namespace Dynamo.ViewModels
 
         private void HandleCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            if (suppressRedrawFromCollectionChanges)
-            {
-                return;
-            }
-
             Redraw();
         }
 
@@ -1559,23 +1553,21 @@ namespace Dynamo.ViewModels
                 return extractedPins;
             }
 
-            suppressRedrawFromCollectionChanges = true;
-            try
+            transientCachedPinLocations.Clear();
+            foreach (var pinViewModel in ConnectorPinViewCollection)
             {
-                foreach (var pinViewModel in ConnectorPinViewCollection.ToList())
-                {
-                    pinViewModel.PropertyChanged -= PinViewModelPropertyChanged;
-                    pinViewModel.RequestSelect -= HandleRequestSelected;
-                    pinViewModel.RequestRedraw -= HandlerRedrawRequest;
-                    pinViewModel.RequestRemove -= HandleConnectorPinViewModelRemove;
-                    ConnectorPinViewCollection.Remove(pinViewModel);
-                    pinViewModel.IsInteractive = false;
-                    extractedPins.Add(pinViewModel);
-                }
+                transientCachedPinLocations.Add(new Point(pinViewModel.Left, pinViewModel.Top));
             }
-            finally
+
+            foreach (var pinViewModel in ConnectorPinViewCollection.ToList())
             {
-                suppressRedrawFromCollectionChanges = false;
+                pinViewModel.PropertyChanged -= PinViewModelPropertyChanged;
+                pinViewModel.RequestSelect -= HandleRequestSelected;
+                pinViewModel.RequestRedraw -= HandlerRedrawRequest;
+                pinViewModel.RequestRemove -= HandleConnectorPinViewModelRemove;
+                ConnectorPinViewCollection.Remove(pinViewModel);
+                pinViewModel.IsInteractive = false;
+                extractedPins.Add(pinViewModel);
             }
 
             if (ConnectorPinViewCollection.Count == 0)

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -55,6 +55,8 @@ namespace Dynamo.ViewModels
         private Point curvePoint1;
         private Point curvePoint2;
         private Point curvePoint3;
+        private readonly List<ConnectorPinViewModel> transientCachedPinVisuals = new List<ConnectorPinViewModel>();
+        private readonly List<Point> transientCachedPinLocations = new List<Point>();
 
         /// <summary>
         /// Required timer for desired delay prior to ' connector anchor' display.
@@ -241,6 +243,11 @@ namespace Dynamo.ViewModels
             {
                 pin.IsCollapsed = isCollapsed;
             }
+
+            foreach (var pin in transientCachedPinVisuals)
+            {
+                pin.IsCollapsed = isCollapsed;
+            }
         }
         private void SetVisibilityOfPins(bool isHidden)
         {
@@ -250,12 +257,22 @@ namespace Dynamo.ViewModels
             {
                 pin.IsHidden = isHidden;
             }
+
+            foreach (var pin in transientCachedPinVisuals)
+            {
+                pin.IsHidden = isHidden;
+            }
         }
         private void SetPartialVisibilityOfPins(bool isHidden)
         {
             if (ConnectorPinViewCollection is null) { return; }
 
             foreach (var pin in ConnectorPinViewCollection)
+            {
+                pin.IsTemporarilyVisible = isHidden;
+            }
+
+            foreach (var pin in transientCachedPinVisuals)
             {
                 pin.IsTemporarilyVisible = isHidden;
             }
@@ -1120,11 +1137,6 @@ namespace Dynamo.ViewModels
             var matchingConnectorPinViewModel = ConnectorPinViewCollection
                 .FirstOrDefault(x => x.Model.GUID == connectorPin.GUID);
 
-            // Fallback to workspace-level lookup for legacy edge cases where the
-            // pin may no longer be tracked in this connector collection.
-            matchingConnectorPinViewModel ??= this.workspaceViewModel.Pins
-                .FirstOrDefault(x => x.Model.GUID == connectorPin.GUID);
-
             if (matchingConnectorPinViewModel is null) return;
             RemoveConnectorPinModelViewModel(matchingConnectorPinViewModel);
         }
@@ -1284,6 +1296,7 @@ namespace Dynamo.ViewModels
             }
 
             this.PropertyChanged -= ConnectorViewModelPropertyChanged;
+            ClearTransientPinCache();
             DiscardAllConnectorPinModels();
 
             if (ConnectorContextMenuViewModel != null)
@@ -1506,6 +1519,7 @@ namespace Dynamo.ViewModels
                 return;
             }
 
+            ClearTransientPinCache();
             DiscardAllConnectorPinModels();
             foreach (var pinLocation in pinLocations)
             {
@@ -1520,7 +1534,8 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Reuses existing pin models as transient pin visuals for a temporary connector (ConnectorModel == null).
+        /// Caches existing pins for transient reconnection without attaching them to the transient connector.
+        /// Their positions are used for transient bezier routing while the cached pin visuals remain visible.
         /// </summary>
         /// <param name="pinModels">Existing pin models detached from the original connector.</param>
         internal void SetTransientConnectorPins(IEnumerable<ConnectorPinModel> pinModels)
@@ -1530,7 +1545,9 @@ namespace Dynamo.ViewModels
                 return;
             }
 
+            ClearTransientPinCache();
             DiscardAllConnectorPinModels();
+
             foreach (var pinModel in pinModels)
             {
                 if (pinModel == null)
@@ -1538,7 +1555,17 @@ namespace Dynamo.ViewModels
                     continue;
                 }
 
-                AddConnectorPinViewModel(pinModel, true);
+                transientCachedPinLocations.Add(new Point(pinModel.X, pinModel.Y));
+
+                var cachedPinViewModel = new ConnectorPinViewModel(this.workspaceViewModel, pinModel)
+                {
+                    IsHidden = this.IsHidden,
+                    IsTemporarilyVisible = isTemporarilyVisible,
+                    IsInteractive = false
+                };
+
+                workspaceViewModel.Pins.Add(cachedPinViewModel);
+                transientCachedPinVisuals.Add(cachedPinViewModel);
             }
         }
 
@@ -1551,7 +1578,7 @@ namespace Dynamo.ViewModels
         {
             try
             {
-                if (ConnectorPinViewCollection?.Count > 0)
+                if ((ConnectorPinViewCollection?.Count > 0) || transientCachedPinLocations.Count > 0)
                 {
                     if (this.ConnectorModel?.End != null)
                     {
@@ -1605,7 +1632,7 @@ namespace Dynamo.ViewModels
         /// <param name="parameter">The position of the end point</param>
         public void Redraw(object parameter)
         {
-            if (ConnectorPinViewCollection?.Count > 0)
+            if ((ConnectorPinViewCollection?.Count > 0) || transientCachedPinLocations.Count > 0)
             {
                 RedrawBezierManyPoints(parameter);
                 return;
@@ -1744,19 +1771,17 @@ namespace Dynamo.ViewModels
                 dotTop = CurvePoint3.Y - EndDotSize / 2;
                 dotLeft = CurvePoint3.X - EndDotSize / 2;
 
-                // Add chain of points including start/end
-                Point[] points = new Point[ConnectorPinViewCollection.Count];
-                int count = 0;
-                foreach (var wirePin in ConnectorPinViewCollection)
-                {
-                    points[count] = new Point(wirePin.Left+ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5), wirePin.Top+ ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5));
-                    count++;
-                }
-
                 var isInputStartReconnection = ActiveStartPort?.PortType == PortType.Input;
-                var orderedPoints = isInputStartReconnection
-                    ? points.OrderByDescending(p => p.X).ToList()
-                    : points.OrderBy(p => p.X).ToList();
+                var orderedPoints = GetBezierPinPoints()
+                    .OrderBy(p => p.X)
+                    .ToList();
+
+                if (isInputStartReconnection)
+                {
+                    orderedPoints = orderedPoints
+                        .OrderByDescending(p => p.X)
+                        .ToList();
+                }
 
                 orderedPoints.Insert(0, CurvePoint0);
                 orderedPoints.Insert(orderedPoints.Count, CurvePoint3);
@@ -1815,6 +1840,35 @@ namespace Dynamo.ViewModels
                 for (int j = 0; j < 2; j++)
                     outPointPairs[i, j] = points[i + j];
             return outPointPairs;
+        }
+
+        private IEnumerable<Point> GetBezierPinPoints()
+        {
+            if (ConnectorPinViewCollection?.Count > 0)
+            {
+                return ConnectorPinViewCollection
+                    .Select(wirePin => new Point(
+                        wirePin.Left + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5),
+                        wirePin.Top + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5)));
+            }
+
+            return transientCachedPinLocations
+                .Select(pinLocation => new Point(
+                    pinLocation.X + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5),
+                    pinLocation.Y + ConnectorPinModel.StaticWidth - (ConnectorPinViewModel.OneThirdWidth * 0.5)));
+        }
+
+        private void ClearTransientPinCache()
+        {
+            foreach (var pinViewModel in transientCachedPinVisuals.ToList())
+            {
+                workspaceViewModel.Pins.Remove(pinViewModel);
+                pinViewModel.Model.Dispose();
+                pinViewModel.Dispose();
+            }
+
+            transientCachedPinVisuals.Clear();
+            transientCachedPinLocations.Clear();
         }
 
         private bool CanRedraw(object parameter)

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -55,6 +55,7 @@ namespace Dynamo.ViewModels
         private Point curvePoint1;
         private Point curvePoint2;
         private Point curvePoint3;
+        private bool suppressPinViewModelRemovalFromModelCollection;
         private readonly List<ConnectorPinViewModel> transientCachedPinVisuals = new List<ConnectorPinViewModel>();
         private readonly List<Point> transientCachedPinLocations = new List<Point>();
 
@@ -1120,6 +1121,11 @@ namespace Dynamo.ViewModels
                     }
                     break;
                 case NotifyCollectionChangedAction.Remove:
+                    if (suppressPinViewModelRemovalFromModelCollection)
+                    {
+                        break;
+                    }
+
                     foreach (ConnectorPinModel oldItem in e.OldItems)
                     {
                         RemoveConnectorPinModelViewModel(oldItem);
@@ -1534,13 +1540,47 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Caches existing pins for transient reconnection without attaching them to the transient connector.
-        /// Their positions are used for transient bezier routing while the cached pin visuals remain visible.
+        /// Extracts connector pin view models so they can be cached and displayed during transient reconnection.
         /// </summary>
-        /// <param name="pinModels">Existing pin models detached from the original connector.</param>
-        internal void SetTransientConnectorPins(IEnumerable<ConnectorPinModel> pinModels)
+        /// <returns>Pin view models detached from this connector.</returns>
+        internal List<ConnectorPinViewModel> ExtractPinsForTransientConnector()
         {
-            if (ConnectorModel != null || pinModels == null)
+            suppressPinViewModelRemovalFromModelCollection = true;
+            var extractedPins = new List<ConnectorPinViewModel>();
+
+            if (ConnectorPinViewCollection == null || ConnectorPinViewCollection.Count == 0)
+            {
+                return extractedPins;
+            }
+
+            foreach (var pinViewModel in ConnectorPinViewCollection.ToList())
+            {
+                pinViewModel.PropertyChanged -= PinViewModelPropertyChanged;
+                pinViewModel.RequestSelect -= HandleRequestSelected;
+                pinViewModel.RequestRedraw -= HandlerRedrawRequest;
+                pinViewModel.RequestRemove -= HandleConnectorPinViewModelRemove;
+                ConnectorPinViewCollection.Remove(pinViewModel);
+                pinViewModel.IsInteractive = false;
+                extractedPins.Add(pinViewModel);
+            }
+
+            if (ConnectorPinViewCollection.Count == 0)
+            {
+                BezierControlPoints = null;
+            }
+
+            return extractedPins;
+        }
+
+        /// <summary>
+        /// Caches existing pin view models for transient reconnection without attaching them
+        /// to the transient connector pin collection. Their positions are used for transient
+        /// bezier routing while the cached pin visuals remain visible.
+        /// </summary>
+        /// <param name="pinViewModels">Existing pin view models detached from the original connector.</param>
+        internal void SetTransientConnectorPins(IEnumerable<ConnectorPinViewModel> pinViewModels)
+        {
+            if (ConnectorModel != null || pinViewModels == null)
             {
                 return;
             }
@@ -1548,24 +1588,25 @@ namespace Dynamo.ViewModels
             ClearTransientPinCache();
             DiscardAllConnectorPinModels();
 
-            foreach (var pinModel in pinModels)
+            foreach (var pinViewModel in pinViewModels)
             {
-                if (pinModel == null)
+                if (pinViewModel == null)
                 {
                     continue;
                 }
 
-                transientCachedPinLocations.Add(new Point(pinModel.X, pinModel.Y));
+                pinViewModel.IsHidden = this.IsHidden;
+                pinViewModel.IsTemporarilyVisible = isTemporarilyVisible;
+                pinViewModel.IsCollapsed = this.IsCollapsed;
+                pinViewModel.IsInteractive = false;
 
-                var cachedPinViewModel = new ConnectorPinViewModel(this.workspaceViewModel, pinModel)
+                transientCachedPinLocations.Add(new Point(pinViewModel.Left, pinViewModel.Top));
+                if (!workspaceViewModel.Pins.Contains(pinViewModel))
                 {
-                    IsHidden = this.IsHidden,
-                    IsTemporarilyVisible = isTemporarilyVisible,
-                    IsInteractive = false
-                };
+                    workspaceViewModel.Pins.Add(pinViewModel);
+                }
 
-                workspaceViewModel.Pins.Add(cachedPinViewModel);
-                transientCachedPinVisuals.Add(cachedPinViewModel);
+                transientCachedPinVisuals.Add(pinViewModel);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -206,10 +206,11 @@ namespace Dynamo.ViewModels
                     .FirstOrDefault(x => x.ConnectorModel == existingConnector);
                 var extractedPins = existingConnectorViewModel?.ExtractPinsForTransientConnector()
                     ?? new List<ConnectorPinViewModel>();
+                var extractedPinLocations = existingConnector.GetPinLocations().ToList();
 
                 // Define the new active connector
                 var activeConnector = new ConnectorViewModel(this, existingConnector.Start);
-                activeConnector.SetTransientConnectorPins(extractedPins);
+                activeConnector.SetTransientConnectorPins(extractedPins, extractedPinLocations);
                 activeConnector.Redraw(existingConnector.End.Center);
                 var c = new ConnectorViewModel[] { activeConnector };
                 this.SetActiveConnectors(c);
@@ -256,9 +257,10 @@ namespace Dynamo.ViewModels
                     .FirstOrDefault(x => x.ConnectorModel == selectedConnector);
                 var extractedPins = selectedConnectorViewModel?.ExtractPinsForTransientConnector()
                     ?? new List<ConnectorPinViewModel>();
+                var extractedPinLocations = selectedConnector.GetPinLocations().ToList();
 
                 var c = new ConnectorViewModel(this, selectedConnector.End);
-                c.SetTransientConnectorPins(extractedPins);
+                c.SetTransientConnectorPins(extractedPins, extractedPinLocations);
                 c.Redraw(selectedConnector.Start.Center);
                 connectorsAr[i] = c;
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -202,10 +202,14 @@ namespace Dynamo.ViewModels
             if (portModel.Connectors.Count > 0 && portModel.Connectors[0].Start != portModel)
             {
                 var existingConnector = portModel.Connectors[0];
+                var existingConnectorViewModel = Connectors
+                    .FirstOrDefault(x => x.ConnectorModel == existingConnector);
+                var extractedPins = existingConnectorViewModel?.ExtractPinsForTransientConnector()
+                    ?? new List<ConnectorPinViewModel>();
 
                 // Define the new active connector
                 var activeConnector = new ConnectorViewModel(this, existingConnector.Start);
-                activeConnector.SetTransientConnectorPins(existingConnector.ConnectorPinModels.ToList());
+                activeConnector.SetTransientConnectorPins(extractedPins);
                 activeConnector.Redraw(existingConnector.End.Center);
                 var c = new ConnectorViewModel[] { activeConnector };
                 this.SetActiveConnectors(c);
@@ -248,8 +252,13 @@ namespace Dynamo.ViewModels
             for (int i = 0; i < selectedConnectors.Count; i++)
             {
                 var selectedConnector = selectedConnectors[i];
+                var selectedConnectorViewModel = Connectors
+                    .FirstOrDefault(x => x.ConnectorModel == selectedConnector);
+                var extractedPins = selectedConnectorViewModel?.ExtractPinsForTransientConnector()
+                    ?? new List<ConnectorPinViewModel>();
+
                 var c = new ConnectorViewModel(this, selectedConnector.End);
-                c.SetTransientConnectorPins(selectedConnector.ConnectorPinModels.ToList());
+                c.SetTransientConnectorPins(extractedPins);
                 c.Redraw(selectedConnector.Start.Center);
                 connectorsAr[i] = c;
             }

--- a/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/StateMachine.cs
@@ -205,7 +205,7 @@ namespace Dynamo.ViewModels
 
                 // Define the new active connector
                 var activeConnector = new ConnectorViewModel(this, existingConnector.Start);
-                activeConnector.SetTransientConnectorPinPositions(existingConnector.GetPinLocations());
+                activeConnector.SetTransientConnectorPins(existingConnector.ConnectorPinModels.ToList());
                 activeConnector.Redraw(existingConnector.End.Center);
                 var c = new ConnectorViewModel[] { activeConnector };
                 this.SetActiveConnectors(c);
@@ -249,7 +249,7 @@ namespace Dynamo.ViewModels
             {
                 var selectedConnector = selectedConnectors[i];
                 var c = new ConnectorViewModel(this, selectedConnector.End);
-                c.SetTransientConnectorPinPositions(selectedConnector.GetPinLocations());
+                c.SetTransientConnectorPins(selectedConnector.ConnectorPinModels.ToList());
                 c.Redraw(selectedConnector.Start.Center);
                 connectorsAr[i] = c;
             }

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -325,6 +325,9 @@ namespace DynamoCoreWpfTests
 
             // Assert that the pin was added
             Assert.AreEqual(initialConnectorPinCount + 1, connectorViewModel.ConnectorPinViewCollection.Count);
+            var originalPinGuids = connectorViewModel.ConnectorModel.ConnectorPinModels
+                .Select(pin => pin.GUID)
+                .ToList();
 
             // Begin reconnection – simulate grabbing the connector and starting a shift drag
             var startPort = connectorViewModel.ConnectorModel.Start;
@@ -344,6 +347,9 @@ namespace DynamoCoreWpfTests
             Assert.IsNull(activeConnector.ConnectorModel, "Expected active connector to be transient during drag.");
             Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
             Assert.IsTrue(activeConnector.ConnectorPinViewCollection.All(pin => !pin.IsInteractive));
+            CollectionAssert.AreEquivalent(
+                originalPinGuids,
+                activeConnector.ConnectorPinViewCollection.Select(pin => pin.Model.GUID));
 
             // Execute the second part of the workflow - simulate placing the connectors over the new port
             this.ViewModel.ExecuteCommand(
@@ -355,6 +361,54 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(1, connectorAfterReconnect.Count());
             Assert.AreEqual(initialConnectorPinCount + 1, connectorAfterReconnect.First().ConnectorPinViewCollection.Count);
             Assert.IsTrue(connectorAfterReconnect.First().ConnectorPinViewCollection.All(pin => pin.IsInteractive));
+            Assert.IsFalse(
+                connectorAfterReconnect.First().ConnectorModel.ConnectorPinModels
+                    .Any(pin => originalPinGuids.Contains(pin.GUID)),
+                "Expected permanent connector pins to be recreated from cached positions.");
+        }
+
+        [Test]
+        public void BeginReconnectionReusesOriginalPinModelsInTransientConnector()
+        {
+            Open(@"UI/ConnectorPinTests.dyn");
+
+            var connectorViewModel = this.ViewModel.CurrentSpaceViewModel.Connectors.First();
+
+            // Add one pin before beginning reconnection.
+            connectorViewModel.PanelX = 292.66666;
+            connectorViewModel.PanelY = 278;
+            connectorViewModel.FlipOnConnectorAnchor();
+            connectorViewModel.PinConnectorCommand.Execute(null);
+
+            var originalPinGuids = connectorViewModel.ConnectorModel.ConnectorPinModels
+                .Select(pin => pin.GUID)
+                .ToList();
+
+            var endPort = connectorViewModel.ConnectorModel.End;
+            this.ViewModel.ExecuteCommand(
+                new DynamoModel.MakeConnectionCommand(
+                    endPort.Owner.GUID,
+                    endPort.Index,
+                    PortType.Input,
+                    MakeConnectionCommand.Mode.Begin));
+
+            var activeConnector = this.ViewModel.CurrentSpaceViewModel.WorkspaceElements
+                .OfType<ConnectorViewModel>()
+                .FirstOrDefault(c => c.IsConnecting);
+
+            Assert.IsNotNull(activeConnector);
+            Assert.IsNull(activeConnector.ConnectorModel);
+            CollectionAssert.AreEquivalent(
+                originalPinGuids,
+                activeConnector.ConnectorPinViewCollection.Select(pin => pin.Model.GUID));
+
+            // Clean up active reconnection state.
+            this.ViewModel.ExecuteCommand(
+                new DynamoModel.MakeConnectionCommand(
+                    Guid.Empty,
+                    -1,
+                    PortType.Input,
+                    MakeConnectionCommand.Mode.Cancel));
         }
         #endregion
 

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -306,7 +306,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        public void ShiftReconnectionUsesNonInteractiveTransientPinsAndPersistsPins()
+        public void ShiftReconnectionUsesCachedPinPositionsAndPersistsPins()
         {
             // Open a test graph with at least two connected nodes
             Open(@"UI/ConnectorPinTests.dyn");
@@ -328,6 +328,7 @@ namespace DynamoCoreWpfTests
             var originalPinGuids = connectorViewModel.ConnectorModel.ConnectorPinModels
                 .Select(pin => pin.GUID)
                 .ToList();
+            var workspacePinCountBeforeReconnect = this.ViewModel.CurrentSpaceViewModel.Pins.Count;
 
             // Begin reconnection – simulate grabbing the connector and starting a shift drag
             var startPort = connectorViewModel.ConnectorModel.Start;
@@ -342,14 +343,15 @@ namespace DynamoCoreWpfTests
                 .OfType<ConnectorViewModel>()
                 .FirstOrDefault(c => c.IsConnecting);
 
-            // Assert that during shift reconnection, a transient connector is created that has the same number of pins
+            // Assert that transient connector uses cached positions instead of transient pin collection.
             Assert.IsNotNull(activeConnector);
             Assert.IsNull(activeConnector.ConnectorModel, "Expected active connector to be transient during drag.");
-            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
-            Assert.IsTrue(activeConnector.ConnectorPinViewCollection.All(pin => !pin.IsInteractive));
-            CollectionAssert.AreEquivalent(
-                originalPinGuids,
-                activeConnector.ConnectorPinViewCollection.Select(pin => pin.Model.GUID));
+            Assert.AreEqual(0, activeConnector.ConnectorPinViewCollection.Count);
+            Assert.AreEqual(workspacePinCountBeforeReconnect, this.ViewModel.CurrentSpaceViewModel.Pins.Count);
+
+            activeConnector.Redraw(new Point2D(650, 350));
+            Assert.IsNotNull(activeConnector.ComputedBezierPathGeometry);
+            Assert.Greater(activeConnector.ComputedBezierPathGeometry.Figures.Count, 1);
 
             // Execute the second part of the workflow - simulate placing the connectors over the new port
             this.ViewModel.ExecuteCommand(
@@ -368,7 +370,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        public void BeginReconnectionReusesOriginalPinModelsInTransientConnector()
+        public void BeginReconnectionUsesCachedPinPositionsWithoutTransientConnectorPins()
         {
             Open(@"UI/ConnectorPinTests.dyn");
 
@@ -380,9 +382,7 @@ namespace DynamoCoreWpfTests
             connectorViewModel.FlipOnConnectorAnchor();
             connectorViewModel.PinConnectorCommand.Execute(null);
 
-            var originalPinGuids = connectorViewModel.ConnectorModel.ConnectorPinModels
-                .Select(pin => pin.GUID)
-                .ToList();
+            var workspacePinCountBeforeReconnect = this.ViewModel.CurrentSpaceViewModel.Pins.Count;
 
             var endPort = connectorViewModel.ConnectorModel.End;
             this.ViewModel.ExecuteCommand(
@@ -398,9 +398,12 @@ namespace DynamoCoreWpfTests
 
             Assert.IsNotNull(activeConnector);
             Assert.IsNull(activeConnector.ConnectorModel);
-            CollectionAssert.AreEquivalent(
-                originalPinGuids,
-                activeConnector.ConnectorPinViewCollection.Select(pin => pin.Model.GUID));
+            Assert.AreEqual(0, activeConnector.ConnectorPinViewCollection.Count);
+            Assert.AreEqual(workspacePinCountBeforeReconnect, this.ViewModel.CurrentSpaceViewModel.Pins.Count);
+
+            activeConnector.Redraw(new Point2D(650, 350));
+            Assert.IsNotNull(activeConnector.ComputedBezierPathGeometry);
+            Assert.Greater(activeConnector.ComputedBezierPathGeometry.Figures.Count, 1);
 
             // Clean up active reconnection state.
             this.ViewModel.ExecuteCommand(
@@ -409,6 +412,8 @@ namespace DynamoCoreWpfTests
                     -1,
                     PortType.Input,
                     MakeConnectionCommand.Mode.Cancel));
+
+            Assert.AreEqual(0, this.ViewModel.CurrentSpaceViewModel.Pins.Count);
         }
         #endregion
 
@@ -600,6 +605,7 @@ namespace DynamoCoreWpfTests
             // Sanity check: we added 1 pin
             Assert.AreEqual(initialConnectorPinCount + 1, connectorViewModel.ConnectorPinViewCollection.Count);
             var pinModelGuid = connectorViewModel.ConnectorModel.ConnectorPinModels.First().GUID;
+            var workspacePinCountBeforeReconnect = this.ViewModel.CurrentSpaceViewModel.Pins.Count;
 
             // Begin reconnection – simulate grabbing the connector and starting a shift drag
             var connectorGuid = connectorViewModel.ConnectorModel.GUID;
@@ -616,7 +622,8 @@ namespace DynamoCoreWpfTests
                 .OfType<ConnectorViewModel>()
                 .FirstOrDefault(c => c.IsConnecting);
             Assert.IsNotNull(activeConnector);
-            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
+            Assert.AreEqual(0, activeConnector.ConnectorPinViewCollection.Count);
+            Assert.AreEqual(workspacePinCountBeforeReconnect, this.ViewModel.CurrentSpaceViewModel.Pins.Count);
 
             activeConnector.Redraw(new Point2D(650, 350));
             Assert.IsNotNull(activeConnector.ComputedBezierPathGeometry);


### PR DESCRIPTION
### Purpose

This PR optimizes the connector pin lifecycle to prevent redundant recreation of pins during disconnect and reconnect operations. Previously, pins were recreated twice: once for the transient connector and again for the final permanent connector. This change ensures that original pins are cached and reused for the transient connector, and only recreated once when the new permanent connector is established.

### Declarations

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Optimized connector pin lifecycle to prevent redundant recreation during disconnect/reconnect operations. Original pins are now cached and reused for transient connectors, and only recreated once for the final permanent connector.

### Reviewers

(FILL ME IN)

### FYIs

The `dotnet test` command could not be executed in the environment where these changes were made. Full test validation should be performed in a standard development/CI environment.

---
<p><a href="https://cursor.com/agents/bc-98dff296-a370-4267-aac9-c17f95eba660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98dff296-a370-4267-aac9-c17f95eba660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

