### PR TITLE
Reconnection pin preservation

### DIFF
--- a/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
+++ b/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
@@ -8,7 +8,6 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Utilities;
 using Newtonsoft.Json;
-using System.Linq;
 
 namespace Dynamo.Graph.Connectors
 {
@@ -121,21 +120,6 @@ namespace Dynamo.Graph.Connectors
             {
                 base.GUID = value;
             }
-        }
-
-        /// <summary>
-        /// Returns a snapshot of pin top-left canvas coordinates for this connector.
-        /// </summary>
-        internal IEnumerable<(double X, double Y)> GetPinLocations()
-        {
-            if (ConnectorPinModels == null || ConnectorPinModels.Count == 0)
-            {
-                return Enumerable.Empty<(double X, double Y)>();
-            }
-
-            return ConnectorPinModels
-                .Select(pin => (pin.X, pin.Y))
-                .ToList();
         }
 
         #endregion 

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -132,11 +132,22 @@ namespace Dynamo.Graph.Workspaces
                 UndoRecorder.RecordModificationForUndo(model);
         }
 
-        internal static void RecordModelsForUndo(Dictionary<ModelBase, UndoRedoRecorder.UserAction> models, UndoRedoRecorder recorder)
+        internal static void RecordModelsForUndo(
+            Dictionary<ModelBase, UndoRedoRecorder.UserAction> models,
+            UndoRedoRecorder recorder,
+            IEnumerable<ModelBase> modelsToModify = null,
+            Action applyModelChanges = null,
+            bool recordSavedModelsFirst = true)
         {
             if (null == recorder)
                 return;
-            if (!ShouldProceedWithRecording(models))
+
+            var modelActionsExist = ShouldProceedWithRecording(models);
+            var modelsToModifyList = modelsToModify?
+                .Where(model => model != null)
+                .Distinct()
+                .ToList() ?? new List<ModelBase>();
+            if (!modelActionsExist && modelsToModifyList.Count == 0 && savedModels == null)
                 return;
 
             if (null != savedModels)
@@ -149,29 +160,47 @@ namespace Dynamo.Graph.Workspaces
 
             using (recorder.BeginActionGroup())
             {
-                if (null != savedModels)
+                if (null != savedModels && recordSavedModelsFirst)
                 {
                     foreach (var modelPair in savedModels)
                     {
                         recorder.RecordDeletionForUndo(modelPair);
                     }
-                    savedModels = null;
                 }
-                foreach (var modelPair in models)
+
+                if (modelActionsExist)
                 {
-                    switch (modelPair.Value)
+                    foreach (var modelPair in models)
                     {
-                        case UndoRedoRecorder.UserAction.Creation:
-                            recorder.RecordCreationForUndo(modelPair.Key);
-                            break;
-                        case UndoRedoRecorder.UserAction.Deletion:
-                            recorder.RecordDeletionForUndo(modelPair.Key);
-                            break;
-                        case UndoRedoRecorder.UserAction.Modification:
-                            recorder.RecordModificationForUndo(modelPair.Key);
-                            break;
+                        switch (modelPair.Value)
+                        {
+                            case UndoRedoRecorder.UserAction.Creation:
+                                recorder.RecordCreationForUndo(modelPair.Key);
+                                break;
+                            case UndoRedoRecorder.UserAction.Deletion:
+                                recorder.RecordDeletionForUndo(modelPair.Key);
+                                break;
+                            case UndoRedoRecorder.UserAction.Modification:
+                                recorder.RecordModificationForUndo(modelPair.Key);
+                                break;
+                        }
                     }
                 }
+
+                foreach (var model in modelsToModifyList)
+                    recorder.RecordModificationForUndo(model);
+
+                applyModelChanges?.Invoke();
+
+                if (null != savedModels && !recordSavedModelsFirst)
+                {
+                    foreach (var modelPair in savedModels)
+                    {
+                        recorder.RecordDeletionForUndo(modelPair);
+                    }
+                }
+
+                savedModels = null;
             }
         }
 
