### PR TITLE
DYN-8951: Stop recreating deleted default group styles on startup

### DIFF
--- a/src/DynamoCore/Configuration/GroupStyleItem.cs
+++ b/src/DynamoCore/Configuration/GroupStyleItem.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Dynamo.Properties;
 
 namespace Dynamo.Configuration
@@ -20,5 +22,22 @@ namespace Dynamo.Configuration
                 new GroupStyleItem() { Name = Resources.GroupStyleDefaultOutputs, HexColorString = Resources.GroupStyleDefaultOutputsColor, FontSize = 36, IsDefault = true, GroupStyleId = new Guid("07655dc1-2d65-4fed-8d6a-37235d3e3a8d") },
                 new GroupStyleItem() { Name = Resources.GroupStyleDefaultReview, HexColorString = Resources.GroupStyleDefaultReviewColor, FontSize = 36 ,IsDefault = true, GroupStyleId = new Guid("bc688959-ce34-4bf5-90f8-6ddd23f80989") }
             };
+
+        /// <summary>
+        /// Creates a new list with clones of the default group styles.
+        /// </summary>
+        internal static List<GroupStyleItem> CloneDefaultGroupStyleItems()
+        {
+            return DefaultGroupStyleItems
+                .Select(defaultStyle => new GroupStyleItem
+                {
+                    Name = defaultStyle.Name,
+                    HexColorString = defaultStyle.HexColorString,
+                    FontSize = defaultStyle.FontSize,
+                    GroupStyleId = defaultStyle.GroupStyleId,
+                    IsDefault = true
+                })
+                .ToList();
+        }
     }
 }

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -1103,7 +1103,10 @@ namespace Dynamo.Configuration
             isTimeStampIncludedInExportFilePath = true;
             DefaultPythonEngine = string.Empty;
             ViewExtensionSettings = new List<ViewExtensionSettings>();
-            GroupStyleItemsList = GroupStyleItem.CloneDefaultGroupStyleItems();
+            // Keep this list empty in the constructor. XmlSerializer invokes this constructor
+            // during deserialization and populates collection properties incrementally.
+            // Seeding defaults here causes deleted defaults to be reintroduced on startup.
+            GroupStyleItemsList = new List<GroupStyleItem>();
             ReadNotificationIds = new List<string>();
             EnableDynamoPlayerRenamedWatchAsOutput = false;
             DynamoPlayerFolderGroups = new List<DynamoPlayerFolderGroup>();

--- a/src/DynamoCore/Configuration/PreferenceSettings.cs
+++ b/src/DynamoCore/Configuration/PreferenceSettings.cs
@@ -1103,7 +1103,7 @@ namespace Dynamo.Configuration
             isTimeStampIncludedInExportFilePath = true;
             DefaultPythonEngine = string.Empty;
             ViewExtensionSettings = new List<ViewExtensionSettings>();
-            GroupStyleItemsList = new List<GroupStyleItem>();
+            GroupStyleItemsList = GroupStyleItem.CloneDefaultGroupStyleItems();
             ReadNotificationIds = new List<string>();
             EnableDynamoPlayerRenamedWatchAsOutput = false;
             DynamoPlayerFolderGroups = new List<DynamoPlayerFolderGroup>();
@@ -1208,7 +1208,10 @@ namespace Dynamo.Configuration
                 }
             }
             settings.CustomPackageFolders = settings.CustomPackageFolders.Distinct().ToList();
-            settings.GroupStyleItemsList = settings.GroupStyleItemsList.GroupBy(entry => entry.Name).Select(result => result.First()).ToList();
+            settings.GroupStyleItemsList = (settings.GroupStyleItemsList ?? GroupStyleItem.CloneDefaultGroupStyleItems())
+                .GroupBy(entry => entry.Name)
+                .Select(result => result.First())
+                .ToList();
             MigrateStdLibTokenToBuiltInToken(settings);
 
             settings.DeserializeInternalPrefs(filePath);
@@ -1247,7 +1250,10 @@ namespace Dynamo.Configuration
             }
                 
             settings.CustomPackageFolders = settings.CustomPackageFolders.Distinct().ToList();
-            settings.GroupStyleItemsList = settings.GroupStyleItemsList.GroupBy(entry => entry.Name).Select(result => result.First()).ToList();
+            settings.GroupStyleItemsList = (settings.GroupStyleItemsList ?? GroupStyleItem.CloneDefaultGroupStyleItems())
+                .GroupBy(entry => entry.Name)
+                .Select(result => result.First())
+                .ToList();
             MigrateStdLibTokenToBuiltInToken(settings);
 
             settings.DeserializeInternalPrefsContent(content);

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -1208,8 +1208,11 @@ namespace Dynamo.Models
                 return PreferenceSettings.Load(xmlFilePath);
             }
 
