### PR TITLE
Connector pin attachment logic

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/ConnectorViewModel.cs
@@ -1491,7 +1491,9 @@ namespace Dynamo.ViewModels
         /// to all previous pins is required for undo/redo recorder.</param>
         internal void DiscardAllConnectorPinModels(List<ModelBase> allDeletedModels = null)
         {
-            foreach (var pin in ConnectorPinViewCollection)
+            // Removing pin models can mutate ConnectorPinViewCollection through
+            // ConnectorPinModelCollectionChanged handlers, so iterate a snapshot.
+            foreach (var pin in ConnectorPinViewCollection.ToList())
             {
                 workspaceViewModel.Pins.Remove(pin);
                 ConnectorModel?.RemovePin(pin.Model);

--- a/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/NoteViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
@@ -186,12 +186,7 @@ namespace Dynamo.ViewModels
 
                 if (node == null) return;
 
-                // In case the user has selected a different Node before Undo
-                // We run the risk of pinning to the wrong Node
-                // Therefore clear selection before running
-                DynamoSelection.Instance.ClearSelection();
-                DynamoSelection.Instance.Selection.Add(node);
-                PinToNode(obj);
+                PinToNode(node, recordForUndo: false);
                 return;
             }
         }
@@ -314,17 +309,21 @@ namespace Dynamo.ViewModels
 
         private void PinToNode(object parameters)
         {
-
             var nodeToPin = DynamoSelection.Instance.Selection
                 .OfType<NodeModel>()
                 .FirstOrDefault();
 
-            if (nodeToPin == null)
-            {
-                return;
-            }
+            PinToNode(nodeToPin, recordForUndo: true);
+        }
 
-            WorkspaceModel.RecordModelForModification(Model, WorkspaceViewModel.Model.UndoRecorder);
+        private void PinToNode(NodeModel nodeToPin, bool recordForUndo)
+        {
+            if (nodeToPin == null) return;
+
+            if (recordForUndo)
+            {
+                WorkspaceModel.RecordModelForModification(Model, WorkspaceViewModel.Model.UndoRecorder);
+            }
 
             var nodeGroup = WorkspaceViewModel.Annotations
                 .FirstOrDefault(x => x.AnnotationModel.ContainsModel(nodeToPin));
@@ -332,6 +331,11 @@ namespace Dynamo.ViewModels
             if (nodeGroup != null)
             {
                 nodeGroup.AnnotationModel.AddToTargetAnnotationModel(this.Model);
+            }
+
+            if (Model.PinnedNode != null)
+            {
+                UnsuscribeFromPinnedNode();
             }
 
             Model.PinnedNode = nodeToPin;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

This PR addresses several issues and clarifications related to transient connector pins:
1.  Ensures selected transient pins are correctly unselected and disposed to prevent stale selection references.
2.  Clarifies the intended behavior and lifecycle of transient connector pins through updated documentation.
3.  Fixes a `Collection was modified` exception when discarding pins during watch node placement.
4.  Corrects a unit test assertion that was misaligned with the transient pin design.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

-   Fixed an issue where selected transient connector pins were not properly unselected upon disposal, preventing stale selection references.
-   Corrected a bug that caused a `Collection was modified` error when placing a watch node on a connector with pins.
-   Improved documentation for transient connector pin management.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

<div><a href="https://cursor.com/agents/bc-18cf3e8f-5178-40f7-b862-7defe9db2890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18cf3e8f-5178-40f7-b862-7defe9db2890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->