### PR TITLE
DYN-10196: Pull request description

### DIFF
--- a/src/DynamoUtilities/Guid.cs
+++ b/src/DynamoUtilities/Guid.cs
@@ -169,6 +169,22 @@ namespace Dynamo.Utilities
                 return updatedGuid.ToString("N");
             });
 
+            // Keep the top-level workspace Name stable even if it looks like a guid.
+            // This avoids changing user-visible workspace names when they happen to be guid-shaped.
+            var workspaceNamePattern = new Regex(
+                @"(?<prefix>""Name""\s*:\s*"")(?<name>(?:\\.|[^""\\])*)(?<suffix>"")",
+                RegexOptions.None,
+                RegexTimeout);
+            var originalWorkspaceNameMatch = workspaceNamePattern.Match(jsonData);
+            if (originalWorkspaceNameMatch.Success)
+            {
+                var originalWorkspaceName = originalWorkspaceNameMatch.Groups["name"].Value;
+                updatedJsonData = workspaceNamePattern.Replace(
+                    updatedJsonData,
+                    m => m.Groups["prefix"].Value + originalWorkspaceName + m.Groups["suffix"].Value,
+                    1);
+            }
+
             // Remap ConnectorGuid entries so connector pins still point to remapped connectors.
             var connectorGuidPattern = new Regex(
                 @"(?<prefix>""ConnectorGuid""\s*:\s*"")(?<guid>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|[a-f0-9]{32})(?<suffix>"")",

--- a/src/DynamoUtilities/Guid.cs
+++ b/src/DynamoUtilities/Guid.cs
@@ -121,17 +121,24 @@ namespace Dynamo.Utilities
             guid[right] = temp;
         }
 
+        private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(5);
+
         /// <summary>
-        /// Performs an update to all Guids inside the json string before deserialization.
-        /// Targets specifically Guids without the '-' hyphen, which are all the workspace elements.
-        /// Replacing all occurrences of each individual Guid guarantees that the relationships between the elements are retained.
+        /// Performs an update to workspace-element Guids inside the json string before deserialization.
+        /// It remaps compact ("N") workspace ids and updates ConnectorPins[].ConnectorGuid values
+        /// so connector-pin links are preserved during import/save-as id remapping.
         /// </summary>
         /// <param name="jsonData">Json representation of workspace.</param>
-        /// <returns>String representation of workspace after all elements' Guids replaced.</returns>
+        /// <returns>String representation of workspace after required Guid replacements.</returns>
         internal static string UpdateWorkspaceGUIDs(string jsonData)
         {
+            if (string.IsNullOrEmpty(jsonData))
+            {
+                return jsonData;
+            }
+
             // Collect all workspace-element ids serialized in "N" format.
-            var compactGuidPattern = new Regex(@"\b[a-f0-9]{32}\b", RegexOptions.IgnoreCase);
+            var compactGuidPattern = new Regex(@"\b[a-f0-9]{32}\b", RegexOptions.IgnoreCase, RegexTimeout);
             var guidRemap = compactGuidPattern.Matches(jsonData)
                 .Cast<Match>()
                 .Select(m => m.Value)
@@ -144,14 +151,8 @@ namespace Dynamo.Utilities
                 return jsonData;
             }
 
-            // Replace both compact and hyphenated guid occurrences, but only for ids that were
-            // remapped from compact workspace-element ids. This keeps unrelated hyphenated guids
-            // (for example style ids) untouched.
-            var anyGuidPattern = new Regex(
-                @"\b[a-f0-9]{32}\b|\b[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\b",
-                RegexOptions.IgnoreCase);
-
-            return anyGuidPattern.Replace(jsonData, match =>
+            // Preserve existing behavior by remapping compact ids globally.
+            var updatedJsonData = compactGuidPattern.Replace(jsonData, match =>
             {
                 Guid parsedGuid;
                 if (!Guid.TryParse(match.Value, out parsedGuid))
@@ -165,9 +166,35 @@ namespace Dynamo.Utilities
                     return match.Value;
                 }
 
-                return match.Value.Contains("-")
+                return updatedGuid.ToString("N");
+            });
+
+            // Remap ConnectorGuid entries so connector pins still point to remapped connectors.
+            var connectorGuidPattern = new Regex(
+                @"(?<prefix>""ConnectorGuid""\s*:\s*"")(?<guid>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|[a-f0-9]{32})(?<suffix>"")",
+                RegexOptions.IgnoreCase,
+                RegexTimeout);
+
+            return connectorGuidPattern.Replace(updatedJsonData, match =>
+            {
+                var connectorGuidValue = match.Groups["guid"].Value;
+                Guid connectorGuid;
+                if (!Guid.TryParse(connectorGuidValue, out connectorGuid))
+                {
+                    return match.Value;
+                }
+
+                Guid updatedGuid;
+                if (!guidRemap.TryGetValue(connectorGuid, out updatedGuid))
+                {
+                    return match.Value;
+                }
+
+                var updatedConnectorGuid = connectorGuidValue.Contains("-")
                     ? updatedGuid.ToString("D")
                     : updatedGuid.ToString("N");
+
+                return match.Groups["prefix"].Value + updatedConnectorGuid + match.Groups["suffix"].Value;
             });
         }
     }