@@ -457,7 +486,32 @@ namespace Dynamo.Graph.Workspaces
             ModelBase model = GetModelForElement(modelData);
             if (model != null)
             {
+                if (model is ConnectorPinModel connectorPinModel)
+                {
+                    var previousConnectorId = connectorPinModel.ConnectorId;
+                    connectorPinModel.Deserialize(modelData, SaveContext.Undo);
+                    RelocateConnectorPin(connectorPinModel, previousConnectorId);
+                    return;
+                }
+
                 model.Deserialize(modelData, SaveContext.Undo);
+            }
+        }
+
+        private void RelocateConnectorPin(ConnectorPinModel connectorPinModel, Guid previousConnectorId)
+        {
+            if (connectorPinModel == null || previousConnectorId == connectorPinModel.ConnectorId)
+            {
+                return;
+            }
+
+            var previousConnector = Connectors.FirstOrDefault(connector => connector.GUID == previousConnectorId);
+            previousConnector?.RemovePin(connectorPinModel);
+
+            var currentConnector = Connectors.FirstOrDefault(connector => connector.GUID == connectorPinModel.ConnectorId);
+            if (currentConnector != null && !currentConnector.ConnectorPinModels.Contains(connectorPinModel))
+            {
+                currentConnector.AddPin(connectorPinModel);
             }
         }
 

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -598,8 +598,7 @@ namespace Dynamo.Models
 
         private static Dictionary<ModelBase, UndoRedoRecorder.UserAction> GetConnectorsToAddAndDelete(
             PortModel endPort,
-            PortModel startPort,
-            IEnumerable<(double X, double Y)> pinLocations = null)
+            PortModel startPort)
         {
             ConnectorModel connectorToRemove = null;
 
@@ -640,21 +639,6 @@ namespace Dynamo.Models
             if (newConnectorModel != null)
             {
                 models.Add(newConnectorModel, UndoRedoRecorder.UserAction.Creation);
-
-                if (pinLocations != null)
-                {
-                    foreach (var pinLocation in pinLocations)
-                    {
-                        var connectorPinModel = new ConnectorPinModel(
-                            pinLocation.X,
-                            pinLocation.Y,
-                            Guid.NewGuid(),
-                            newConnectorModel.GUID);
-
-                        newConnectorModel.AddPin(connectorPinModel);
-                        models.Add(connectorPinModel, UndoRedoRecorder.UserAction.Creation);
-                    }
-                }
             }
             return models;
         }

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -43,7 +43,7 @@ namespace Dynamo.Models
 
         private PortModel[] activeStartPorts;
         private PortModel firstStartPort;
