### PR TITLE
Group styles preferences toggle

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -84,6 +84,7 @@ namespace Dynamo.Configuration
         private bool optionalInputsCollapsed;
         private bool unconnectedOutputsCollapsed;
         private bool collapseToMinSize;
+        private bool showDefaultGroupStyles;
 
         #region Constants
         /// <summary>
@@ -197,6 +198,20 @@ namespace Dynamo.Configuration
         /// Indicates if groups should display the default description.
         /// </summary>
         public bool ShowDefaultGroupDescription { get; set; }
+
+        /// <summary>
+        /// Indicates if default group styles should be shown in the graph context menu.
+        /// </summary>
+        public bool ShowDefaultGroupStyles
+        {
+            get => showDefaultGroupStyles;
+            set
+            {
+                if (showDefaultGroupStyles == value) return;
+                showDefaultGroupStyles = value;
+                RaisePropertyChanged(nameof(ShowDefaultGroupStyles));
+            }
+        }
 
         /// <summary>
         /// Indicates if the optional input ports are collapsed by default.
@@ -1072,6 +1087,7 @@ namespace Dynamo.Configuration
             DefaultRunType = RunType.Automatic;
             DefaultNodeAutocompleteSuggestion = NodeAutocompleteSuggestion.MLRecommendation;
             ShowDefaultGroupDescription = true;
+            ShowDefaultGroupStyles = true;
             OptionalInPortsCollapsed = true;
             UnconnectedOutPortsCollapsed = true;
             CollapseToMinSize = true;

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 Dynamo.Models.DynamoModel.DefaultStartConfiguration.EnableUnTrustedLocationsNotifications.get -> bool
 Dynamo.Models.DynamoModel.DefaultStartConfiguration.EnableUnTrustedLocationsNotifications.set -> void
 Dynamo.Models.DynamoModel.IStartConfiguration.EnableUnTrustedLocationsNotifications.get -> bool
