### PR TITLE
DYN-8951: Allow deleting default group styles and restore via reset

### DIFF
--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -1188,7 +1188,13 @@ namespace Dynamo.Configuration
             PreferenceSettings settings = null;
 
             if (String.IsNullOrEmpty(filePath) || (!File.Exists(filePath)))
-                return new PreferenceSettings();
+            {
+                var defaultSettings = new PreferenceSettings();
+                defaultSettings.GroupStyleItemsList = CreateDefaultGroupStyleItems();
+                return defaultSettings;
+            }
+
+            var hasGroupStyleItemsListElement = File.ReadAllText(filePath).Contains("<GroupStyleItemsList", StringComparison.Ordinal);
 
             try
             {
@@ -1224,7 +1230,12 @@ namespace Dynamo.Configuration
                 }
             }
             settings.CustomPackageFolders = settings.CustomPackageFolders.Distinct().ToList();
+            settings.GroupStyleItemsList ??= new List<GroupStyleItem>();
             settings.GroupStyleItemsList = settings.GroupStyleItemsList.GroupBy(entry => entry.Name).Select(result => result.First()).ToList();
+            if (!hasGroupStyleItemsListElement && settings.GroupStyleItemsList.Count == 0)
+            {
+                settings.GroupStyleItemsList = CreateDefaultGroupStyleItems();
+            }
             MigrateStdLibTokenToBuiltInToken(settings);
 
             settings.DeserializeInternalPrefs(filePath);
@@ -1246,6 +1257,8 @@ namespace Dynamo.Configuration
             if(string.IsNullOrEmpty(content))
                 return new PreferenceSettings() { isCreatedFromValidFile = false };
 
+            var hasGroupStyleItemsListElement = content.Contains("<GroupStyleItemsList", StringComparison.Ordinal);
+
             try
             {
                 var serializer = new XmlSerializer(typeof(PreferenceSettings));
@@ -1263,12 +1276,31 @@ namespace Dynamo.Configuration
             }
                 
             settings.CustomPackageFolders = settings.CustomPackageFolders.Distinct().ToList();
+            settings.GroupStyleItemsList ??= new List<GroupStyleItem>();
             settings.GroupStyleItemsList = settings.GroupStyleItemsList.GroupBy(entry => entry.Name).Select(result => result.First()).ToList();
+            if (!hasGroupStyleItemsListElement && settings.GroupStyleItemsList.Count == 0)
+            {
+                settings.GroupStyleItemsList = CreateDefaultGroupStyleItems();
+            }
             MigrateStdLibTokenToBuiltInToken(settings);
 
             settings.DeserializeInternalPrefsContent(content);
 
             return settings;
+        }
+
+        private static List<GroupStyleItem> CreateDefaultGroupStyleItems()
+        {
+            return GroupStyleItem.DefaultGroupStyleItems
+                .Select(defaultStyle => new GroupStyleItem
+                {
+                    Name = defaultStyle.Name,
+                    HexColorString = defaultStyle.HexColorString,
+                    FontSize = defaultStyle.FontSize,
+                    GroupStyleId = defaultStyle.GroupStyleId,
+                    IsDefault = true
+                })
+                .ToList();
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2601,7 +2601,7 @@ Do you wish to uninstall {1}? Restart {2} to complete the uninstall and try down
     <value>Reset Styles</value>
   </data>
   <data name="ResetStylesButtonToolTip" xml:space="preserve">
-    <value>Deletes all user-created (non-default) group styles. This does not affect styles in existing graphs and cannot be undone.</value>
+    <value>Deletes all user-created (non-default) group styles and restores the default group styles. This does not affect styles in existing graphs and cannot be undone.</value>
   </data>
   <data name="ResetPythonNet3ButtonText" xml:space="preserve">
     <value>Reset PythonNet3</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2908,7 +2908,7 @@ Do you wish to uninstall {1}? Restart {2} to complete the uninstall and try down
     <value>Reset Styles</value>
   </data>
   <data name="ResetStylesButtonToolTip" xml:space="preserve">
-    <value>Deletes all user-created (non-default) group styles. This does not affect styles in existing graphs and cannot be undone.</value>
+    <value>Deletes all user-created (non-default) group styles and restores the default group styles. This does not affect styles in existing graphs and cannot be undone.</value>
   </data>
   <data name="ResetPythonNet3ButtonText" xml:space="preserve">
     <value>Reset PythonNet3</value>

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -814,9 +814,6 @@ namespace Dynamo.ViewModels
                         annotationModel.UpdateBoundaryFromSelection();
                     }
                     break;
