### PR TITLE
connector reattachment performance #1

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -58,6 +58,8 @@ namespace Dynamo.ViewModels
         private readonly List<ConnectorPinViewModel> transientCachedPins = new List<ConnectorPinViewModel>();
         private readonly List<Point> transientCachedPinLocations = new List<Point>();
         private bool suppressPinVMRemoval;
+        private int pinCollectionRedrawDeferralDepth;
+        private bool pinCollectionRedrawPending;
 
         /// <summary>
         /// Required timer for desired delay prior to ' connector anchor' display.
@@ -1042,17 +1044,20 @@ namespace Dynamo.ViewModels
             model.ConnectorPinModels.CollectionChanged += ConnectorPinModelCollectionChanged;
 
             ConnectorPinViewCollection = new ObservableCollection<ConnectorPinViewModel>();
-            ConnectorPinViewCollection.CollectionChanged += HandleCollectionChanged;
             workspaceViewModel.PropertyChanged += WorkspaceViewModel_PropertyChanged;
 
 
             if (connectorModel.ConnectorPinModels != null)
             {
-                foreach (var p in connectorModel.ConnectorPinModels)
+                using (DeferPinCollectionRedraw())
                 {
-                    AddConnectorPinViewModel(p);
+                    foreach (var p in connectorModel.ConnectorPinModels)
+                    {
+                        AddConnectorPinViewModel(p);
+                    }
                 }
             }
+            ConnectorPinViewCollection.CollectionChanged += HandleCollectionChanged;
 
             connectorModel.Start.PropertyChanged += StartPortModel_PropertyChanged;
             connectorModel.End.PropertyChanged += EndPortModel_PropertyChanged;
@@ -1100,15 +1105,21 @@ namespace Dynamo.ViewModels
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    foreach (ConnectorPinModel newItem in e.NewItems)
+                    using (DeferPinCollectionRedraw())
                     {
-                        AddConnectorPinViewModel(newItem);
+                        foreach (ConnectorPinModel newItem in e.NewItems)
+                        {
+                            AddConnectorPinViewModel(newItem);
+                        }
                     }
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                    foreach (ConnectorPinModel oldItem in e.OldItems)
+                    using (DeferPinCollectionRedraw())
                     {
-                        RemoveConnectorPinModelViewModel(oldItem);
+                        foreach (ConnectorPinModel oldItem in e.OldItems)
+                        {
+                            RemoveConnectorPinModelViewModel(oldItem);
+                        }
                     }
                     break;
                 default: break;
@@ -1217,7 +1228,43 @@ namespace Dynamo.ViewModels
 
         private void HandleCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
+            if (pinCollectionRedrawDeferralDepth > 0)
+            {
+                pinCollectionRedrawPending = true;
+                return;
+            }
+
             Redraw();
+        }
+
+        private IDisposable DeferPinCollectionRedraw()
+        {
+            pinCollectionRedrawDeferralDepth++;
+            return new PinCollectionRedrawDeferral(this);
+        }
+
+        private sealed class PinCollectionRedrawDeferral : IDisposable
+        {
+            private ConnectorViewModel owner;
+
+            internal PinCollectionRedrawDeferral(ConnectorViewModel owner)
+            {
+                this.owner = owner;
+            }
+
+            public void Dispose()
+            {
+                if (owner is null) return;
+
+                owner.pinCollectionRedrawDeferralDepth = Math.Max(0, owner.pinCollectionRedrawDeferralDepth - 1);
+                if (owner.pinCollectionRedrawDeferralDepth == 0 && owner.pinCollectionRedrawPending)
+                {
+                    owner.pinCollectionRedrawPending = false;
+                    owner.Redraw();
+                }
+
+                owner = null;
+            }
         }
 
         private void WorkspaceViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -1436,18 +1483,21 @@ namespace Dynamo.ViewModels
 
         private void HandlePinModelChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            foreach (ConnectorPinModel oldPin in e.OldItems)
+            using (DeferPinCollectionRedraw())
             {
-                var matchingPinViewModel = ConnectorPinViewCollection.FirstOrDefault(pin => pin.ConnectorGuid == oldPin.ConnectorId);
-                oldPin.Dispose();
+                foreach (ConnectorPinModel oldPin in e.OldItems)
+                {
+                    var matchingPinViewModel = ConnectorPinViewCollection.FirstOrDefault(pin => pin.ConnectorGuid == oldPin.ConnectorId);
+                    oldPin.Dispose();
 
-                workspaceViewModel.Pins.Remove(matchingPinViewModel);
-                ConnectorPinViewCollection.Remove(matchingPinViewModel);
+                    workspaceViewModel.Pins.Remove(matchingPinViewModel);
+                    ConnectorPinViewCollection.Remove(matchingPinViewModel);
 
-                if (ConnectorPinViewCollection.Count == 0)
-                    BezierControlPoints = null;
+                    if (ConnectorPinViewCollection.Count == 0)
+                        BezierControlPoints = null;
 
-                matchingPinViewModel.Dispose();
+                    matchingPinViewModel.Dispose();
+                }
             }
         }
 
@@ -1511,16 +1561,19 @@ namespace Dynamo.ViewModels
                 return extractedPins;
             }
 
-            foreach (var pinViewModel in ConnectorPinViewCollection.ToList())
+            using (DeferPinCollectionRedraw())
             {
-                pinViewModel.PropertyChanged -= PinViewModelPropertyChanged;
-                pinViewModel.RequestSelect -= HandleRequestSelected;
-                pinViewModel.RequestRedraw -= HandlerRedrawRequest;
-                pinViewModel.RequestRemove -= HandleConnectorPinViewModelRemove;
-                pinViewModel.IsInteractive = false;
+                foreach (var pinViewModel in ConnectorPinViewCollection.ToList())
+                {
+                    pinViewModel.PropertyChanged -= PinViewModelPropertyChanged;
+                    pinViewModel.RequestSelect -= HandleRequestSelected;
+                    pinViewModel.RequestRedraw -= HandlerRedrawRequest;
+                    pinViewModel.RequestRemove -= HandleConnectorPinViewModelRemove;
+                    pinViewModel.IsInteractive = false;
 
-                ConnectorPinViewCollection.Remove(pinViewModel);
-                extractedPins.Add(pinViewModel);
+                    ConnectorPinViewCollection.Remove(pinViewModel);
+                    extractedPins.Add(pinViewModel);
+                }
             }
 
             return extractedPins;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

This PR addresses significant UI lag observed when reattaching a permanent connector that has multiple pins. The primary cause identified was redundant full connector redraws occurring for each pin added during the reconnection process. This change optimizes the redraw behavior to occur only once after all pins have been processed.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Improved performance and reduced UI lag when reattaching connectors with multiple pins by optimizing redraw operations.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

---
<p><a href="https://cursor.com/agents/bc-8bee8b3e-b1eb-40dd-a3ec-7f516a22a88f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bee8b3e-b1eb-40dd-a3ec-7f516a22a88f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->