### PR TITLE
Pasted connector pins

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
+++ b/src/DynamoCore/Graph/Workspaces/WorkspaceModel.cs
@@ -2636,7 +2636,7 @@ namespace Dynamo.Graph.Workspaces
                 var connectorGuid = IdToGuidConverter(pinViewInfo.ConnectorGuid);
 
                 var matchingConnector = Connectors.FirstOrDefault(x => x.GUID == connectorGuid);
-                if (matchingConnector is null) { return; }
+                if (matchingConnector is null) { continue; }
 
                 if (offsetX == 0.0 && offsetY == 0.0)
                 {

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -3399,6 +3399,12 @@ namespace Dynamo.Models
                     AddToSelection(item);
                 }
 
+                // Keep connector pins selected together with the pasted graph chunk.
+                foreach (var connectorPin in newConnectorPins)
+                {
+                    AddToSelection(connectorPin);
+                }
+
                 DynamoSelection.Instance.ClearSelectionDisabled = false;
 
                 // Record models that are created as part of the command.

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -3144,6 +3144,15 @@ namespace Dynamo.Models
 
                 ClipBoard.AddRange(connectors);
             }
+
+            var connectorPins = ClipBoard
+                .OfType<ConnectorModel>()
+                .SelectMany(connector => connector.ConnectorPinModels)
+                .Where(pin => !ClipBoard.Contains(pin))
+                .Cast<ModelBase>()
+                .ToList();
+
+            ClipBoard.AddRange(connectorPins);
         }
 
         /// <summary>
@@ -3193,6 +3202,7 @@ namespace Dynamo.Models
 
             var nodes = ClipBoard.OfType<NodeModel>();
             var connectors = ClipBoard.OfType<ConnectorModel>();
+            var connectorPins = ClipBoard.OfType<ConnectorPinModel>();
             var notes = ClipBoard.OfType<NoteModel>();
             // we only want to get groups that either has nested groups
             // or does not belong to a group here.
@@ -3287,26 +3297,58 @@ namespace Dynamo.Models
 
                 ModelBase start;
                 ModelBase end;
-                var newConnectors =
-                    from c in connectors
-
-                        // If the guid is in nodeLookup, then we connect to the new pasted node. Otherwise we
-                        // re-connect to the original.
-                    let startNode =
-                            modelLookup.TryGetValue(c.Start.Owner.GUID, out start)
-                                ? start as NodeModel
-                                : CurrentWorkspace.Nodes.FirstOrDefault(x => x.GUID == c.Start.Owner.GUID)
-                    let endNode =
+                var newConnectors = new List<ConnectorModel>();
+                var connectorLookup = new Dictionary<Guid, ConnectorModel>();
+                foreach (var c in connectors)
+                {
+                    // If the guid is in nodeLookup, then we connect to the new pasted node. Otherwise we
+                    // re-connect to the original.
+                    var startNode =
+                        modelLookup.TryGetValue(c.Start.Owner.GUID, out start)
+                            ? start as NodeModel
+                            : CurrentWorkspace.Nodes.FirstOrDefault(x => x.GUID == c.Start.Owner.GUID);
+                    var endNode =
                         modelLookup.TryGetValue(c.End.Owner.GUID, out end)
                             ? end as NodeModel
-                            : CurrentWorkspace.Nodes.FirstOrDefault(x => x.GUID == c.End.Owner.GUID)
+                            : CurrentWorkspace.Nodes.FirstOrDefault(x => x.GUID == c.End.Owner.GUID);
 
                     // Don't make a connector if either end is null.
-                    where startNode != null && endNode != null
-                    select
-                        ConnectorModel.Make(startNode, endNode, c.Start.Index, c.End.Index);
+                    if (startNode == null || endNode == null)
+                    {
+                        continue;
+                    }
+
+                    var newConnector = ConnectorModel.Make(startNode, endNode, c.Start.Index, c.End.Index);
+                    if (newConnector == null)
+                    {
+                        continue;
+                    }
+
+                    newConnectors.Add(newConnector);
+                    connectorLookup[c.GUID] = newConnector;
+                }
 
                 createdModels.AddRange(newConnectors);
