### PR TITLE
Dyf file template restriction

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4663,15 +4663,6 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Templates must be Dynamo workspace files (*.dyn)..
-        /// </summary>
-        public static string MessageErrorOpeningTemplateInvalidExtension {
-            get {
-                return ResourceManager.GetString("MessageErrorOpeningTemplateInvalidExtension", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Loading the packages is taking longer than expected. What would you like to do?.
         /// </summary>
         public static string MessageExcessiveLoadTime {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4663,6 +4663,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Templates must be Dynamo workspace files (*.dyn)..
+        /// </summary>
+        public static string MessageErrorOpeningTemplateInvalidExtension {
+            get {
+                return ResourceManager.GetString("MessageErrorOpeningTemplateInvalidExtension", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Loading the packages is taking longer than expected. What would you like to do?.
         /// </summary>
         public static string MessageExcessiveLoadTime {
@@ -5829,7 +5838,7 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open {0} Template....
+        ///   Looks up a localized string similar to New Graph from Template....
         /// </summary>
         public static string OpenDynamoTemplateDialogTitle {
             get {

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -5829,6 +5829,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Open {0} Template....
+        /// </summary>
+        public static string OpenDynamoTemplateDialogTitle {
+            get {
+                return ResourceManager.GetString("OpenDynamoTemplateDialogTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Provide compatibility information for the package...
         /// </summary>
         public static string PackageCompatibilityMatrixMissing {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -4165,9 +4165,6 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="MessageErrorOpeningInvalidPath" xml:space="preserve">
     <value>Invalid file path provided. In case the file is archived, please make sure to extract it before opening.\n{0}</value>
   </data>
-  <data name="MessageErrorOpeningTemplateInvalidExtension" xml:space="preserve">
-    <value>Templates must be Dynamo workspace files (*.dyn).</value>
-  </data>
   <data name="GroupContextMenuFreezeGroup" xml:space="preserve">
     <value>Freeze Group</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1554,7 +1554,7 @@ Next assemblies were loaded several times:
     <value>Open {0} Definition...</value>
   </data>
   <data name="OpenDynamoTemplateDialogTitle" xml:space="preserve">
-    <value>New graph from template</value>
+    <value>New Graph from Template...</value>
   </data>
   <data name="PackageDownloadConfirmMessageBoxTitle" xml:space="preserve">
     <value>Package Download Confirmation</value>
@@ -4164,6 +4164,9 @@ To make this file into a new template, save it to a different folder, then move 
   </data>
   <data name="MessageErrorOpeningInvalidPath" xml:space="preserve">
     <value>Invalid file path provided. In case the file is archived, please make sure to extract it before opening.\n{0}</value>
+  </data>
+  <data name="MessageErrorOpeningTemplateInvalidExtension" xml:space="preserve">
+    <value>Templates must be Dynamo workspace files (*.dyn).</value>
   </data>
   <data name="GroupContextMenuFreezeGroup" xml:space="preserve">
     <value>Freeze Group</value>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1553,6 +1553,9 @@ Next assemblies were loaded several times:
   <data name="OpenDynamoDefinitionDialogTitle" xml:space="preserve">
     <value>Open {0} Definition...</value>
   </data>
+  <data name="OpenDynamoTemplateDialogTitle" xml:space="preserve">
+    <value>Open {0} Template...</value>
+  </data>
   <data name="PackageDownloadConfirmMessageBoxTitle" xml:space="preserve">
     <value>Package Download Confirmation</value>
     <comment>Message box title</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1554,7 +1554,7 @@ Next assemblies were loaded several times:
     <value>Open {0} Definition...</value>
   </data>
   <data name="OpenDynamoTemplateDialogTitle" xml:space="preserve">
-    <value>Open {0} Template...</value>
+    <value>New graph from template</value>
   </data>
   <data name="PackageDownloadConfirmMessageBoxTitle" xml:space="preserve">
     <value>Package Download Confirmation</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1052,6 +1052,9 @@ To avoid unintended behavior, uninstall the conflicting loaded package(s), resta
   <data name="OpenDynamoDefinitionDialogTitle" xml:space="preserve">
     <value>Open {0} Definition...</value>
   </data>
+  <data name="OpenDynamoTemplateDialogTitle" xml:space="preserve">
+    <value>Open {0} Template...</value>
+  </data>
   <data name="PackageDownloadConfirmMessageBoxTitle" xml:space="preserve">
     <value>Package Download Confirmation</value>
     <comment>Message box title</comment>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1053,7 +1053,7 @@ To avoid unintended behavior, uninstall the conflicting loaded package(s), resta
     <value>Open {0} Definition...</value>
   </data>
   <data name="OpenDynamoTemplateDialogTitle" xml:space="preserve">
-    <value>Open {0} Template...</value>
+    <value>New graph from template</value>
   </data>
   <data name="PackageDownloadConfirmMessageBoxTitle" xml:space="preserve">
     <value>Package Download Confirmation</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -4156,9 +4156,6 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="MessageErrorOpeningInvalidPath" xml:space="preserve">
     <value>Invalid file path provided. In case the file is archived, please make sure to extract it before opening.\n{0}</value>
   </data>
-  <data name="MessageErrorOpeningTemplateInvalidExtension" xml:space="preserve">
-    <value>Templates must be Dynamo workspace files (*.dyn).</value>
-  </data>
   <data name="GroupContextMenuFreezeGroup" xml:space="preserve">
     <value>Freeze Group</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1053,7 +1053,7 @@ To avoid unintended behavior, uninstall the conflicting loaded package(s), resta
     <value>Open {0} Definition...</value>
   </data>
   <data name="OpenDynamoTemplateDialogTitle" xml:space="preserve">
-    <value>New graph from template</value>
+    <value>New Graph from Template...</value>
   </data>
   <data name="PackageDownloadConfirmMessageBoxTitle" xml:space="preserve">
     <value>Package Download Confirmation</value>
@@ -4155,6 +4155,9 @@ To make this file into a new template, save it to a different folder, then move 
   </data>
   <data name="MessageErrorOpeningInvalidPath" xml:space="preserve">
     <value>Invalid file path provided. In case the file is archived, please make sure to extract it before opening.\n{0}</value>
+  </data>
+  <data name="MessageErrorOpeningTemplateInvalidExtension" xml:space="preserve">
+    <value>Templates must be Dynamo workspace files (*.dyn).</value>
   </data>
   <data name="GroupContextMenuFreezeGroup" xml:space="preserve">
     <value>Freeze Group</value>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -54,6 +54,7 @@ static Dynamo.Wpf.Properties.Resources.DynamoSplashScreen.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageBoxDontShowAgainLabel.get -> string
 static Dynamo.Wpf.Properties.Resources.OfflineStatusTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.OnlineStatusTooltip.get -> string
+static Dynamo.Wpf.Properties.Resources.OpenDynamoTemplateDialogTitle.get -> string
 static Dynamo.Wpf.Properties.Resources.PackageDropdownInstalledVersionLabel.get -> string
 static Dynamo.Wpf.Properties.Resources.PackageManagerPackageUpdateAvailable.get -> string
 static Dynamo.Wpf.Properties.Resources.PackageManagerUninstall.get -> string

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -52,7 +52,6 @@ static Dynamo.Wpf.Properties.Resources.DocumentationBrowserAutoSyncLabel.get -> 
 static Dynamo.Wpf.Properties.Resources.DocumentationBrowserPreferences.get -> string
 static Dynamo.Wpf.Properties.Resources.DynamoSplashScreen.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageBoxDontShowAgainLabel.get -> string
-static Dynamo.Wpf.Properties.Resources.MessageErrorOpeningTemplateInvalidExtension.get -> string
 static Dynamo.Wpf.Properties.Resources.OfflineStatusTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.OnlineStatusTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.OpenDynamoTemplateDialogTitle.get -> string

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -52,6 +52,7 @@ static Dynamo.Wpf.Properties.Resources.DocumentationBrowserAutoSyncLabel.get -> 
 static Dynamo.Wpf.Properties.Resources.DocumentationBrowserPreferences.get -> string
 static Dynamo.Wpf.Properties.Resources.DynamoSplashScreen.get -> string
 static Dynamo.Wpf.Properties.Resources.MessageBoxDontShowAgainLabel.get -> string
+static Dynamo.Wpf.Properties.Resources.MessageErrorOpeningTemplateInvalidExtension.get -> string
 static Dynamo.Wpf.Properties.Resources.OfflineStatusTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.OnlineStatusTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.OpenDynamoTemplateDialogTitle.get -> string

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2490,12 +2490,16 @@ namespace Dynamo.ViewModels
             var dialogTitle = isTemplate
                 ? Resources.OpenDynamoTemplateDialogTitle
                 : string.Format(Resources.OpenDynamoDefinitionDialogTitle, BrandingResourceProvider.ProductName);
+            var fileFilter = string.Format(Resources.FileDialogDynamoDefinitions,
+                BrandingResourceProvider.ProductName, fileExtensions);
+            if (!isTemplate)
+            {
+                fileFilter += "|" + string.Format(Resources.FileDialogAllFiles, "*.*");
+            }
 
             DynamoOpenFileDialog _fileDialog = new DynamoOpenFileDialog(this)
             {
-                Filter = string.Format(Resources.FileDialogDynamoDefinitions,
-                         BrandingResourceProvider.ProductName, fileExtensions) + "|" +
-                         string.Format(Resources.FileDialogAllFiles, "*.*"),
+                Filter = fileFilter,
                 Title = dialogTitle
             };
 
@@ -2542,6 +2546,17 @@ namespace Dynamo.ViewModels
 
             if (_fileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
+                if (isTemplate && !string.Equals(Path.GetExtension(_fileDialog.FileName), ".dyn", StringComparison.OrdinalIgnoreCase))
+                {
+                    DynamoMessageBox.Show(
+                        Owner,
+                        Resources.MessageErrorOpeningTemplateInvalidExtension,
+                        Resources.MessageErrorOpeningFileGeneral,
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error);
+                    return;
+                }
+
                 if (CanOpen(_fileDialog.FileName))
                 {
                     if (isTemplate)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2487,13 +2487,16 @@ namespace Dynamo.ViewModels
 
             bool isTemplate = parameter != null && (parameter as string).Equals("Template");
             var fileExtensions = isTemplate ? "*.dyn" : "*.dyn;*.dyf";
+            var dialogTitle = isTemplate
+                ? string.Format(Resources.OpenDynamoTemplateDialogTitle, BrandingResourceProvider.ProductName)
+                : string.Format(Resources.OpenDynamoDefinitionDialogTitle, BrandingResourceProvider.ProductName);
 
             DynamoOpenFileDialog _fileDialog = new DynamoOpenFileDialog(this)
             {
                 Filter = string.Format(Resources.FileDialogDynamoDefinitions,
                          BrandingResourceProvider.ProductName, fileExtensions) + "|" +
                          string.Format(Resources.FileDialogAllFiles, "*.*"),
-                Title = string.Format(Resources.OpenDynamoDefinitionDialogTitle,BrandingResourceProvider.ProductName)
+                Title = dialogTitle
             };
 
             // If opening a template, use templates dir as the initial dir

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2546,17 +2546,6 @@ namespace Dynamo.ViewModels
 
             if (_fileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
-                if (isTemplate && !string.Equals(Path.GetExtension(_fileDialog.FileName), ".dyn", StringComparison.OrdinalIgnoreCase))
-                {
-                    DynamoMessageBox.Show(
-                        Owner,
-                        Resources.MessageErrorOpeningTemplateInvalidExtension,
-                        Resources.MessageErrorOpeningFileGeneral,
-                        MessageBoxButton.OK,
-                        MessageBoxImage.Error);
-                    return;
-                }
-
                 if (CanOpen(_fileDialog.FileName))
                 {
                     if (isTemplate)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2488,7 +2488,7 @@ namespace Dynamo.ViewModels
             bool isTemplate = parameter != null && (parameter as string).Equals("Template");
             var fileExtensions = isTemplate ? "*.dyn" : "*.dyn;*.dyf";
             var dialogTitle = isTemplate
-                ? string.Format(Resources.OpenDynamoTemplateDialogTitle, BrandingResourceProvider.ProductName)
+                ? Resources.OpenDynamoTemplateDialogTitle
                 : string.Format(Resources.OpenDynamoDefinitionDialogTitle, BrandingResourceProvider.ProductName);
 
             DynamoOpenFileDialog _fileDialog = new DynamoOpenFileDialog(this)

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2486,11 +2486,12 @@ namespace Dynamo.ViewModels
             }
 
             bool isTemplate = parameter != null && (parameter as string).Equals("Template");
+            var fileExtensions = isTemplate ? "*.dyn" : "*.dyn;*.dyf";
 
             DynamoOpenFileDialog _fileDialog = new DynamoOpenFileDialog(this)
             {
                 Filter = string.Format(Resources.FileDialogDynamoDefinitions,
-                         BrandingResourceProvider.ProductName, "*.dyn;*.dyf") + "|" +
+                         BrandingResourceProvider.ProductName, fileExtensions) + "|" +
                          string.Format(Resources.FileDialogAllFiles, "*.*"),
                 Title = string.Format(Resources.OpenDynamoDefinitionDialogTitle,BrandingResourceProvider.ProductName)
             };

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -2485,7 +2485,8 @@ namespace Dynamo.ViewModels
                     return;
             }
 
-            bool isTemplate = parameter != null && (parameter as string).Equals("Template");
+            bool isTemplate = parameter is string dialogType
+                && string.Equals(dialogType, "Template", StringComparison.Ordinal);
             var fileExtensions = isTemplate ? "*.dyn" : "*.dyn;*.dyf";
             var dialogTitle = isTemplate
                 ? Resources.OpenDynamoTemplateDialogTitle


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
Please Note:
1. Before submitting the PR, please review [How to Contribute to Dynamo](https://github.com/DynamoDS/Dynamo/blob/master/CONTRIBUTING.md)
2. Dynamo Team will meet 1x a month to review PRs found on Github (Issues will be handled separately)
3. PRs will be reviewed from oldest to newest
4. If a reviewed PR requires changes by the owner, the owner of the PR has 30 days to respond. If the PR has seen no activity by the next session, it will be either closed by the team or depending on its utility will be taken over by someone on the team
5. PRs should use either Dynamo's default PR template or [one of these other template options](https://github.com/DynamoDS/Dynamo/wiki/Choosing-a-Pull-Request-Template) in order to be considered for review.
6. PRs that do not have one of the Dynamo PR templates completely filled out with all declarations satisfied will not be reviewed by the Dynamo team.
7. PRs made to the `DynamoRevit` repo will need to be cherry-picked into all the DynamoRevit Release branches that Dynamo supports. Contributors will be responsible for cherry-picking their reviewed commits to the other branches after a `LGTM` label is added to the PR.
-->

### Purpose

This PR restricts the 'File > Open > Template' dialog to display only `.dyn` files, excluding `.dyf` files. Previously, both `.dyn` and `.dyf` files were shown, which was not the intended behavior for templates.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

The 'File > Open > Template' dialog now correctly filters to show only `.dyn` files, disallowing `.dyf` files as templates.

### Reviewers

(FILL ME IN)

### FYIs

Note: The automated environment lacked `dotnet` for full build/test validation.

<div><a href="https://cursor.com/agents/bc-ab0174a4-458d-409b-838a-5a4f2f61052c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab0174a4-458d-409b-838a-5a4f2f61052c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->