-            // Otherwise make a default preference settings object.
-            return new PreferenceSettings();
+            // Otherwise make a default preference settings object. Seed default group styles
+            // only for brand-new settings (no previous session file).
+            var defaultSettings = new PreferenceSettings();
+            defaultSettings.GroupStyleItemsList = GroupStyleItem.CloneDefaultGroupStyleItems();
+            return defaultSettings;
         }
 
         private void SetDefaultPythonTemplate()

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -2601,7 +2601,7 @@ Do you wish to uninstall {1}? Restart {2} to complete the uninstall and try down
     <value>Reset Styles</value>
   </data>
   <data name="ResetStylesButtonToolTip" xml:space="preserve">
-    <value>Deletes all user-created (non-default) group styles. This does not affect styles in existing graphs and cannot be undone.</value>
+    <value>Restores the default group styles and removes user-created styles. This does not affect styles in existing graphs and cannot be undone.</value>
   </data>
   <data name="ResetPythonNet3ButtonText" xml:space="preserve">
     <value>Reset PythonNet3</value>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2908,7 +2908,7 @@ Do you wish to uninstall {1}? Restart {2} to complete the uninstall and try down
     <value>Reset Styles</value>
   </data>
   <data name="ResetStylesButtonToolTip" xml:space="preserve">
-    <value>Deletes all user-created (non-default) group styles. This does not affect styles in existing graphs and cannot be undone.</value>
+    <value>Restores the default group styles and removes user-created styles. This does not affect styles in existing graphs and cannot be undone.</value>
   </data>
   <data name="ResetPythonNet3ButtonText" xml:space="preserve">
     <value>Reset PythonNet3</value>

--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -1821,14 +1821,17 @@ namespace Dynamo.ViewModels
         {
             preferencesStyleItemsList = styleItemsList;
 
-            var defaultGroupStylesList = styleItemsList.Where(style => style.IsDefault == true);
-            var customGroupStylesList = styleItemsList.Where(style => style.IsDefault == false);
+            var defaultGroupStylesList = styleItemsList.Where(style => style.IsDefault == true).ToList();
+            var customGroupStylesList = styleItemsList.Where(style => style.IsDefault == false).ToList();
 
             //Adds to the list the Default Group Styles created by Dynamo
             groupStyleList.AddRange(defaultGroupStylesList);
 
-            //Adds the separator between the Default Group Styles and the Custom Group Styles
-            groupStyleList.Add(new GroupStyleSeparator());
+            // Adds the separator only when both default and custom groups are present.
+            if (defaultGroupStylesList.Any() && customGroupStylesList.Any())
+            {
+                groupStyleList.Add(new GroupStyleSeparator());
+            }
 
             //Adds to the list the Custom Group Styles created by the user
             groupStyleList.AddRange(customGroupStylesList);

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -624,7 +624,7 @@ namespace Dynamo.ViewModels
         /// </summary>
         public bool CanResetGroupStyles
         {
-            get { return preferenceSettings.GroupStyleItemsList.Any(style => !style.IsDefault); }
+            get { return !MatchesDefaultGroupStyles(preferenceSettings.GroupStyleItemsList); }
         }
 
         /// <summary>
@@ -1606,12 +1606,6 @@ namespace Dynamo.ViewModels
             //By Default the warning state of the Visual Settings tab (Group Styles section) will be disabled
             isWarningEnabled = false;
 
-            // Initialize group styles with default and custom GroupStyleItems.
-            var customStyles = preferenceSettings.GroupStyleItemsList.Where(style => style.IsDefault != true).ToList();
-            var newGroupStylesList = new List<GroupStyleItem>(GroupStyleItem.DefaultGroupStyleItems);
-            newGroupStylesList.AddRange(customStyles);
-            preferenceSettings.GroupStyleItemsList = newGroupStylesList;
-
             StyleItemsList = preferenceSettings.GroupStyleItemsList.ToObservableCollection();
 
             //When pressing the "Add Style" button some controls will be shown with some values by default so later they can be populated by the user
@@ -2008,20 +2002,39 @@ namespace Dynamo.ViewModels
         /// </summary>
         internal void ResetCustomGroupStyles()
         {
-            preferenceSettings.GroupStyleItemsList = GroupStyleItem.DefaultGroupStyleItems
-                .Select(defaultStyle => new GroupStyleItem
-                {
-                    Name = defaultStyle.Name,
-                    HexColorString = defaultStyle.HexColorString,
-                    FontSize = defaultStyle.FontSize,
-                    GroupStyleId = defaultStyle.GroupStyleId,
-                    IsDefault = true
-                })
-                .ToList();
+            preferenceSettings.GroupStyleItemsList = GroupStyleItem.CloneDefaultGroupStyleItems();
 
             RaisePropertyChanged(nameof(StyleItemsList));
             RaisePropertyChanged(nameof(CanResetGroupStyles));
             UpdateSavedChangesLabel();
+        }
+
+        private static bool MatchesDefaultGroupStyles(IEnumerable<GroupStyleItem> styles)
+        {
+            var stylesList = styles?.ToList() ?? new List<GroupStyleItem>();
+            if (stylesList.Count != GroupStyleItem.DefaultGroupStyleItems.Count)
+            {
+                return false;
+            }
+
+            foreach (var defaultStyle in GroupStyleItem.DefaultGroupStyleItems)
+            {
+                var currentStyle = stylesList.FirstOrDefault(style => style.GroupStyleId == defaultStyle.GroupStyleId);
+                if (currentStyle == null)
+                {
+                    return false;
+                }
+
+                if (!currentStyle.IsDefault ||
+                    !string.Equals(currentStyle.Name, defaultStyle.Name, StringComparison.Ordinal) ||
+                    !string.Equals(currentStyle.HexColorString, defaultStyle.HexColorString, StringComparison.OrdinalIgnoreCase) ||
+                    currentStyle.FontSize != defaultStyle.FontSize)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -2009,6 +2009,8 @@ namespace Dynamo.ViewModels
             UpdateSavedChangesLabel();
         }
 
+        // Returns true only when the current styles exactly match Dynamo's canonical default set.
+        // This drives Reset button visibility: any missing/extra/edited style keeps Reset available.
         private static bool MatchesDefaultGroupStyles(IEnumerable<GroupStyleItem> styles)
         {
             var stylesList = styles?.ToList() ?? new List<GroupStyleItem>();

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -250,5 +250,20 @@ namespace DynamoCoreWpfTests
             Assert.IsFalse(prefViewModel.CanResetGroupStyles);
             Assert.AreEqual(Visibility.Collapsed, preferencesWindow.ResetStylesButton.Visibility);
         }
+
+        [Test]
+        public void PreferencesViewModel_DoesNotRecreateDefaultStyles_WhenListIsEmpty()
+        {
+            Open(@"UI\GroupTest.dyn");
+
+            var dynamoViewModel = View.DataContext as DynamoViewModel;
+            Assert.IsNotNull(dynamoViewModel);
+            dynamoViewModel.PreferenceSettings.GroupStyleItemsList = new List<GroupStyleItem>();
+
+            var preferencesViewModel = new PreferencesViewModel(dynamoViewModel);
+
+            Assert.AreEqual(0, preferencesViewModel.StyleItemsList.Count);
+            Assert.IsTrue(preferencesViewModel.CanResetGroupStyles);
+        }
     }
 }

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -265,5 +265,37 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(0, preferencesViewModel.StyleItemsList.Count);
             Assert.IsTrue(preferencesViewModel.CanResetGroupStyles);
         }