+
+                var newConnectorPins = new List<ConnectorPinModel>();
+                foreach (var connectorPin in connectorPins)
+                {
+                    if (!connectorLookup.TryGetValue(connectorPin.ConnectorId, out var matchingConnector))
+                    {
+                        continue;
+                    }
+
+                    var copiedPin = new ConnectorPinModel(
+                        connectorPin.X + shiftX + offset,
+                        connectorPin.Y + shiftY + offset,
+                        Guid.NewGuid(),
+                        matchingConnector.GUID);
+
+                    matchingConnector.AddPin(copiedPin);
+                    newConnectorPins.Add(copiedPin);
+                }
+
+                createdModels.AddRange(newConnectorPins);
 
                 //Grouping depends on the selected node models.
                 //so adding the group after nodes / notes are added to workspace.

--- a/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/Converters/SerializationConverters.cs
@@ -44,7 +44,16 @@ namespace Dynamo.Wpf.ViewModels.Core.Converters
 
             foreach (var wirePin in workspaceView.Pins)
             {
-                serializer.Serialize(writer, wirePin);
+                writer.WriteStartObject();
+                writer.WritePropertyName(nameof(ConnectorPinViewModel.Left));
+                writer.WriteValue(wirePin.Left);
+                writer.WritePropertyName(nameof(ConnectorPinViewModel.Top));
+                writer.WriteValue(wirePin.Top);
+                writer.WritePropertyName(nameof(ConnectorPinViewModel.IsHidden));
+                writer.WriteValue(wirePin.IsHidden);
+                writer.WritePropertyName(nameof(ConnectorPinViewModel.ConnectorGuid));
+                writer.WriteValue(wirePin.ConnectorGuid.ToString("N"));
+                writer.WriteEndObject();
             }
             writer.WriteEndArray();
 

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -293,7 +293,14 @@ namespace Dynamo.ViewModels
 
                 try
                 {
-                    await UIDispatcher?.BeginInvoke(DispatcherPriority.ApplicationIdle, () => OnlineAccess = result.Item1);
+                    var dispatcher = UIDispatcher;
+                    if (dispatcher == null || dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
+                    {
+                        Trace.WriteLine("Skipping online access update: UI dispatcher is unavailable.");
+                        return;
+                    }
+
+                    await dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, () => OnlineAccess = result.Item1);
                 }
                 catch(Exception ex)
                 {

--- a/src/DynamoUtilities/Guid.cs
+++ b/src/DynamoUtilities/Guid.cs
@@ -135,13 +135,8 @@ namespace Dynamo.Utilities
             var compactGuidPattern = new Regex(@"\b[a-f0-9]{32}\b", RegexOptions.IgnoreCase);
             var guidRemap = compactGuidPattern.Matches(jsonData)
                 .Cast<Match>()
-                .Select(m =>
-                {
-                    Guid parsedGuid;
-                    return Guid.TryParse(m.Value, out parsedGuid) ? (Guid?)parsedGuid : null;
-                })
-                .Where(g => g.HasValue)
-                .Select(g => g.Value)
+                .Select(m => m.Value)
+                .Select(Guid.Parse)
                 .Distinct()
                 .ToDictionary(g => g, _ => Guid.NewGuid());
 

--- a/src/DynamoUtilities/Guid.cs
+++ b/src/DynamoUtilities/Guid.cs
@@ -125,26 +125,56 @@ namespace Dynamo.Utilities
         /// Performs an update to all Guids inside the json string before deserialization.
         /// Targets specifically Guids without the '-' hyphen, which are all the workspace elements.
         /// Replacing all occurrences of each individual Guid guarantees that the relationships between the elements are retained.
+        /// Any hyphenated occurrences of those same guids are also updated to preserve references (for example in View data).
         /// </summary>
         /// <param name="jsonData">Json representation of workspace.</param>
         /// <returns>String representation of workspace after all elements' Guids replaced.</returns>
         internal static string UpdateWorkspaceGUIDs(string jsonData)
         {
-            string pattern = @"([a-z0-9]{32})";
-            string updatedJsonData = jsonData;
-
-            // The unique collection of Guids
-            var mc = Regex.Matches(jsonData, pattern)
+            // Collect all workspace-element ids serialized in "N" format.
+            var compactGuidPattern = new Regex(@"\b[a-f0-9]{32}\b", RegexOptions.IgnoreCase);
+            var guidRemap = compactGuidPattern.Matches(jsonData)
                 .Cast<Match>()
-                .Select(m => m.Value)
-                .Distinct();
+                .Select(m =>
+                {
+                    Guid parsedGuid;
+                    return Guid.TryParse(m.Value, out parsedGuid) ? (Guid?)parsedGuid : null;
+                })
+                .Where(g => g.HasValue)
+                .Select(g => g.Value)
+                .Distinct()
+                .ToDictionary(g => g, _ => Guid.NewGuid());
 
-            foreach (var match in mc)
+            if (guidRemap.Count == 0)
             {
-                updatedJsonData = updatedJsonData.Replace(match, Guid.NewGuid().ToString("N"));
+                return jsonData;
             }
 
-            return updatedJsonData;
+            // Replace both compact and hyphenated guid occurrences, but only for ids that were
+            // remapped from compact workspace-element ids. This keeps unrelated hyphenated guids
+            // (for example style ids) untouched.
+            var anyGuidPattern = new Regex(
+                @"\b[a-f0-9]{32}\b|\b[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\b",
+                RegexOptions.IgnoreCase);
+
+            return anyGuidPattern.Replace(jsonData, match =>
+            {
+                Guid parsedGuid;
+                if (!Guid.TryParse(match.Value, out parsedGuid))
+                {
+                    return match.Value;
+                }
+
+                Guid updatedGuid;
+                if (!guidRemap.TryGetValue(parsedGuid, out updatedGuid))
+                {
+                    return match.Value;
+                }
+
+                return match.Value.Contains("-")
+                    ? updatedGuid.ToString("D")
+                    : updatedGuid.ToString("N");
+            });
         }
     }
 }

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -573,6 +573,51 @@ namespace Dynamo.Tests
 
             Assert.AreEqual(25, CurrentDynamoModel.CurrentWorkspace.Nodes.ElementAt(3).X);
             Assert.AreEqual(27, CurrentDynamoModel.CurrentWorkspace.Nodes.ElementAt(3).Y);
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void CanCopyAndPasteConnectorPinsWithConnectors()
+        {
+            var numberNode = new CodeBlockNodeModel(
+                "1;",
+                100.0,
+                100.0,
+                CurrentDynamoModel.LibraryServices,
+                CurrentDynamoModel.CurrentWorkspace.ElementResolver);
+            var watchNode = new Watch { X = 350, Y = 100 };
+
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(numberNode, false);
+            CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(watchNode, false);
+
+            var connector = ConnectorModel.Make(numberNode, watchNode, 0, 0);
+            Assert.IsNotNull(connector);
+
+            var originalPin = new ConnectorPinModel(225, 100, Guid.NewGuid(), connector.GUID);
+            connector.ConnectorPinModels.Add(originalPin);
+
+            CurrentDynamoModel.AddToSelection(numberNode);
+            CurrentDynamoModel.AddToSelection(watchNode);
+
+            CurrentDynamoModel.Copy();
+
+            Assert.AreEqual(1, CurrentDynamoModel.ClipBoard.OfType<ConnectorModel>().Count());
+            Assert.AreEqual(1, CurrentDynamoModel.ClipBoard.OfType<ConnectorPinModel>().Count());
+
+            var originalConnectorCount = CurrentDynamoModel.CurrentWorkspace.Connectors.Count();
+
+            CurrentDynamoModel.Paste();
+
+            Assert.AreEqual(4, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
+            Assert.AreEqual(originalConnectorCount + 1, CurrentDynamoModel.CurrentWorkspace.Connectors.Count());
+
+            var copiedConnector = CurrentDynamoModel.CurrentWorkspace.Connectors
+                .First(c => c.GUID != connector.GUID);
+            Assert.AreEqual(1, copiedConnector.ConnectorPinModels.Count);
+
+            var copiedPin = copiedConnector.ConnectorPinModels.Single();
+            Assert.AreEqual(copiedConnector.GUID, copiedPin.ConnectorId);
+            Assert.AreNotEqual(originalPin.GUID, copiedPin.GUID);
         }
 
         [Test]

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -614,6 +614,10 @@ namespace Dynamo.Tests
 
             Assert.AreEqual(4, CurrentDynamoModel.CurrentWorkspace.Nodes.Count());
             Assert.AreEqual(originalConnectorCount + 1, CurrentDynamoModel.CurrentWorkspace.Connectors.Count());
+            Assert.AreEqual(
+                1,
+                DynamoSelection.Instance.Selection.OfType<ConnectorPinModel>().Count(),
+                "Pasted connector pins should be part of the current selection.");
 
             var copiedConnector = CurrentDynamoModel.CurrentWorkspace.Connectors
                 .First(c => c.GUID != connector.GUID);

--- a/test/DynamoCoreTests/CoreTests.cs
+++ b/test/DynamoCoreTests/CoreTests.cs
@@ -579,13 +579,17 @@ namespace Dynamo.Tests
         [Category("UnitTests")]
         public void CanCopyAndPasteConnectorPinsWithConnectors()
         {
-            var numberNode = new CodeBlockNodeModel(
-                "1;",
-                100.0,
-                100.0,
-                CurrentDynamoModel.LibraryServices,
-                CurrentDynamoModel.CurrentWorkspace.ElementResolver);
-            var watchNode = new Watch { X = 350, Y = 100 };
+            var numberNode = new DoubleInput();
+            numberNode.Height = 2;
+            numberNode.Width = 2;
+            numberNode.CenterX = 100;
+            numberNode.CenterY = 100;
+
+            var watchNode = new Watch();
+            watchNode.Height = 2;
+            watchNode.Width = 2;
+            watchNode.CenterX = 350;
+            watchNode.CenterY = 100;
 
             CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(numberNode, false);
             CurrentDynamoModel.CurrentWorkspace.AddAndRegisterNode(watchNode, false);

--- a/test/DynamoCoreWpf3Tests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpf3Tests/WorkspaceSaving.cs
@@ -712,6 +712,43 @@ namespace Dynamo.Tests
         }
 
         [Test]
+        [Category("UnitTests")]
+        public void SaveAsPreservesConnectorPins()
+        {
+            string examplePath = Path.Combine(TestDirectory, @"core\ConnectorPinSelectionTest.dyn");
+            ViewModel.OpenCommand.Execute(examplePath);
+
+            var initialPinCount = ViewModel.Model.CurrentWorkspace.Connectors
+                .SelectMany(connector => connector.ConnectorPinModels)
+                .Count();
+            Assert.Greater(initialPinCount, 0, "The baseline graph should contain connector pins.");
+
+            var saveAsPath = GetNewFileNameOnTempPath("dyn");
+            ViewModel.CurrentSpaceViewModel.Save(
+                saveAsPath,
+                false,
+                ViewModel.Model.EngineController,
+                SaveContext.SaveAs);
+
+            var savedJson = JObject.Parse(File.ReadAllText(saveAsPath));
+            var savedConnectorPins = savedJson["View"]?["ConnectorPins"] as JArray;
+            Assert.IsNotNull(savedConnectorPins);
+            Assert.AreEqual(initialPinCount, savedConnectorPins.Count);
+
+            var reloadedWorkspace = ViewModel.Model.CurrentWorkspace;
+            var reloadedPins = reloadedWorkspace.Connectors
+                .SelectMany(connector => connector.ConnectorPinModels)
+                .ToList();
+
+            Assert.AreEqual(initialPinCount, reloadedPins.Count);
+
+            var reloadedConnectorIds = new HashSet<Guid>(
+                reloadedWorkspace.Connectors.Select(connector => connector.GUID));
+
+            Assert.IsTrue(reloadedPins.All(pin => reloadedConnectorIds.Contains(pin.ConnectorId)));
+        }
+
+        [Test]
         public void RemovePIIDataFromWorkspace()
         {
             string graphWithPIIDataPath = Path.Combine(TestDirectory, (@"UI\GraphWithPIIData.dyn"));

--- a/test/DynamoCoreWpf3Tests/WorkspaceSaving.cs
+++ b/test/DynamoCoreWpf3Tests/WorkspaceSaving.cs
@@ -734,6 +734,15 @@ namespace Dynamo.Tests
             var savedConnectorPins = savedJson["View"]?["ConnectorPins"] as JArray;
             Assert.IsNotNull(savedConnectorPins);
             Assert.AreEqual(initialPinCount, savedConnectorPins.Count);
+            Assert.IsTrue(savedConnectorPins
+                .Children<JObject>()
+                .All(pin =>
+                {
+                    var connectorGuid = pin[nameof(ConnectorPinViewModel.ConnectorGuid)]?.Value<string>();
+                    return !string.IsNullOrEmpty(connectorGuid)
+                           && connectorGuid.Length == 32
+                           && !connectorGuid.Contains("-");
+                }));
 
             var reloadedWorkspace = ViewModel.Model.CurrentWorkspace;
             var reloadedPins = reloadedWorkspace.Connectors


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

This PR fixes a bug where `ConnectorPinModel`s were not copied and pasted along with their associated `ConnectorModel`s. Previously, only the nodes and connectors would be pasted, leaving out any pins.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Connector pins are now correctly copied and pasted when their parent connectors and connected nodes are selected.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of

---
<p><a href="https://cursor.com/agents/bc-28bd144a-5506-478a-a990-c6d45d758911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28bd144a-5506-478a-a990-c6d45d758911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->