--- a/test/DynamoCoreTests/Models/OpenFileCommandTest.cs
+++ b/test/DynamoCoreTests/Models/OpenFileCommandTest.cs
@@ -124,6 +124,32 @@ namespace Dynamo.Tests.ModelsTest
 
         [Test]
         [Category("UnitTests")]
+        public void TestInsertConnectorPinsAreLoadedAndMappedToImportedConnectors()
+        {
+            // Home workspace starts with no pins.
+            var initialPinCount = this.CurrentDynamoModel.CurrentWorkspace.Connectors
+                .SelectMany(connector => connector.ConnectorPinModels)
+                .Count();
+            Assert.AreEqual(0, initialPinCount);
+
+            var wspath = Path.Combine(TestDirectory, @"core\ConnectorPinSelectionTest.dyn");
+            this.CurrentDynamoModel.InsertFileFromPath(wspath);
+
+            var importedPins = this.CurrentDynamoModel.CurrentWorkspace.Connectors
+                .SelectMany(connector => connector.ConnectorPinModels)
+                .ToList();
+
+            Assert.AreEqual(3, importedPins.Count, "The imported graph should contribute 3 connector pins.");
+
+            var connectorIds = this.CurrentDynamoModel.CurrentWorkspace.Connectors
+                .Select(connector => connector.GUID)
+                .ToHashSet();
+
+            Assert.IsTrue(importedPins.All(pin => connectorIds.Contains(pin.ConnectorId)));
+        }
+
+        [Test]
+        [Category("UnitTests")]
         public void TestInsertNotes()
         {
             // Home space contains 0 nodes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
```
### Purpose

This PR addresses two issues related to connector pins being lost:
1.  **DYN-10196 (Pins lost on Save As)**: When a workspace was saved as a new file, connector pin references could become invalid, leading to pins disappearing after reload.
2.  **Pins lost on Import**: When using the "Import" function to bring an existing graph into a new one, connector pins from the imported graph were not loaded.

The core of the fix ensures that `ConnectorPin` GUIDs are consistently remapped during both Save As and Import operations, regardless of whether they are in compact ("N") or hyphenated ("D") format, thereby preserving their association with connectors. Additionally, `WorkspaceModel.LoadConnectorPins` was made more robust to prevent all pins from failing to load if one is invalid.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document. *(No public API changes)*

### Release Notes

Fixed issues where connector pins could be lost after "Save As" or when importing a graph, by ensuring consistent GUID remapping for connector pins and improving the pin loading process.

### Reviewers

(FILL ME IN) Reviewer 1

**Key changes to review:**
-   **`GuidUtility.UpdateWorkspaceGUIDs`**: Logic updated to specifically remap `ConnectorGuid` values (both 'N' and 'D' formats) using the same old→new GUID map generated for workspace elements.
-   **Regex Timeouts**: Added `TimeSpan.FromSeconds(5)` timeout to all `new Regex(...)` calls in `UpdateWorkspaceGUIDs` to address SonarQube S6444.
-   **XML Documentation**: Updated XML doc for `UpdateWorkspaceGUIDs` to reflect the new behavior.
-   **`WorkspaceModel.LoadConnectorPins`**: Changed `return` to `continue` when a connector is not found, preventing early termination of pin loading.
-   **New Tests**:
    -   `SaveAsPreservesConnectorPins` (in `WorkspaceSaving.cs`) was updated to correctly exercise the `SaveAs` path and verify pin preservation.
    -   `TestInsertConnectorPinsAreLoadedAndMappedToImportedConnectors` (in `OpenFileCommandTest.cs`) was added to specifically test the import scenario for connector pins.

### FYIs

(FILL ME IN, Optional)
```

---
<p><a href="https://cursor.com/agents/bc-ea585421-30b5-4d62-bccc-a68ffdef768a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea585421-30b5-4d62-bccc-a68ffdef768a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->