+Dynamo.Configuration.PreferenceSettings.ShowDefaultGroupStyles.get -> bool
+Dynamo.Configuration.PreferenceSettings.ShowDefaultGroupStyles.set -> void

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -8594,6 +8594,24 @@ namespace Dynamo.Wpf.Properties {
                 return ResourceManager.GetString("PreferencesViewShowDefaultGroupDescription", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Show default group styles.
+        /// </summary>
+        public static string PreferencesViewShowDefaultGroupStyles {
+            get {
+                return ResourceManager.GetString("PreferencesViewShowDefaultGroupStyles", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to When off, default group styles remain editable in Preferences but are hidden from the graph style menu..
+        /// </summary>
+        public static string PreferencesViewShowDefaultGroupStylesTooltip {
+            get {
+                return ResourceManager.GetString("PreferencesViewShowDefaultGroupStylesTooltip", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Show Preview Bubbles.

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -4174,6 +4174,12 @@ To make this file into a new template, save it to a different folder, then move 
   <data name="PreferencesViewShowDefaultGroupDescription" xml:space="preserve">
     <value>Show default group description</value>
   </data>
+  <data name="PreferencesViewShowDefaultGroupStyles" xml:space="preserve">
+    <value>Show default group styles</value>
+  </data>
+  <data name="PreferencesViewShowDefaultGroupStylesTooltip" xml:space="preserve">
+    <value>When off, default group styles remain editable in Preferences but are hidden from the graph style menu.</value>
+  </data>
   <data name="NodeAutoCompleteToolTip" xml:space="preserve">
     <value>Click to get Node Autocomplete suggestions</value>
   </data>

--- a/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
+++ b/src/DynamoCoreWpf/PublicAPI.Unshipped.txt
@@ -24,6 +24,8 @@ Dynamo.ViewModels.DynamoViewModel.ToastManager.set -> void
 Dynamo.ViewModels.DynamoViewModel.ShowPythonEngineUpgradeCanvasToast(string message, bool stayOpen = true, string filePath = null) -> void
 Dynamo.ViewModels.PreferencesViewModel.AutoSyncDocumentBrowserIsChecked.get -> bool
 Dynamo.ViewModels.PreferencesViewModel.AutoSyncDocumentBrowserIsChecked.set -> void
+Dynamo.ViewModels.PreferencesViewModel.ShowDefaultGroupStyles.get -> bool
+Dynamo.ViewModels.PreferencesViewModel.ShowDefaultGroupStyles.set -> void
 Dynamo.ViewModels.PreferencesViewModel.ShowPythonAutoMigrationNotificationIsChecked.get -> bool
 Dynamo.ViewModels.PreferencesViewModel.ShowPythonAutoMigrationNotificationIsChecked.set -> void
 Dynamo.Wpf.UI.ToastManager
@@ -60,6 +62,8 @@ static Dynamo.Wpf.Properties.Resources.PackageManagerUninstall.get -> string
 static Dynamo.Wpf.Properties.Resources.PackageManagerUpdate.get -> string
 static Dynamo.Wpf.Properties.Resources.PreferencesViewShowPythonEngineChangeNotifications.get -> string
 static Dynamo.Wpf.Properties.Resources.PreferencesViewShowPythonEngineChangeNotificationsTooltip.get -> string
+static Dynamo.Wpf.Properties.Resources.PreferencesViewShowDefaultGroupStyles.get -> string
+static Dynamo.Wpf.Properties.Resources.PreferencesViewShowDefaultGroupStylesTooltip.get -> string
 static Dynamo.Wpf.Properties.Resources.ResetStylesButton.get -> string
 static Dynamo.Wpf.Properties.Resources.ResetStylesButtonToolTip.get -> string
 static Dynamo.Wpf.Properties.Resources.ResetPythonNet3ButtonText.get -> string

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1821,25 +1821,39 @@ namespace Dynamo.ViewModels
         /// <returns></returns>
         private void LoadGroupStylesFromPreferences(IEnumerable<Configuration.StyleItem> styleItemsList)
         {
+            styleItemsList ??= Enumerable.Empty<Configuration.StyleItem>();
+
             var defaultStyleIds = GroupStyleItem.DefaultGroupStyleItems
                 .Select(style => style.GroupStyleId)
                 .ToHashSet();
             var defaultStyleNames = GroupStyleItem.DefaultGroupStyleItems
-                .Select(style => style.Name)
+                .Select(style => style.Name?.Trim())
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-            var defaultGroupStylesList = styleItemsList
-                .Where(style => style.IsDefault)
-                .GroupBy(style => style.GroupStyleId)
-                .Select(group => group.First());
+            // Always use the canonical Dynamo defaults for menu population.
+            // This prevents duplicated default entries if settings contain stale/legacy values.
+            var defaultGroupStylesList = GroupStyleItem.DefaultGroupStyleItems
+                .Select(defaultStyle => new GroupStyleItem
+                {
+                    Name = defaultStyle.Name,
+                    HexColorString = defaultStyle.HexColorString,
+                    FontSize = defaultStyle.FontSize,
+                    GroupStyleId = defaultStyle.GroupStyleId,
+                    IsDefault = true
+                });
 
-            // Exclude legacy default entries that may have been persisted as custom styles.
+            // Exclude any default-like entries that may have been persisted with custom metadata.
             var customGroupStylesList = styleItemsList
-                .Where(style => !style.IsDefault)
+                .Where(style => style != null)
                 .Where(style => !defaultStyleIds.Contains(style.GroupStyleId))
-                .Where(style => !defaultStyleNames.Contains(style.Name))
-                .GroupBy(style => style.GroupStyleId != Guid.Empty ? style.GroupStyleId.ToString("N") : style.Name, StringComparer.OrdinalIgnoreCase)
-                .Select(group => group.First());
+                .Where(style => !defaultStyleNames.Contains(style.Name?.Trim()))
+                .GroupBy(
+                    style => style.GroupStyleId != Guid.Empty
+                        ? style.GroupStyleId.ToString("N")
+                        : style.Name?.Trim(),
+                    StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
+                .ToList();
 
             if (preferenceSettings.ShowDefaultGroupStyles)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1821,6 +1821,16 @@ namespace Dynamo.ViewModels
         /// <returns></returns>
         private void LoadGroupStylesFromPreferences(IEnumerable<Configuration.StyleItem> styleItemsList)
         {
+            // Ensure idempotence even if this method is called repeatedly.
+            if (groupStyleList == null)
+            {
+                groupStyleList = new ObservableCollection<Configuration.StyleItem>();
+            }
+            else
+            {
+                groupStyleList.Clear();
+            }
+
             styleItemsList ??= Enumerable.Empty<Configuration.StyleItem>();
 
             var defaultStyleIds = GroupStyleItem.DefaultGroupStyleItems
@@ -1877,7 +1887,6 @@ namespace Dynamo.ViewModels
         /// </summary>
         internal void ReloadGroupStyles()
         {
-            groupStyleList.Clear();
             LoadGroupStylesFromPreferences(preferenceSettings.GroupStyleItemsList);
         }
 

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1895,7 +1895,11 @@ namespace Dynamo.ViewModels
         /// </summary>
         internal bool IsGroupStyleMenuEnabled()
         {
-            return preferenceSettings?.ShowDefaultGroupStyles ?? true;
+            var showDefaultGroupStyles = preferenceSettings?.ShowDefaultGroupStyles ?? true;
+            var hasCustomStyles = preferenceSettings?.GroupStyleItemsList?
+                .Any(style => style != null && !style.IsDefault) ?? false;
+
+            return showDefaultGroupStyles || hasCustomStyles;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1895,10 +1895,7 @@ namespace Dynamo.ViewModels
         /// </summary>
         internal bool IsGroupStyleMenuEnabled()
         {
-            var hasCustomStyles = preferenceSettings?.GroupStyleItemsList?
-                .Any(style => style != null && !style.IsDefault) ?? false;
-
-            return !(preferenceSettings?.ShowDefaultGroupStyles == false && hasCustomStyles);
+            return preferenceSettings?.ShowDefaultGroupStyles ?? true;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -39,7 +39,6 @@ namespace Dynamo.ViewModels
         private const int portVerticalMidPoint = 17;
         private const int portToggleOffset = 30;
         private ObservableCollection<Dynamo.Configuration.StyleItem> groupStyleList;
-        private IEnumerable<Configuration.StyleItem> preferencesStyleItemsList;
         private PreferenceSettings preferenceSettings;
         private double heightBeforeToggle;
         private double widthBeforeToggle;
@@ -813,6 +812,9 @@ namespace Dynamo.ViewModels
                     {
                         annotationModel.UpdateBoundaryFromSelection();
                     }
+                    break;
+                case nameof(PreferenceSettings.ShowDefaultGroupStyles):
+                    ReloadGroupStyles();
                     break;
             }
         }
@@ -1819,18 +1821,22 @@ namespace Dynamo.ViewModels
         /// <returns></returns>
         private void LoadGroupStylesFromPreferences(IEnumerable<Configuration.StyleItem> styleItemsList)
         {
-            preferencesStyleItemsList = styleItemsList;
+            var defaultGroupStylesList = styleItemsList.Where(style => style.IsDefault);
+            var customGroupStylesList = styleItemsList.Where(style => !style.IsDefault);
 
-            var defaultGroupStylesList = styleItemsList.Where(style => style.IsDefault == true);
-            var customGroupStylesList = styleItemsList.Where(style => style.IsDefault == false);
+            if (preferenceSettings.ShowDefaultGroupStyles)
+            {
+                // Adds to the list the default group styles created by Dynamo.
+                groupStyleList.AddRange(defaultGroupStylesList);
 
-            //Adds to the list the Default Group Styles created by Dynamo
-            groupStyleList.AddRange(defaultGroupStylesList);
+                if (customGroupStylesList.Any())
+                {
+                    // Adds the separator between default and custom group styles.
+                    groupStyleList.Add(new GroupStyleSeparator());
+                }
+            }
 
-            //Adds the separator between the Default Group Styles and the Custom Group Styles
-            groupStyleList.Add(new GroupStyleSeparator());
-
-            //Adds to the list the Custom Group Styles created by the user
+            // Adds to the list the custom group styles created by the user.
             groupStyleList.AddRange(customGroupStylesList);
         }
 
@@ -1840,10 +1846,8 @@ namespace Dynamo.ViewModels
         /// </summary>
         internal void ReloadGroupStyles()
         {
-            if (preferencesStyleItemsList == null) return;
             groupStyleList.Clear();
-
-            LoadGroupStylesFromPreferences(preferencesStyleItemsList);
+            LoadGroupStylesFromPreferences(preferenceSettings.GroupStyleItemsList);
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1821,8 +1821,25 @@ namespace Dynamo.ViewModels
         /// <returns></returns>
         private void LoadGroupStylesFromPreferences(IEnumerable<Configuration.StyleItem> styleItemsList)
         {
-            var defaultGroupStylesList = styleItemsList.Where(style => style.IsDefault);
-            var customGroupStylesList = styleItemsList.Where(style => !style.IsDefault);
+            var defaultStyleIds = GroupStyleItem.DefaultGroupStyleItems
+                .Select(style => style.GroupStyleId)
+                .ToHashSet();
+            var defaultStyleNames = GroupStyleItem.DefaultGroupStyleItems
+                .Select(style => style.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var defaultGroupStylesList = styleItemsList
+                .Where(style => style.IsDefault)
+                .GroupBy(style => style.GroupStyleId)
+                .Select(group => group.First());
+
+            // Exclude legacy default entries that may have been persisted as custom styles.
+            var customGroupStylesList = styleItemsList
+                .Where(style => !style.IsDefault)
+                .Where(style => !defaultStyleIds.Contains(style.GroupStyleId))
+                .Where(style => !defaultStyleNames.Contains(style.Name))
+                .GroupBy(style => style.GroupStyleId != Guid.Empty ? style.GroupStyleId.ToString("N") : style.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First());
 
             if (preferenceSettings.ShowDefaultGroupStyles)
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1891,6 +1891,17 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Returns whether Group Style submenu should be enabled in the group context menu.
+        /// </summary>
+        internal bool IsGroupStyleMenuEnabled()
+        {
+            var hasCustomStyles = preferenceSettings?.GroupStyleItemsList?
+                .Any(style => style != null && !style.IsDefault) ?? false;
+
+            return !(preferenceSettings?.ShowDefaultGroupStyles == false && hasCustomStyles);
+        }
+
+        /// <summary>
         /// Selects this group and models within it.
         /// </summary>
         internal void SelectAll()

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -840,6 +840,22 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
+        /// Indicates if default group styles should be shown in graph context menus.
+        /// </summary>
+        public bool ShowDefaultGroupStyles
+        {
+            get
+            {
+                return preferenceSettings.ShowDefaultGroupStyles;
+            }
+            set
+            {
+                preferenceSettings.ShowDefaultGroupStyles = value;
+                RaisePropertyChanged(nameof(ShowDefaultGroupStyles));
+            }
+        }
+
+        /// <summary>
         /// Indicates if the optional input ports are collapsed by default.
         /// </summary>
         public bool OptionalInputsCollapsed
@@ -1938,6 +1954,9 @@ namespace Dynamo.ViewModels
                     goto default;
                 case nameof(ShowDefaultGroupDescription):
                     description = Res.ResourceManager.GetString(nameof(Res.PreferencesViewShowDefaultGroupDescription), System.Globalization.CultureInfo.InvariantCulture);
+                    goto default;
+                case nameof(ShowDefaultGroupStyles):
+                    description = Res.ResourceManager.GetString(nameof(Res.PreferencesViewShowDefaultGroupStyles), System.Globalization.CultureInfo.InvariantCulture);
                     goto default;
                 case nameof(OptionalInputsCollapsed):
                     description = Res.ResourceManager.GetString(nameof(Res.PreferencesViewHideInportsDescription), System.Globalization.CultureInfo.InvariantCulture);

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -1546,9 +1546,47 @@ namespace Dynamo.ViewModels
                 }
             }
 
+            NormalizeGroupStyles();
             preferenceSettings.SanitizeValues();
             RaisePropertyChanged(string.Empty);
             return true;
+        }
+
+        private static GroupStyleItem CloneStyle(GroupStyleItem style, bool forceAsDefault)
+        {
+            return new GroupStyleItem
+            {
+                Name = style.Name,
+                HexColorString = style.HexColorString,
+                FontSize = style.FontSize,
+                GroupStyleId = style.GroupStyleId,
+                IsDefault = forceAsDefault
+            };
+        }
+
+        private void NormalizeGroupStyles()
+        {
+            var defaultStyleIds = GroupStyleItem.DefaultGroupStyleItems
+                .Select(style => style.GroupStyleId)
+                .ToHashSet();
+            var defaultStyleNames = GroupStyleItem.DefaultGroupStyleItems
+                .Select(style => style.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var customStyles = preferenceSettings.GroupStyleItemsList
+                .Where(style => style != null)
+                .Where(style => !defaultStyleIds.Contains(style.GroupStyleId))
+                .Where(style => !defaultStyleNames.Contains(style.Name))
+                .GroupBy(style => style.GroupStyleId != Guid.Empty ? style.GroupStyleId.ToString("N") : style.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(group => CloneStyle(group.First(), false))
+                .ToList();
+
+            var normalizedGroupStylesList = GroupStyleItem.DefaultGroupStyleItems
+                .Select(style => CloneStyle(style, true))
+                .ToList();
+            normalizedGroupStylesList.AddRange(customStyles);
+
+            preferenceSettings.GroupStyleItemsList = normalizedGroupStylesList;
         }
 
         internal void InitializeGeometryScaling()
@@ -1622,11 +1660,8 @@ namespace Dynamo.ViewModels
             //By Default the warning state of the Visual Settings tab (Group Styles section) will be disabled
             isWarningEnabled = false;
 
-            // Initialize group styles with default and custom GroupStyleItems.
-            var customStyles = preferenceSettings.GroupStyleItemsList.Where(style => style.IsDefault != true).ToList();
-            var newGroupStylesList = new List<GroupStyleItem>(GroupStyleItem.DefaultGroupStyleItems);
-            newGroupStylesList.AddRange(customStyles);
-            preferenceSettings.GroupStyleItemsList = newGroupStylesList;
+            // Initialize group styles with a normalized default + custom list.
+            NormalizeGroupStyles();
 
             StyleItemsList = preferenceSettings.GroupStyleItemsList.ToObservableCollection();
 

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -1883,7 +1883,8 @@ namespace Dynamo.Nodes
 
             GroupStyleSelectorGrid = CreateSubmenuItem(
                 Wpf.Properties.Resources.GroupStyleContextAnnotation,
-                CreateGroupStyleSelector);
+                CreateGroupStyleSelector,
+                ViewModel.IsGroupStyleMenuEnabled());
             groupPopupPanel.Children.Add(GroupStyleSelectorGrid);
 
             groupPopupPanel.Children.Add(CreateSubmenuItem(
@@ -1988,7 +1989,7 @@ namespace Dynamo.Nodes
             return border;
         }
 
-        private Grid CreateSubmenuItem(string label, Func<UIElement> submenuContentFactory)
+        private Grid CreateSubmenuItem(string label, Func<UIElement> submenuContentFactory, bool isEnabled = true)
         {
             var popup = new Popup
             {
@@ -2017,7 +2018,10 @@ namespace Dynamo.Nodes
                 Foreground = _nodeContextMenuForeground,
                 Margin = new Thickness(10, 0, 0, 0),
                 VerticalAlignment = VerticalAlignment.Center,
+                Opacity = isEnabled ? 1.0 : 0.5,
             };
+
+            arrow.Opacity = isEnabled ? 1.0 : 0.5;
 
             var layoutGrid = new Grid();
             layoutGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
@@ -2028,10 +2032,11 @@ namespace Dynamo.Nodes
             layoutGrid.Children.Add(text);
             layoutGrid.Children.Add(arrow);
 
-            var border = WrapWithMenuBorder(layoutGrid);
+            var border = WrapWithMenuBorder(layoutGrid, isEnabled: isEnabled);
 
             border.MouseEnter += (s, e) =>
             {
+                if (!isEnabled) return;
                 popup.Child = submenuContentFactory.Invoke();
                 popup.PlacementTarget = border;
                 popup.IsOpen = true;
@@ -2040,6 +2045,7 @@ namespace Dynamo.Nodes
 
             border.MouseLeave += (s, e) =>
             {
+                if (!isEnabled) return;
                 if (!popup.IsMouseOver)
                 {
                     popup.IsOpen = false;

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -1370,7 +1370,7 @@
                                                        Height="14"
                                                        HorizontalAlignment="Center"
                                                        VerticalAlignment="Center"
-                                                       Style="{StaticResource QuestionIconNotClickable}">
+                                                       Style="{StaticResource QuestionIcon}">
                                                     <Image.ToolTip>
                                                         <ToolTip Content="{x:Static p:Resources.PreferencesViewShowDefaultGroupStylesTooltip}"
                                                                  Style="{StaticResource GenericToolTipLight}"/>

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -1199,6 +1199,7 @@
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
                                         </Grid.RowDefinitions>
                                         <Label Grid.Row="0"
                                                Content="{x:Static p:Resources.PreferencesViewGroupStylesHeader}"
@@ -1345,13 +1346,45 @@
                                                        Foreground="{StaticResource PreferencesWindowFontColor}"/>
                                             </Grid>
                                         </Grid>
+                                        <Grid Grid.Row="5" Margin="0,12,0,0">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                </Grid.ColumnDefinitions>
+                                                <ToggleButton Width="{StaticResource ToggleButtonWidth}"
+                                                              Height="{StaticResource ToggleButtonHeight}"
+                                                              VerticalAlignment="Center"
+                                                              Margin="2,0,0,0"
+                                                              Grid.Column="0"
+                                                              IsEnabled="True"
+                                                              IsChecked="{Binding Path=ShowDefaultGroupStyles}"
+                                                              Style="{StaticResource EllipseToggleButton1}"/>
+                                                <Label Grid.Column="1"
+                                                       Content="{x:Static p:Resources.PreferencesViewShowDefaultGroupStyles}"
+                                                       Foreground="{StaticResource PreferencesWindowFontColor}"/>
+                                                <Image Grid.Column="2"
+                                                       Margin="6,2,0,0"
+                                                       Width="14"
+                                                       Height="14"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center"
+                                                       Style="{StaticResource QuestionIconNotClickable}">
+                                                    <Image.ToolTip>
+                                                        <ToolTip Content="{x:Static p:Resources.PreferencesViewShowDefaultGroupStylesTooltip}"
+                                                                 Style="{StaticResource GenericToolTipLight}"/>
+                                                    </Image.ToolTip>
+                                                </Image>
+                                            </Grid>
+                                        </Grid>
                                         <!--Hide ports-->
-                                        <Label Grid.Row="5"
+                                        <Label Grid.Row="6"
                                                Content="{x:Static p:Resources.PreferencesViewCollapsedGroupHeader}"
                                                Margin="-3,12,0,0"
                                                FontWeight="Bold"
                                                Foreground="{StaticResource PreferencesWindowFontColor}"/>
-                                        <Grid Grid.Row="6" Margin="0,12,0,0">
+                                        <Grid Grid.Row="7" Margin="0,12,0,0">
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto"/>
@@ -1370,7 +1403,7 @@
                                                        Foreground="{StaticResource PreferencesWindowFontColor}"/>
                                             </Grid>
                                         </Grid>
-                                        <Grid Grid.Row="7" Margin="0,12,0,0">
+                                        <Grid Grid.Row="8" Margin="0,12,0,0">
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto"/>
@@ -1389,7 +1422,7 @@
                                                        Foreground="{StaticResource PreferencesWindowFontColor}"/>
                                             </Grid>
                                         </Grid>
-                                        <Grid Grid.Row="8" Margin="0,12,0,5">
+                                        <Grid Grid.Row="9" Margin="0,12,0,5">
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto"/>

--- a/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
+++ b/test/DynamoCoreTests/Configuration/PreferenceSettingsTests.cs
@@ -74,6 +74,7 @@ namespace Dynamo.Tests.Configuration
             Assert.AreEqual(settings.DynamoPlayerFolderGroups.Count, 0);
             Assert.AreEqual(settings.EnableDynamoPlayerRenamedWatchAsOutput, false);
             Assert.AreEqual(settings.Locale, "Default");
+            Assert.AreEqual(settings.ShowDefaultGroupStyles, true);
 
             // Save
             settings.Save(tempPath);
@@ -95,6 +96,7 @@ namespace Dynamo.Tests.Configuration
             Assert.AreEqual(settings.DynamoPlayerFolderGroups.Count, 0);
             Assert.AreEqual(settings.EnableDynamoPlayerRenamedWatchAsOutput, false);
             Assert.AreEqual(settings.Locale, "Default");
+            Assert.AreEqual(settings.ShowDefaultGroupStyles, true);
 
             // Change setting values
             settings.SetIsBackgroundPreviewActive("MyBackgroundPreview", false);
@@ -144,6 +146,7 @@ namespace Dynamo.Tests.Configuration
             });
             settings.EnableDynamoPlayerRenamedWatchAsOutput = true;
             settings.Locale = "zh-CN";
+            settings.ShowDefaultGroupStyles = false;
 
 
             // Save
@@ -183,6 +186,7 @@ namespace Dynamo.Tests.Configuration
             Assert.AreEqual(settings.DynamoPlayerFolderGroups[0].Folders.Count, 1);
             Assert.AreEqual(settings.EnableDynamoPlayerRenamedWatchAsOutput, true);
             Assert.AreEqual(settings.Locale, "zh-CN");
+            Assert.AreEqual(settings.ShowDefaultGroupStyles, false);
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -244,6 +244,25 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void TestRepeatedContextMenuOpen_DoesNotAccumulateDefaultStyles()
+        {
+            Open(@"UI\GroupTest.dyn");
+
+            var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
+
+            var firstCount = GetGroupStyleContextOptionCount(annotationView);
+            annotationView.GroupContextMenuPopup.IsOpen = false;
+            DispatcherUtil.DoEvents();
+
+            var secondCount = GetGroupStyleContextOptionCount(annotationView);
+            annotationView.GroupContextMenuPopup.IsOpen = false;
+            DispatcherUtil.DoEvents();
+
+            Assert.AreEqual(4, firstCount);
+            Assert.AreEqual(4, secondCount);
+        }
+
+        [Test]
         public void CustomColorPicker_PrePopulateDefaultColors()
         {
             Open(@"UI\GroupTest.dyn");

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -178,7 +178,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        public void TestHideDefaultGroupStyles_ContextMenu_IsDisabledWhenCustomStylesExist()
+        public void TestHideDefaultGroupStyles_ContextMenu_IsEnabledWhenCustomStylesExist()
         {
             Open(@"UI\GroupTest.dyn");
 
@@ -202,8 +202,8 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(4, prefViewModel.StyleItemsList.Count(style => style.IsDefault));
 
             var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
-            var isSubmenuOpen = IsGroupStyleSubmenuOpen(annotationView);
-            Assert.IsFalse(isSubmenuOpen, "Group Style submenu should be disabled when defaults are hidden and custom styles exist.");
+            var contextMenuStyleCount = GetGroupStyleContextOptionCount(annotationView);
+            Assert.AreEqual(1, contextMenuStyleCount, "Group Style submenu should be enabled and show custom styles when defaults are hidden.");
 
             preferencesWindow.CloseButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
             DispatcherUtil.DoEvents();

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -220,6 +220,30 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void TestDuplicatedDefaultStyles_DoNotDuplicateContextMenuEntries()
+        {
+            Open(@"UI\GroupTest.dyn");
+
+            var preferencesSettings = (View.DataContext as DynamoViewModel).PreferenceSettings;
+            var duplicatedDefaults = GroupStyleItem.DefaultGroupStyleItems
+                .Concat(GroupStyleItem.DefaultGroupStyleItems.Select(defaultStyle => new GroupStyleItem
+                {
+                    Name = defaultStyle.Name,
+                    HexColorString = defaultStyle.HexColorString,
+                    FontSize = defaultStyle.FontSize,
+                    GroupStyleId = Guid.NewGuid(),
+                    IsDefault = true
+                }))
+                .ToList();
+
+            preferencesSettings.GroupStyleItemsList = duplicatedDefaults;
+
+            var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
+            var contextMenuStyleCount = GetGroupStyleContextOptionCount(annotationView);
+            Assert.AreEqual(4, contextMenuStyleCount, "Context menu should only show canonical default styles once.");
+        }
+
+        [Test]
         public void CustomColorPicker_PrePopulateDefaultColors()
         {
             Open(@"UI\GroupTest.dyn");

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -210,6 +210,19 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void TestHideDefaultGroupStyles_ContextMenu_IsDisabledWhenNoCustomStylesExist()
+        {
+            Open(@"UI\GroupTest.dyn");
+
+            var preferencesSettings = (View.DataContext as DynamoViewModel).PreferenceSettings;
+            preferencesSettings.ShowDefaultGroupStyles = false;
+
+            var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
+            var isSubmenuOpen = IsGroupStyleSubmenuOpen(annotationView);
+            Assert.IsFalse(isSubmenuOpen, "Group Style submenu should be disabled when defaults are hidden.");
+        }
+
+        [Test]
         public void TestLegacyDefaultStyles_DoNotDuplicateContextMenuEntries()
         {
             Open(@"UI\GroupTest.dyn");

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -29,6 +29,43 @@ namespace DynamoCoreWpfTests
             return annotationViewOfType.First();
         }
 
+        private int GetGroupStyleContextOptionCount(AnnotationView annotationView)
+        {
+            // Manually create and open the group context menu (normally triggered by right-click).
+            annotationView.CreateAndAttachAnnotationPopup();
+            annotationView.GroupContextMenuPopup.IsOpen = true;
+            DispatcherUtil.DoEvents();
+
+            var stylesSubmenu = annotationView.GroupStyleSelectorGrid as Grid;
+            Assert.IsNotNull(stylesSubmenu, "Styles sub-menu border not found.");
+
+            var border = stylesSubmenu.Children.OfType<Border>().FirstOrDefault();
+            var popup = stylesSubmenu.Children.OfType<Popup>().FirstOrDefault();
+
+            Assert.IsNotNull(border, "Sub-menu border not found.");
+            Assert.IsNotNull(popup, "Sub-menu popup not found.");
+
+            // Trigger MouseEnter to populate the popup content.
+            border.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0)
+            {
+                RoutedEvent = Mouse.MouseEnterEvent
+            });
+            DispatcherUtil.DoEvents();
+
+            Assert.IsTrue(popup.IsOpen, "Popup did not open after MouseEnter.");
+            Assert.IsInstanceOf<Border>(popup.Child, "Popup content is not a Border.");
+
+            var wrapper = popup.Child as Border;
+            var stackPanel = wrapper.Child as StackPanel;
+            Assert.IsNotNull(stackPanel, "Could not find StackPanel inside popup.");
+
+            return stackPanel.Children
+                .OfType<Border>()
+                .Select(b => b.Child)
+                .OfType<StackPanel>()
+                .Count();
+        }
+
         public override void Open(string path)
         {
             base.Open(path);
@@ -110,46 +147,44 @@ namespace DynamoCoreWpfTests
             preferencesWindow.CloseButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
             DispatcherUtil.DoEvents();
 
-            // Manually create and open the group context menu (normally triggered by right-click)
-            annotationView.CreateAndAttachAnnotationPopup();
-
-            // Open context menu
-            annotationView.GroupContextMenuPopup.IsOpen = true;
-            DispatcherUtil.DoEvents();
-
-            var stylesSubmenu = annotationView.GroupStyleSelectorGrid as Grid;
-            Assert.IsNotNull(stylesSubmenu, "Styles sub-menu border not found.");
-
-            var border = stylesSubmenu.Children.OfType<Border>().FirstOrDefault();
-            var popup = stylesSubmenu.Children.OfType<Popup>().FirstOrDefault();
-
-            Assert.IsNotNull(border, "Sub-menu border not found.");
-            Assert.IsNotNull(popup, "Sub-menu popup not found.");
-
-            // Trigger MouseEnter to populate the popup content
-            border.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0)
-            {
-                RoutedEvent = Mouse.MouseEnterEvent
-            });
-            DispatcherUtil.DoEvents();
-
-            Assert.IsTrue(popup.IsOpen, "Popup did not open after MouseEnter.");
-            Assert.IsInstanceOf<Border>(popup.Child, "Popup content is not a Border.");
-
-            var wrapper = popup.Child as Border;
-            var stackPanel = wrapper.Child as StackPanel;
-
-            Assert.IsNotNull(stackPanel, "Could not find StackPanel inside popup.");            
-
-            // Count group style options
-            var innerStackCount = stackPanel.Children
-                .OfType<Border>()
-                .Select(b => b.Child)
-                .OfType<StackPanel>()
-                .Count();
+            var innerStackCount = GetGroupStyleContextOptionCount(annotationView);
 
             //Check that the GroupStyles in the AnnotationView match the ones in the PreferencesView
             Assert.AreEqual(innerStackCount, currentGroupStylesCounter);
+        }
+
+        [Test]
+        public void TestHideDefaultGroupStyles_ContextMenu()
+        {
+            Open(@"UI\GroupTest.dyn");
+
+            var preferencesSettings = (View.DataContext as DynamoViewModel).PreferenceSettings;
+            preferencesSettings.GroupStyleItemsList.Add(new GroupStyleItem
+            {
+                Name = "Custom 1",
+                HexColorString = "FFFF00",
+                IsDefault = false,
+                GroupStyleId = Guid.NewGuid(),
+                FontSize = 36
+            });
+            preferencesSettings.ShowDefaultGroupStyles = false;
+
+            var preferencesWindow = new PreferencesView(View);
+            preferencesWindow.Show();
+            DispatcherUtil.DoEvents();
+
+            var prefViewModel = preferencesWindow.DataContext as PreferencesViewModel;
+            Assert.AreEqual(5, prefViewModel.StyleItemsList.Count);
+            Assert.AreEqual(4, prefViewModel.StyleItemsList.Count(style => style.IsDefault));
+
+            var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
+            var contextMenuStyleCount = GetGroupStyleContextOptionCount(annotationView);
+
+            // Only custom styles are shown in graph context menu when defaults are hidden.
+            Assert.AreEqual(1, contextMenuStyleCount);
+
+            preferencesWindow.CloseButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+            DispatcherUtil.DoEvents();
         }
 
         [Test]

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -66,6 +66,30 @@ namespace DynamoCoreWpfTests
                 .Count();
         }
 
+        private bool IsGroupStyleSubmenuOpen(AnnotationView annotationView)
+        {
+            annotationView.CreateAndAttachAnnotationPopup();
+            annotationView.GroupContextMenuPopup.IsOpen = true;
+            DispatcherUtil.DoEvents();
+
+            var stylesSubmenu = annotationView.GroupStyleSelectorGrid as Grid;
+            Assert.IsNotNull(stylesSubmenu, "Styles sub-menu border not found.");
+
+            var border = stylesSubmenu.Children.OfType<Border>().FirstOrDefault();
+            var popup = stylesSubmenu.Children.OfType<Popup>().FirstOrDefault();
+
+            Assert.IsNotNull(border, "Sub-menu border not found.");
+            Assert.IsNotNull(popup, "Sub-menu popup not found.");
+
+            border.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0)
+            {
+                RoutedEvent = Mouse.MouseEnterEvent
+            });
+            DispatcherUtil.DoEvents();
+
+            return popup.IsOpen;
+        }
+
         public override void Open(string path)
         {
             base.Open(path);
@@ -154,7 +178,7 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
-        public void TestHideDefaultGroupStyles_ContextMenu()
+        public void TestHideDefaultGroupStyles_ContextMenu_IsDisabledWhenCustomStylesExist()
         {
             Open(@"UI\GroupTest.dyn");
 
@@ -178,10 +202,8 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(4, prefViewModel.StyleItemsList.Count(style => style.IsDefault));
 
             var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
-            var contextMenuStyleCount = GetGroupStyleContextOptionCount(annotationView);
-
-            // Only custom styles are shown in graph context menu when defaults are hidden.
-            Assert.AreEqual(1, contextMenuStyleCount);
+            var isSubmenuOpen = IsGroupStyleSubmenuOpen(annotationView);
+            Assert.IsFalse(isSubmenuOpen, "Group Style submenu should be disabled when defaults are hidden and custom styles exist.");
 
             preferencesWindow.CloseButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
             DispatcherUtil.DoEvents();

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -188,6 +188,38 @@ namespace DynamoCoreWpfTests
         }
 
         [Test]
+        public void TestLegacyDefaultStyles_DoNotDuplicateContextMenuEntries()
+        {
+            Open(@"UI\GroupTest.dyn");
+
+            var preferencesSettings = (View.DataContext as DynamoViewModel).PreferenceSettings;
+            preferencesSettings.GroupStyleItemsList = GroupStyleItem.DefaultGroupStyleItems
+                .Select(defaultStyle => new GroupStyleItem
+                {
+                    Name = defaultStyle.Name,
+                    HexColorString = defaultStyle.HexColorString,
+                    FontSize = defaultStyle.FontSize,
+                    GroupStyleId = Guid.Empty,
+                    IsDefault = false
+                })
+                .ToList();
+
+            var preferencesWindow = new PreferencesView(View);
+            preferencesWindow.Show();
+            DispatcherUtil.DoEvents();
+
+            var prefViewModel = preferencesWindow.DataContext as PreferencesViewModel;
+            Assert.AreEqual(4, prefViewModel.StyleItemsList.Count, "Preferences should normalize to one set of defaults.");
+
+            var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
+            var contextMenuStyleCount = GetGroupStyleContextOptionCount(annotationView);
+            Assert.AreEqual(4, contextMenuStyleCount, "Context menu should only show one set of default styles.");
+
+            preferencesWindow.CloseButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+            DispatcherUtil.DoEvents();
+        }
+
+        [Test]
         public void CustomColorPicker_PrePopulateDefaultColors()
         {
             Open(@"UI\GroupTest.dyn");

--- a/test/settings/DynamoSettings-NewSettings.xml
+++ b/test/settings/DynamoSettings-NewSettings.xml
@@ -8,6 +8,7 @@
   <GraphicScaleUnit>Feet</GraphicScaleUnit>
   <ShowPreviewBubbles>false</ShowPreviewBubbles>
   <ShowDefaultGroupDescription>false</ShowDefaultGroupDescription>
+  <ShowDefaultGroupStyles>false</ShowDefaultGroupStyles>
   <OptionalInPortsCollapsed>false</OptionalInPortsCollapsed>
   <UnconnectedOutPortsCollapsed>false</UnconnectedOutPortsCollapsed>
   <CollapseToMinSize>false</CollapseToMinSize>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

This PR introduces a new preference toggle, "Show default group styles," to address the need for greater control over group style customization for corporate standardization. Users can now hide the default group styles (Actions, Inputs, Outputs, Review) from the graph's context menu while retaining their visibility and editability within the Preferences window. This prevents frustration caused by inability to fully customize group styles and `DynamoSettings.xml` edits being overwritten.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

A new preference toggle, "Show default group styles," has been added under Preferences > Visual Settings > Group Styles. When this toggle is off, the default group styles (Actions, Inputs, Outputs, Review) will no longer appear in the graph's context menu, allowing users to streamline their group style options. These default styles will still be visible and editable within the Preferences window.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

<div><a href="https://cursor.com/agents/bc-7871cd2b-2e03-4c85-82cd-ad6235bf9d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7871cd2b-2e03-4c85-82cd-ad6235bf9d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->