+
+        [Test]
+        public void GroupStyleMenuSeparator_VisibleOnlyWithDefaultAndCustomStyles()
+        {
+            Open(@"UI\GroupTest.dyn");
+
+            var dynamoViewModel = View.DataContext as DynamoViewModel;
+            Assert.IsNotNull(dynamoViewModel);
+
+            var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
+            var annotationViewModel = annotationView.DataContext as AnnotationViewModel;
+            Assert.IsNotNull(annotationViewModel);
+
+            dynamoViewModel.PreferenceSettings.GroupStyleItemsList = GroupStyleItem.CloneDefaultGroupStyleItems();
+            annotationViewModel.ReloadGroupStyles();
+            DispatcherUtil.DoEvents();
+
+            Assert.AreEqual(0, annotationViewModel.GroupStyleList.OfType<GroupStyleSeparator>().Count());
+
+            dynamoViewModel.PreferenceSettings.GroupStyleItemsList.Add(new GroupStyleItem
+            {
+                Name = "Custom Style",
+                HexColorString = "FFFFFF",
+                FontSize = 36,
+                GroupStyleId = Guid.NewGuid(),
+                IsDefault = false
+            });
+            annotationViewModel.ReloadGroupStyles();
+            DispatcherUtil.DoEvents();
+
+            Assert.AreEqual(1, annotationViewModel.GroupStyleList.OfType<GroupStyleSeparator>().Count());
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

Fixes the startup behavior where default group styles are recreated after being deleted from Preferences.

Key changes:
- Removed automatic default-style reinsertion from `PreferencesViewModel` initialization.
- Updated `CanResetGroupStyles` so "Reset Styles" is visible whenever current styles differ from canonical defaults.
- Added a shared clone helper for default styles (`GroupStyleItem.CloneDefaultGroupStyleItems`) used by Reset logic.
- Added a regression test ensuring `PreferencesViewModel` does not recreate defaults when the list is empty.
- Prevented constructor reseeding during XML deserialization by keeping `PreferenceSettings.GroupStyleItemsList` empty in the constructor.
- Seeded default group styles only for true first-run settings creation (when no preference file exists) in `DynamoModel.CreateOrLoadPreferences`.
- Updated the "Reset Styles" tooltip text to reflect that it restores default group styles.
- Updated group style menu population so the separator is shown only when both default and custom styles are present.
- Added a regression test validating separator visibility rules in the group style menu.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Default group styles deleted by users are no longer recreated on startup; they are restored only when "Reset Styles" is used.

### Reviewers

(FILL ME IN) Reviewer 1

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aaf60041-6f35-42a8-8105-15be34eb7b2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aaf60041-6f35-42a8-8105-15be34eb7b2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