-                case nameof(PreferenceSettings.ShowDefaultGroupStyles):
-                    ReloadGroupStyles();
-                    break;
             }
         }
 
@@ -1824,19 +1821,17 @@ namespace Dynamo.ViewModels
         {
             preferencesStyleItemsList = styleItemsList;
 
-            var defaultGroupStylesList = styleItemsList.Where(style => style.IsDefault == true);
-            var customGroupStylesList = styleItemsList.Where(style => style.IsDefault == false);
+            var styleItems = styleItemsList?.ToList() ?? new List<Configuration.StyleItem>();
+            var defaultGroupStylesList = styleItems.Where(style => style.IsDefault == true);
+            var customGroupStylesList = styleItems.Where(style => style.IsDefault == false);
 
-            //Adds to the list the Default Group Styles created by Dynamo
-            if (preferenceSettings.ShowDefaultGroupStyles)
+            // Adds to the list the default Group Styles created by Dynamo.
+            groupStyleList.AddRange(defaultGroupStylesList);
+
+            if (defaultGroupStylesList.Any() && customGroupStylesList.Any())
             {
-                groupStyleList.AddRange(defaultGroupStylesList);
-
-                if (customGroupStylesList.Any())
-                {
-                    //Adds the separator between the Default Group Styles and the Custom Group Styles
-                    groupStyleList.Add(new GroupStyleSeparator());
-                }
+                // Adds the separator between the Default Group Styles and the Custom Group Styles.
+                groupStyleList.Add(new GroupStyleSeparator());
             }
 
             //Adds to the list the Custom Group Styles created by the user
@@ -1860,11 +1855,7 @@ namespace Dynamo.ViewModels
         /// </summary>
         internal bool IsGroupStyleMenuEnabled()
         {
-            var showDefaultGroupStyles = preferenceSettings?.ShowDefaultGroupStyles ?? true;    
-            var hasCustomStyles = preferenceSettings?.GroupStyleItemsList?
-                .Any(style => style != null && !style.IsDefault) ?? false;
-
-            return showDefaultGroupStyles || hasCustomStyles;
+            return preferenceSettings?.GroupStyleItemsList?.Any(style => style != null) ?? false;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -620,11 +620,27 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// Returns whether there are custom (non-default) styles that can be removed.
+        /// Returns whether styles can be reset:
+        /// either custom styles exist, or one or more default styles are missing.
         /// </summary>
         public bool CanResetGroupStyles
         {
-            get { return preferenceSettings.GroupStyleItemsList.Any(style => !style.IsDefault); }
+            get
+            {
+                var existingStyles = preferenceSettings.GroupStyleItemsList;
+                if (existingStyles == null) return false;
+
+                var hasCustomStyles = existingStyles.Any(style => style != null && !style.IsDefault);
+                if (hasCustomStyles) return true;
+
+                var existingDefaultStyleIds = existingStyles
+                    .Where(style => style != null && style.IsDefault)
+                    .Select(style => style.GroupStyleId)
+                    .ToHashSet();
+
+                return GroupStyleItem.DefaultGroupStyleItems
+                    .Any(defaultStyle => !existingDefaultStyleIds.Contains(defaultStyle.GroupStyleId));
+            }
         }
 
         /// <summary>
@@ -1621,12 +1637,6 @@ namespace Dynamo.ViewModels
 
             //By Default the warning state of the Visual Settings tab (Group Styles section) will be disabled
             isWarningEnabled = false;
-
-            // Initialize group styles with default and custom GroupStyleItems.
-            var customStyles = preferenceSettings.GroupStyleItemsList.Where(style => style.IsDefault != true).ToList();
-            var newGroupStylesList = new List<GroupStyleItem>(GroupStyleItem.DefaultGroupStyleItems);
-            newGroupStylesList.AddRange(customStyles);
-            preferenceSettings.GroupStyleItemsList = newGroupStylesList;
 
             StyleItemsList = preferenceSettings.GroupStyleItemsList.ToObservableCollection();
 

--- a/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
+++ b/src/DynamoCoreWpf/Views/Menu/PreferencesView.xaml
@@ -100,7 +100,6 @@
                                     Margin="0,0,8,0"
                                     HorizontalAlignment="Right"
                                     VerticalAlignment="Top"
-                                    Visibility="{Binding Path=IsDefault, Converter={StaticResource InverseBoolToVisibilityConverter}}"
                                     Click="RemoveStyle_Click"
                                     Style="{StaticResource FlatIconButtonStyle}"
                                     Width="20"
@@ -1199,7 +1198,6 @@
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="Auto" />
                                         </Grid.RowDefinitions>
                                         <Label Grid.Row="0"
                                                Content="{x:Static p:Resources.PreferencesViewGroupStylesHeader}"
@@ -1346,45 +1344,13 @@
                                                        Foreground="{StaticResource PreferencesWindowFontColor}"/>
                                             </Grid>
                                         </Grid>
-                                        <Grid Grid.Row="5" Margin="0,12,0,0">
-                                            <Grid>
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                </Grid.ColumnDefinitions>
-                                                <ToggleButton Width="{StaticResource ToggleButtonWidth}"
-                                                              Height="{StaticResource ToggleButtonHeight}"
-                                                              VerticalAlignment="Center"
-                                                              Margin="2,0,0,0"
-                                                              Grid.Column="0"
-                                                              IsEnabled="True"
-                                                              IsChecked="{Binding Path=ShowDefaultGroupStyles}"
-                                                              Style="{StaticResource EllipseToggleButton1}"/>
-                                                <Label Grid.Column="1"
-                                                       Content="{x:Static p:Resources.PreferencesViewShowDefaultGroupStyles}"
-                                                       Foreground="{StaticResource PreferencesWindowFontColor}"/>
-                                                <Image Grid.Column="2"
-                                                       Margin="6,2,0,0"
-                                                       Width="14"
-                                                       Height="14"
-                                                       HorizontalAlignment="Center"
-                                                       VerticalAlignment="Center"
-                                                       Style="{StaticResource QuestionIcon}">
-                                                    <Image.ToolTip>
-                                                        <ToolTip Content="{x:Static p:Resources.PreferencesViewShowDefaultGroupStylesTooltip}"
-                                                                 Style="{StaticResource GenericToolTipLight}"/>
-                                                    </Image.ToolTip>
-                                                </Image>
-                                            </Grid>
-                                        </Grid>
                                         <!--Hide ports-->
-                                        <Label Grid.Row="6"
+                                        <Label Grid.Row="5"
                                                Content="{x:Static p:Resources.PreferencesViewCollapsedGroupHeader}"
                                                Margin="-3,12,0,0"
                                                FontWeight="Bold"
                                                Foreground="{StaticResource PreferencesWindowFontColor}"/>
-                                        <Grid Grid.Row="7" Margin="0,12,0,0">
+                                        <Grid Grid.Row="6" Margin="0,12,0,0">
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto"/>
@@ -1403,7 +1369,7 @@
                                                        Foreground="{StaticResource PreferencesWindowFontColor}"/>
                                             </Grid>
                                         </Grid>
-                                        <Grid Grid.Row="8" Margin="0,12,0,0">
+                                        <Grid Grid.Row="7" Margin="0,12,0,0">
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto"/>
@@ -1422,7 +1388,7 @@
                                                        Foreground="{StaticResource PreferencesWindowFontColor}"/>
                                             </Grid>
                                         </Grid>
-                                        <Grid Grid.Row="9" Margin="0,12,0,5">
+                                        <Grid Grid.Row="8" Margin="0,12,0,5">
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="Auto"/>

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -250,5 +250,45 @@ namespace DynamoCoreWpfTests
             Assert.IsFalse(prefViewModel.CanResetGroupStyles);
             Assert.AreEqual(Visibility.Collapsed, preferencesWindow.ResetStylesButton.Visibility);
         }
+
+        [Test]
+        public void DeletingDefaultStyle_DoesNotRecreateUntilReset()
+        {
+            Open(@"UI\GroupTest.dyn");
+
+            var preferencesWindow = new PreferencesView(View);
+            preferencesWindow.Show();
+            DispatcherUtil.DoEvents();
+
+            var prefViewModel = preferencesWindow.DataContext as PreferencesViewModel;
+            Assert.AreEqual(4, prefViewModel.StyleItemsList.Count(style => style.IsDefault));
+
+            var styleToRemove = prefViewModel.StyleItemsList.First(style => style.IsDefault);
+            prefViewModel.RemoveStyleEntry(styleToRemove.Name);
+            DispatcherUtil.DoEvents();
+
+            Assert.AreEqual(3, prefViewModel.StyleItemsList.Count(style => style.IsDefault));
+            Assert.IsTrue(prefViewModel.CanResetGroupStyles);
+            Assert.AreEqual(Visibility.Visible, preferencesWindow.ResetStylesButton.Visibility);
+
+            preferencesWindow.CloseButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+            DispatcherUtil.DoEvents();
+
+            var reopenedPreferencesWindow = new PreferencesView(View);
+            reopenedPreferencesWindow.Show();
+            DispatcherUtil.DoEvents();
+
+            var reopenedViewModel = reopenedPreferencesWindow.DataContext as PreferencesViewModel;
+            Assert.AreEqual(3, reopenedViewModel.StyleItemsList.Count(style => style.IsDefault));
+
+            reopenedPreferencesWindow.ResetStylesButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+            DispatcherUtil.DoEvents();
+
+            Assert.AreEqual(4, reopenedViewModel.StyleItemsList.Count(style => style.IsDefault));
+            Assert.IsFalse(reopenedViewModel.StyleItemsList.Any(style => !style.IsDefault));
+
+            reopenedPreferencesWindow.CloseButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+            DispatcherUtil.DoEvents();
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

This PR replaces the recent “hide default group styles” behavior with a delete-and-restore workflow.

Key changes:
- Removed automatic default-style re-injection from `PreferencesViewModel`, so deleted default styles are not recreated when reopening Preferences.
- Updated `PreferenceSettings.Load`/`LoadContent` to seed defaults only when settings do not explicitly contain a `GroupStyleItemsList` element (backward-compatible initialization without re-creating user-deleted defaults).
- Enabled deleting default styles from Preferences by exposing the delete action in the style item template.
- Updated reset-state logic (`CanResetGroupStyles`) so **Reset Styles** is available when custom styles exist **or** default styles are missing.
- Updated group context-menu style loading to respect the persisted style list directly (no hide-default toggle behavior).
- Updated Reset Styles tooltip text to reflect restoring default styles.
- Added a UI regression test: `DeletingDefaultStyle_DoesNotRecreateUntilReset`.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Default group styles can now be deleted from Preferences and are no longer automatically recreated; using **Reset Styles** removes custom styles and restores default styles.

### Reviewers

(FILL ME IN) Reviewer 1

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8417ff5-7720-40d9-bf19-c764b1fd437f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8417ff5-7720-40d9-bf19-c764b1fd437f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