-        private Dictionary<Guid, List<(double X, double Y)>> reconnectionPinLocationsByStartPortId;
+        private Dictionary<Guid, List<ConnectorPinModel>> reconnectionPinsByStartPortId;
 
         protected virtual void OpenFileImpl(OpenFileCommand command)
         {
@@ -374,7 +374,7 @@ namespace Dynamo.Models
         {
             bool isInPort = portType == PortType.Input;
             activeStartPorts = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByStartPortId = null;
 
             if (CurrentWorkspace.GetModelInternal(nodeId) is not NodeModel node)
                 return;
@@ -389,7 +389,7 @@ namespace Dynamo.Models
                     ConnectorModel connector = portModel.Connectors[0];
                     activeStartPorts = new PortModel[] { connector.Start };
                     firstStartPort = connector.Start;
-                    RecordReconnectionPinLocations(connector.Start, connector);
+                    RecordReconnectionPins(connector.Start, connector);
                     // Disconnect the connector model from its start and end ports
                     // and remove it from the connectors collection. This will also
                     // remove the view model.
@@ -414,7 +414,7 @@ namespace Dynamo.Models
 
         private void BeginDuplicateConnection(Guid nodeId, int portIndex, PortType portType)
         {
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByStartPortId = null;
 
             // If the port clicked is an output port, begin connection as per normal
             if (portType == PortType.Output)
@@ -446,7 +446,7 @@ namespace Dynamo.Models
         {
             if (portType == PortType.Input) return; //only handle multiple connections when the port selected is an output port
             if (!(CurrentWorkspace.GetModelInternal(nodeId) is NodeModel node)) return;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByStartPortId = null;
 
             PortModel selectedPort = node.OutPorts[portIndex];
 
@@ -468,7 +468,7 @@ namespace Dynamo.Models
             {
                 ConnectorModel connector = selectedConnectors[i];
                 activeStartPorts[i] = connector.End;
-                RecordReconnectionPinLocations(connector.End, connector);
+                RecordReconnectionPins(connector.End, connector);
             }
             CurrentWorkspace.SaveAndDeleteModels(selectedConnectors.ToList<ModelBase>());
             return;
@@ -490,13 +490,27 @@ namespace Dynamo.Models
 
             var models = GetConnectorsToAddAndDelete(
                 portModel,
-                activeStartPorts[0],
-                ConsumeReconnectionPinLocations(activeStartPorts[0]));
+                activeStartPorts[0]);
 
-            WorkspaceModel.RecordModelsForUndo(models, CurrentWorkspace.UndoRecorder);
+            var pinsToTransfer = ConsumeReconnectionPins(activeStartPorts[0]).ToList();
+            var transferTargetConnector = GetCreatedConnector(models);
+            if (transferTargetConnector == null)
+            {
+                foreach (var pin in pinsToTransfer)
+                {
+                    pin?.Dispose();
+                }
+                pinsToTransfer.Clear();
+            }
+            WorkspaceModel.RecordModelsForUndo(
+                models,
+                CurrentWorkspace.UndoRecorder,
+                pinsToTransfer,
+                () => TransferReconnectionPins(transferTargetConnector, pinsToTransfer),
+                recordSavedModelsFirst: false);
             activeStartPorts = null;
             firstStartPort = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByStartPortId = null;
         }
 
         private void EndShiftReconnections(Guid nodeId, int portIndex, PortType portType)
@@ -509,22 +523,44 @@ namespace Dynamo.Models
             
             var firstModel = GetConnectorsToAddAndDelete(
                 selectedPort,
-                activeStartPorts[0],
-                ConsumeReconnectionPinLocations(activeStartPorts[0]));
+                activeStartPorts[0]);
+            var pinTransfers = new List<(ConnectorModel Connector, List<ConnectorPinModel> Pins)>();
+            AddReconnectionPinTransfer(
+                firstModel,
+                ConsumeReconnectionPins(activeStartPorts[0]),
+                pinTransfers);
             for (int i = 1; i < activeStartPorts.Count(); i++)
             {
                 var models = GetConnectorsToAddAndDelete(
                     selectedPort,
-                    activeStartPorts[i],
-                    ConsumeReconnectionPinLocations(activeStartPorts[i]));
+                    activeStartPorts[i]);
+                AddReconnectionPinTransfer(
+                    models,
+                    ConsumeReconnectionPins(activeStartPorts[i]),
+                    pinTransfers);
                 foreach (var m in models)
                 {
                     firstModel.Add(m.Key, m.Value);
                 }
             }
-            WorkspaceModel.RecordModelsForUndo(firstModel, CurrentWorkspace.UndoRecorder);
+            var pinsToModify = pinTransfers
+                .SelectMany(x => x.Pins)
+                .Distinct()
+                .ToList();
+            WorkspaceModel.RecordModelsForUndo(
+                firstModel,
+                CurrentWorkspace.UndoRecorder,
+                pinsToModify,
+                () =>
+                {
+                    foreach (var transfer in pinTransfers)
+                    {
+                        TransferReconnectionPins(transfer.Connector, transfer.Pins);
+                    }
+                },
+                recordSavedModelsFirst: false);
             activeStartPorts = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByStartPortId = null;
             return;
         }
 
@@ -544,9 +580,19 @@ namespace Dynamo.Models
         private void CancelConnections()
         {
             CurrentWorkspace.DeleteSavedModels();
+            if (reconnectionPinsByStartPortId != null)
+            {
+                foreach (var pin in reconnectionPinsByStartPortId.Values
+                    .SelectMany(pins => pins)
+                    .Where(pin => pin != null)
+                    .Distinct())
+                {
+                    pin.Dispose();
+                }
+            }
             activeStartPorts = null;
             firstStartPort = null;
-            reconnectionPinLocationsByStartPortId = null;
+            reconnectionPinsByStartPortId = null;
             return;
         }
 
@@ -613,31 +659,116 @@ namespace Dynamo.Models
             return models;
         }
 
