### PR TITLE
Recent commits review

### DIFF
--- a/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
+++ b/src/DynamoCore/Graph/Connectors/ConnectorModel.cs
@@ -126,11 +126,11 @@ namespace Dynamo.Graph.Connectors
         /// <summary>
         /// Returns a snapshot of pin top-left canvas coordinates for this connector.
         /// </summary>
-        internal IEnumerable<(double X, double Y)> GetPinLocations()
+        internal List<(double X, double Y)> GetPinLocations()
         {
             if (ConnectorPinModels == null || ConnectorPinModels.Count == 0)
             {
-                return Enumerable.Empty<(double X, double Y)>();
+                return new List<(double X, double Y)>();
             }
 
             return ConnectorPinModels

--- a/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
+++ b/src/DynamoCore/Graph/Workspaces/UndoRedo.cs
@@ -509,8 +509,14 @@ namespace Dynamo.Graph.Workspaces
             else if (typeName.Contains(nameof(ConnectorPinModel)))
             {
                 var connectorPin = NodeGraph.LoadPinFromXml(modelData);
+                if (connectorPin is null) return;
+
                 var matchingConnector = Connectors.FirstOrDefault(c => c.GUID == connectorPin.ConnectorId);
-                if (matchingConnector is null) return;
+                if (matchingConnector is null)
+                {
+                    connectorPin.Dispose();
+                    return;
+                }
 
                 // Avoid orphan pin models
                 if (matchingConnector.ConnectorPinModels.Any(p => p.GUID == connectorPin.GUID))

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -621,7 +621,7 @@ namespace Dynamo.Models
             }
 
             reconnectionPinLocationsByStartPortId ??= new Dictionary<Guid, List<(double X, double Y)>>();
-            reconnectionPinLocationsByStartPortId[activeStartPort.GUID] = connector.GetPinLocations().ToList();
+            reconnectionPinLocationsByStartPortId[activeStartPort.GUID] = connector.GetPinLocations();
         }
 
         private IEnumerable<(double X, double Y)> ConsumeReconnectionPinLocations(PortModel activeStartPort)

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -67,3 +67,5 @@ static Dynamo.Wpf.Properties.Resources.SplashScreenSettingsImportedRestartMessag
 static Dynamo.Wpf.Properties.Resources.SplashScreenSettingsResetSuccess.get -> string
 static Dynamo.Wpf.Properties.Resources.ToastHyperlinkPathText.get -> string
 static readonly Dynamo.PackageManager.UI.PackageManagerTabControl.SuppressHomeEndWhenSelectedProperty -> System.Windows.DependencyProperty
+Dynamo.ViewModels.ConnectorPinViewModel.IsInteractive.get -> bool
+Dynamo.ViewModels.ConnectorPinViewModel.IsInteractive.set -> void

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorPinViewModel.cs
@@ -225,6 +225,22 @@ namespace Dynamo.ViewModels
             }
         }
 
+        private bool isInteractive = true;
+        /// <summary>
+        /// Gets or sets whether the pin is interactive (hover/click/context menu).
+        /// </summary>
+        [JsonIgnore]
+        public bool IsInteractive
+        {
+            get => isInteractive;
+            set
+            {
+                if (isInteractive == value) return;
+                isInteractive = value;
+                RaisePropertyChanged(nameof(IsInteractive));
+            }
+        }
+
         private bool isInGroup;
         /// <summary>
         /// Gets or sets whether the pin is in a group and updates the command state when this changes.

--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1171,7 +1171,8 @@ namespace Dynamo.ViewModels
             var pinViewModel = new ConnectorPinViewModel(this.workspaceViewModel, pinModel)
             {
                 IsHidden = this.IsHidden,
-                IsTemporarilyVisible = isTemporarilyVisible
+                IsTemporarilyVisible = isTemporarilyVisible,
+                IsInteractive = true
             };
             pinViewModel.PropertyChanged += PinViewModelPropertyChanged;
 
@@ -1548,6 +1549,7 @@ namespace Dynamo.ViewModels
                     pinViewModel.RequestSelect -= HandleRequestSelected;
                     pinViewModel.RequestRedraw -= HandlerRedrawRequest;
                     pinViewModel.RequestRemove -= HandleConnectorPinViewModelRemove;
+                    pinViewModel.IsInteractive = false;
 
                     ConnectorPinViewCollection.Remove(pinViewModel);
                     extractedPins.Add(pinViewModel);
@@ -1575,6 +1577,7 @@ namespace Dynamo.ViewModels
             {
                 if (pinViewModel == null) continue;
 
+                pinViewModel.IsInteractive = false;
                 transientCachedPinLocations.Add(new Point(pinViewModel.Left, pinViewModel.Top));
                 transientCachedPins.Add(pinViewModel);                
             }
@@ -1783,15 +1786,9 @@ namespace Dynamo.ViewModels
                 dotLeft = CurvePoint3.X - EndDotSize / 2;
 
                 var isInputStartReconnection = ActiveStartPort?.PortType == PortType.Input;
-                var orderedPoints = GetBezierPinPoints()
-                    .OrderBy(p => p.X)
-                    .ToList();
-                if (isInputStartReconnection)
-                {
-                    orderedPoints = orderedPoints
-                        .OrderByDescending(p => p.X)
-                        .ToList();
-                }                
+                var orderedPoints = isInputStartReconnection
+                    ? GetBezierPinPoints().OrderByDescending(p => p.X).ToList()
+                    : GetBezierPinPoints().OrderBy(p => p.X).ToList();
 
                 orderedPoints.Insert(0, CurvePoint0);
                 orderedPoints.Insert(orderedPoints.Count, CurvePoint3);
@@ -1833,7 +1830,7 @@ namespace Dynamo.ViewModels
             }
             catch (Exception ex)
             {
-                string mess = ex.Message;
+                workspaceViewModel.DynamoViewModel.Model.Logger.Log("Error when redrawing multi-segment connector: " + ex);
             }
         }
 
@@ -1857,6 +1854,7 @@ namespace Dynamo.ViewModels
         {
             foreach (var pinViewModel in transientCachedPins.ToList())
             {
+                ConnectorPinViewCollection.Remove(pinViewModel);
                 workspaceViewModel.Pins.Remove(pinViewModel);
                 pinViewModel.Model.Dispose();
                 pinViewModel.Dispose();

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -306,7 +306,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        public void ShiftReconnectionTransfersPinsToTransientConnectorAndPersistsAfterReconnect()
+        public void ShiftReconnectionUsesTransientPinCacheAndPersistsPinsAfterReconnect()
         {
             // Open a test graph with at least two connected nodes
             Open(@"UI/ConnectorPinTests.dyn");
@@ -344,18 +344,15 @@ namespace DynamoCoreWpfTests
                 .OfType<ConnectorViewModel>()
                 .FirstOrDefault(c => c.IsConnecting);
 
-            // Assert that during shift reconnection, a transient connector is created that has the same number of pins
+            // During shift reconnection, pins are transferred off the original connector and
+            // cached on the transient connector for redraw (not kept in its view collection).
             Assert.IsNotNull(activeConnector);
             Assert.IsNull(activeConnector.ConnectorModel, "Expected active connector to be transient during drag.");
-            Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
             Assert.AreEqual(0, connectorViewModel.ConnectorPinViewCollection.Count);
 
-            var transientPinLocations = activeConnector.ConnectorPinViewCollection
-                .Select(pin => (pin.Left, pin.Top))
-                .OrderBy(pin => pin.Left)
-                .ThenBy(pin => pin.Top)
-                .ToList();
-            CollectionAssert.AreEqual(pinLocationsBeforeReconnect, transientPinLocations);
+            activeConnector.Redraw(new Point2D(650, 350));
+            Assert.IsNotNull(activeConnector.ComputedBezierPathGeometry);
+            Assert.Greater(activeConnector.ComputedBezierPathGeometry.Figures.Count, 1);
 
             // Execute the second part of the workflow - simulate placing the connectors over the new port.
             this.ViewModel.ExecuteCommand(

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -306,7 +306,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        public void ShiftReconnectionUsesNonInteractiveTransientPinsAndPersistsPins()
+        public void ShiftReconnectionTransfersPinsToTransientConnectorAndPersistsAfterReconnect()
         {
             // Open a test graph with at least two connected nodes
             Open(@"UI/ConnectorPinTests.dyn");
@@ -325,6 +325,11 @@ namespace DynamoCoreWpfTests
 
             // Assert that the pin was added
             Assert.AreEqual(initialConnectorPinCount + 1, connectorViewModel.ConnectorPinViewCollection.Count);
+            var pinLocationsBeforeReconnect = connectorViewModel.ConnectorPinViewCollection
+                .Select(pin => (pin.Left, pin.Top))
+                .OrderBy(pin => pin.Left)
+                .ThenBy(pin => pin.Top)
+                .ToList();
 
             // Begin reconnection – simulate grabbing the connector and starting a shift drag
             var startPort = connectorViewModel.ConnectorModel.Start;
@@ -343,18 +348,31 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(activeConnector);
             Assert.IsNull(activeConnector.ConnectorModel, "Expected active connector to be transient during drag.");
             Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
-            Assert.IsTrue(activeConnector.ConnectorPinViewCollection.All(pin => !pin.IsInteractive));
+            Assert.AreEqual(0, connectorViewModel.ConnectorPinViewCollection.Count);
 
-            // Execute the second part of the workflow - simulate placing the connectors over the new port
+            var transientPinLocations = activeConnector.ConnectorPinViewCollection
+                .Select(pin => (pin.Left, pin.Top))
+                .OrderBy(pin => pin.Left)
+                .ThenBy(pin => pin.Top)
+                .ToList();
+            CollectionAssert.AreEqual(pinLocationsBeforeReconnect, transientPinLocations);
+
+            // Execute the second part of the workflow - simulate placing the connectors over the new port.
             this.ViewModel.ExecuteCommand(
                 new DynamoModel.MakeConnectionCommand(codeblock.GUID, 0, PortType.Output,
                 MakeConnectionCommand.Mode.EndShiftReconnections));
 
-            // Assert that after reconnection, the new connector has the same number of pins and they are interactive
+            // Assert that after reconnection, the new connector has the same number of pins and locations.
             var connectorAfterReconnect = this.ViewModel.CurrentSpaceViewModel.Connectors;
             Assert.AreEqual(1, connectorAfterReconnect.Count());
             Assert.AreEqual(initialConnectorPinCount + 1, connectorAfterReconnect.First().ConnectorPinViewCollection.Count);
-            Assert.IsTrue(connectorAfterReconnect.First().ConnectorPinViewCollection.All(pin => pin.IsInteractive));
+
+            var pinLocationsAfterReconnect = connectorAfterReconnect.First().ConnectorPinViewCollection
+                .Select(pin => (pin.Left, pin.Top))
+                .OrderBy(pin => pin.Left)
+                .ThenBy(pin => pin.Top)
+                .ToList();
+            CollectionAssert.AreEqual(pinLocationsBeforeReconnect, pinLocationsAfterReconnect);
         }
         #endregion
 

--- a/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
+++ b/test/DynamoCoreWpfTests/ConnectorViewModelTests.cs
@@ -343,6 +343,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(activeConnector);
             Assert.IsNull(activeConnector.ConnectorModel, "Expected active connector to be transient during drag.");
             Assert.AreEqual(initialConnectorPinCount + 1, activeConnector.ConnectorPinViewCollection.Count);
+            Assert.IsTrue(activeConnector.ConnectorPinViewCollection.All(pin => !pin.IsInteractive));
 
             // Execute the second part of the workflow - simulate placing the connectors over the new port
             this.ViewModel.ExecuteCommand(
@@ -353,6 +354,7 @@ namespace DynamoCoreWpfTests
             var connectorAfterReconnect = this.ViewModel.CurrentSpaceViewModel.Connectors;
             Assert.AreEqual(1, connectorAfterReconnect.Count());
             Assert.AreEqual(initialConnectorPinCount + 1, connectorAfterReconnect.First().ConnectorPinViewCollection.Count);
+            Assert.IsTrue(connectorAfterReconnect.First().ConnectorPinViewCollection.All(pin => pin.IsInteractive));
         }
         #endregion
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

This PR addresses several issues identified in recent commits related to connector and pin management, specifically:
1.  **Fixing a high-risk runtime binding regression:** Reintroduces the `IsInteractive` property to `ConnectorPinViewModel` to correctly enable/disable pin interaction, resolving a silent WPF binding failure.
2.  **Preventing an object leak:** Ensures proper disposal of `ConnectorPinModel` instances during undo/redo operations when a matching connector is not found.
3.  **Improving diagnostic capabilities:** Replaces swallowed exceptions with proper logging in the connector redraw path.
4.  **Removing redundancies and optimizing code:** Eliminates double materialization of pin locations and redundant sorting in redraw logic.
5.  **Aligning tests and documentation:** Updates test assertions and method summaries to reflect current intended behavior for transient pins.

### Declarations

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

-   Fixed an issue where connector pins might not correctly respond to user interaction (e.g., during reconnection) due to a missing property binding.
-   Improved stability of undo/redo operations by ensuring proper cleanup of connector pin objects.
-   Enhanced error logging for connector rendering issues, making them easier to diagnose.
-   Optimized internal connector drawing logic for better performance.

### Reviewers

(FILL ME IN)

### FYIs

Automated tests could not be executed in the environment where these changes were generated. Please ensure full test suite passes.

---
<p><a href="https://cursor.com/agents/bc-8b1c5d02-bdfb-44de-9533-c822ee000e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b1c5d02-bdfb-44de-9533-c822ee000e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->