-        private void RecordReconnectionPinLocations(PortModel activeStartPort, ConnectorModel connector)
+        private static ConnectorModel GetCreatedConnector(Dictionary<ModelBase, UndoRedoRecorder.UserAction> models)
+        {
+            if (models == null)
+            {
+                return null;
+            }
+
+            foreach (var modelPair in models)
+            {
+                if (modelPair.Value == UndoRedoRecorder.UserAction.Creation &&
+                    modelPair.Key is ConnectorModel connectorModel)
+                {
+                    return connectorModel;
+                }
+            }
+
+            return null;
+        }
+
+        private static void AddReconnectionPinTransfer(
+            Dictionary<ModelBase, UndoRedoRecorder.UserAction> models,
+            IEnumerable<ConnectorPinModel> pins,
+            List<(ConnectorModel Connector, List<ConnectorPinModel> Pins)> pinTransfers)
+        {
+            if (pinTransfers == null || pins == null)
+            {
+                return;
+            }
+
+            var pinList = pins
+                .Where(pin => pin != null)
+                .ToList();
+            if (pinList.Count == 0)
+            {
+                return;
+            }
+
+            var connectorModel = GetCreatedConnector(models);
+            if (connectorModel == null)
+            {
+                foreach (var pin in pinList)
+                {
+                    pin.Dispose();
+                }
+                return;
+            }
+
+            pinTransfers.Add((connectorModel, pinList));
+        }
+
+        private static void TransferReconnectionPins(
+            ConnectorModel connectorModel,
+            IEnumerable<ConnectorPinModel> pins)
+        {
+            if (connectorModel == null || pins == null)
+            {
+                return;
+            }
+
+            foreach (var pin in pins)
+            {
+                if (pin == null)
+                {
+                    continue;
+                }
+
+                pin.ConnectorId = connectorModel.GUID;
+                if (!connectorModel.ConnectorPinModels.Contains(pin))
+                {
+                    connectorModel.AddPin(pin);
+                }
+            }
+        }
+
+        private void RecordReconnectionPins(PortModel activeStartPort, ConnectorModel connector)
         {
             if (activeStartPort == null || connector == null)
             {
                 return;
             }
 
-            reconnectionPinLocationsByStartPortId ??= new Dictionary<Guid, List<(double X, double Y)>>();
-            reconnectionPinLocationsByStartPortId[activeStartPort.GUID] = connector.GetPinLocations().ToList();
+            if (connector.ConnectorPinModels == null || connector.ConnectorPinModels.Count == 0)
+            {
+                return;
+            }
+
+            reconnectionPinsByStartPortId ??= new Dictionary<Guid, List<ConnectorPinModel>>();
+            var pins = connector.ConnectorPinModels.ToList();
+            reconnectionPinsByStartPortId[activeStartPort.GUID] = pins;
+
+            foreach (var connectorPinModel in pins)
+            {
+                connector.RemovePin(connectorPinModel);
+            }
         }
 
-        private IEnumerable<(double X, double Y)> ConsumeReconnectionPinLocations(PortModel activeStartPort)
+        private IEnumerable<ConnectorPinModel> ConsumeReconnectionPins(PortModel activeStartPort)
         {
-            if (activeStartPort == null || reconnectionPinLocationsByStartPortId == null)
+            if (activeStartPort == null || reconnectionPinsByStartPortId == null)
             {
-                return Array.Empty<(double X, double Y)>();
+                return Array.Empty<ConnectorPinModel>();
             }
 
-            if (!reconnectionPinLocationsByStartPortId.TryGetValue(activeStartPort.GUID, out var pinLocations))
+            if (!reconnectionPinsByStartPortId.TryGetValue(activeStartPort.GUID, out var pins))
             {
-                return Array.Empty<(double X, double Y)>();
+                return Array.Empty<ConnectorPinModel>();
             }
 
-            reconnectionPinLocationsByStartPortId.Remove(activeStartPort.GUID);
-            return pinLocations;
+            reconnectionPinsByStartPortId.Remove(activeStartPort.GUID);
+            return pins;
         }
 
         private void DeleteModelImpl(DeleteModelCommand command)

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -57,6 +57,9 @@ namespace Dynamo.ViewModels
         private Point curvePoint3;
         private readonly List<ConnectorPinViewModel> transientCachedPins = new List<ConnectorPinViewModel>();
         private readonly List<Point> transientCachedPinLocations = new List<Point>();
+        // Set while pin VMs are temporarily extracted for reconnection preview.
+        // It prevents duplicate pin VM removals when corresponding pin models are
+        // detached from the source connector model in the same interaction.
         private bool suppressPinVMRemoval;
 
         /// <summary>
@@ -1110,6 +1113,10 @@ namespace Dynamo.ViewModels
                     {
                         RemoveConnectorPinModelViewModel(oldItem);
                     }
+                    if (suppressPinVMRemoval && ConnectorModel?.ConnectorPinModels.Count == 0)
+                    {
+                        suppressPinVMRemoval = false;
+                    }
                     break;
                 default: break;
             }
@@ -1120,6 +1127,7 @@ namespace Dynamo.ViewModels
         /// <param name="connectorPin"></param>
         private void RemoveConnectorPinModelViewModel(ConnectorPinModel connectorPin)
         {
+            // Reconnection preview already extracted these pin VMs.
             if (suppressPinVMRemoval) return;
 
             var matchingConnectorPinViewModel = this.workspaceViewModel.Pins.FirstOrDefault(x => x.Model.GUID == connectorPin.GUID);
@@ -1293,6 +1301,7 @@ namespace Dynamo.ViewModels
             {
                 ConnectorAnchorViewModel.Dispose();
             }
+            suppressPinVMRemoval = false;
             base.Dispose();
         }
 
@@ -1503,7 +1512,6 @@ namespace Dynamo.ViewModels
         /// pins to extract.</returns>
         internal List<ConnectorPinViewModel> AddTransientConnectorPins()
         {
-            suppressPinVMRemoval = true;                                                                            // DO WE NEED THIS - YES!  WHERE DO WE SET IT TO FALSE?
             var extractedPins = new List<ConnectorPinViewModel>();
 
             if (ConnectorPinViewCollection == null || ConnectorPinViewCollection.Count == 0)
@@ -1511,6 +1519,7 @@ namespace Dynamo.ViewModels
                 return extractedPins;
             }
 
+            suppressPinVMRemoval = true;
             foreach (var pinViewModel in ConnectorPinViewCollection.ToList())
             {
                 pinViewModel.PropertyChanged -= PinViewModelPropertyChanged;

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1829,7 +1829,8 @@ namespace Dynamo.ViewModels
             foreach (var pinViewModel in transientCachedPins.ToList())
             {
                 workspaceViewModel.Pins.Remove(pinViewModel);
-                pinViewModel.Model.Dispose();
+                // Transient pins may be transferred back to a permanent connector
+                // during reconnection, so do not dispose the underlying model here.
                 pinViewModel.Dispose();
             }
 

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -545,7 +545,8 @@ namespace DynamoCoreWpfTests
 
             // Sanity check: we added 1 pin
             Assert.AreEqual(initialConnectorPinCount + 1, connectorViewModel.ConnectorPinViewCollection.Count);
-            var pinModelGuid = connectorViewModel.ConnectorModel.ConnectorPinModels.First().GUID;
+            var originalPinModel = connectorViewModel.ConnectorModel.ConnectorPinModels.First();
+            var pinModelGuid = originalPinModel.GUID;
 
             // Begin reconnection – simulate grabbing the connector and starting a shift drag
             var connectorGuid = connectorViewModel.ConnectorModel.GUID;
@@ -577,6 +578,10 @@ namespace DynamoCoreWpfTests
             var connectorAfterReconnect = this.ViewModel.CurrentSpaceViewModel.Connectors;
             Assert.AreEqual(1, connectorAfterReconnect.Count());
             Assert.AreEqual(initialConnectorPinCount + 1, connectorAfterReconnect.First().ConnectorPinViewCollection.Count());
+            var pinAfterReconnect = connectorAfterReconnect.First().ConnectorModel.ConnectorPinModels
+                .FirstOrDefault(p => p.GUID == pinModelGuid);
+            Assert.IsNotNull(pinAfterReconnect, "Expected pin model GUID to be preserved after reconnection.");
+            Assert.AreSame(originalPinModel, pinAfterReconnect, "Expected the same pin model instance to be reused after reconnection.");
 
             // --- Undo ---
             Model.ExecuteCommand(new UndoRedoCommand(UndoRedoCommand.Operation.Undo));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

This PR addresses the issue where connector pins (models) were deleted and recreated during connector reconnection. It ensures that pins are preserved and transferred to the new permanent connector, and that a single Undo action correctly restores the original connector and its associated pins.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

- Connector pins are now preserved as existing `ConnectorPinModel` instances during connector reconnection, instead of being deleted and recreated.
- Pins are correctly transferred to the newly created connector after reconnection.
- A single Undo action after a connector reconnection will now fully restore the original connector and its associated pins.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

---
<p><a href="https://cursor.com/agents/bc-b967fe11-735e-4b0d-81cb-5f63ce725fb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b967fe11-735e-4b0d-81cb-5f63ce725fb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->