### PR TITLE
DYN-8951: Add missing group style unit tests

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/AnnotationViewModel.cs
@@ -39,7 +39,6 @@ namespace Dynamo.ViewModels
         private const int portVerticalMidPoint = 17;
         private const int portToggleOffset = 30;
         private ObservableCollection<Dynamo.Configuration.StyleItem> groupStyleList;
-        private IEnumerable<Configuration.StyleItem> preferencesStyleItemsList;
         private PreferenceSettings preferenceSettings;
         private double heightBeforeToggle;
         private double widthBeforeToggle;
@@ -1828,7 +1827,10 @@ namespace Dynamo.ViewModels
         /// <returns></returns>
         private void LoadGroupStylesFromPreferences(IEnumerable<Configuration.StyleItem> styleItemsList)
         {
-            preferencesStyleItemsList = styleItemsList;
+            if (styleItemsList == null)
+            {
+                return;
+            }
 
             var defaultGroupStylesList = styleItemsList.Where(style => style.IsDefault == true);
             var customGroupStylesList = styleItemsList.Where(style => style.IsDefault == false);
@@ -1852,10 +1854,9 @@ namespace Dynamo.ViewModels
         /// </summary>
         internal void ReloadGroupStyles()
         {
-            if (preferencesStyleItemsList == null) return;
             groupStyleList.Clear();
 
-            LoadGroupStylesFromPreferences(preferencesStyleItemsList);
+            LoadGroupStylesFromPreferences(preferenceSettings.GroupStyleItemsList);
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Menu/PreferencesViewModel.cs
@@ -2010,10 +2010,13 @@ namespace Dynamo.ViewModels
         }
 
         /// <summary>
-        /// 
+        /// Determines whether the provided styles exactly match Dynamo's default group styles.
         /// </summary>
-        /// <param name="styles"></param>
-        /// <returns></returns>
+        /// <param name="styles">The styles to compare against the default styles.</param>
+        /// <returns>
+        /// <c>true</c> when the style collection has the same number of entries as the defaults and each default
+        /// style is present with matching id, name, color, font size, and default flag; otherwise, <c>false</c>.
+        /// </returns>
         private static bool MatchesDefaultGroupStyles(IEnumerable<GroupStyleItem> styles)
         {
             var stylesList = styles?.ToList() ?? new List<GroupStyleItem>();

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -251,6 +251,9 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(Visibility.Collapsed, preferencesWindow.ResetStylesButton.Visibility);
         }
 
+        /// <summary>
+        /// Validates that PreferencesViewModel does not recreate default styles when the list is empty
+        /// </summary>
         [Test]
         public void PreferencesViewModel_DoesNotRecreateDefaultStyles_WhenListIsEmpty()
         {
@@ -258,10 +261,13 @@ namespace DynamoCoreWpfTests
 
             var dynamoViewModel = View.DataContext as DynamoViewModel;
             Assert.IsNotNull(dynamoViewModel);
+            //Removes all the styles from preferences
             dynamoViewModel.PreferenceSettings.GroupStyleItemsList = new List<GroupStyleItem>();
 
+            //Creates the PreferencesViewModel
             var preferencesViewModel = new PreferencesViewModel(dynamoViewModel);
 
+            //Validates that no default style was recreated and reset is available
             Assert.AreEqual(0, preferencesViewModel.StyleItemsList.Count);
             Assert.IsTrue(preferencesViewModel.CanResetGroupStyles);
         }

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -266,19 +266,25 @@ namespace DynamoCoreWpfTests
             Assert.IsTrue(preferencesViewModel.CanResetGroupStyles);
         }
 
+        /// <summary>
+        /// Edits a default GroupStyle and validates that the Reset button restores all default values
+        /// </summary>
         [Test]
         public void ResetStylesButton_RestoresDefaults_WhenDefaultStyleIsEdited()
         {
             Open(@"UI\GroupTest.dyn");
 
+            //Creates the Preferences dialog
             var preferencesWindow = new PreferencesView(View);
             preferencesWindow.Show();
             DispatcherUtil.DoEvents();
 
             var prefViewModel = preferencesWindow.DataContext as PreferencesViewModel;
             Assert.IsNotNull(prefViewModel);
+            //By default the reset button should be disabled
             Assert.IsFalse(prefViewModel.CanResetGroupStyles);
 
+            //Copies the current styles and edits one default style
             var editedStyles = prefViewModel.StyleItemsList.Select(style => new GroupStyleItem
             {
                 Name = style.Name,
@@ -296,42 +302,57 @@ namespace DynamoCoreWpfTests
             prefViewModel.StyleItemsList = editedStyles.ToObservableCollection();
             DispatcherUtil.DoEvents();
 
+            //Check that reset is enabled after editing a default style
             Assert.IsTrue(prefViewModel.CanResetGroupStyles);
             Assert.AreEqual(Visibility.Visible, preferencesWindow.ResetStylesButton.Visibility);
 
+            //Clicks the reset button
             preferencesWindow.ResetStylesButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
             DispatcherUtil.DoEvents();
 
+            //Validates that all defaults are restored
             Assert.IsFalse(prefViewModel.CanResetGroupStyles);
             AssertGroupStylesMatchDefaults(prefViewModel.StyleItemsList);
         }
 
+        /// <summary>
+        /// Removes a default GroupStyle and validates that the Reset button restores the missing style
+        /// </summary>
         [Test]
         public void ResetStylesButton_RestoresDefaults_WhenDefaultStyleIsDeleted()
         {
             Open(@"UI\GroupTest.dyn");
 
+            //Creates the Preferences dialog
             var preferencesWindow = new PreferencesView(View);
             preferencesWindow.Show();
             DispatcherUtil.DoEvents();
 
             var prefViewModel = preferencesWindow.DataContext as PreferencesViewModel;
             Assert.IsNotNull(prefViewModel);
+            //By default the reset button should be disabled
             Assert.IsFalse(prefViewModel.CanResetGroupStyles);
 
+            //Removes one default style from the list
             prefViewModel.StyleItemsList = prefViewModel.StyleItemsList.Skip(1).ToObservableCollection();
             DispatcherUtil.DoEvents();
 
+            //Check that reset is enabled after deleting a default style
             Assert.IsTrue(prefViewModel.CanResetGroupStyles);
             Assert.AreEqual(Visibility.Visible, preferencesWindow.ResetStylesButton.Visibility);
 
+            //Clicks the reset button
             preferencesWindow.ResetStylesButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
             DispatcherUtil.DoEvents();
 
+            //Validates that all defaults are restored
             Assert.IsFalse(prefViewModel.CanResetGroupStyles);
             AssertGroupStylesMatchDefaults(prefViewModel.StyleItemsList);
         }
 
+        /// <summary>
+        /// Validates that the Group Style submenu is disabled when there are no styles in preferences
+        /// </summary>
         [Test]
         public void GroupStyleSubmenu_IsDisabledAndDoesNotOpen_WhenNoStylesExist()
         {
@@ -339,6 +360,7 @@ namespace DynamoCoreWpfTests
 
             var dynamoViewModel = View.DataContext as DynamoViewModel;
             Assert.IsNotNull(dynamoViewModel);
+            //Removes all the styles from preferences
             dynamoViewModel.PreferenceSettings.GroupStyleItemsList = new List<GroupStyleItem>();
 
             var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
@@ -362,6 +384,7 @@ namespace DynamoCoreWpfTests
             Assert.IsNotNull(submenuLabel, "Could not find submenu label.");
             Assert.AreEqual(0.5, submenuLabel.Opacity, 0.001, "Disabled submenu should be visually dimmed.");
 
+            //Trigger MouseEnter to verify the submenu does not open when disabled
             border.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0)
             {
                 RoutedEvent = Mouse.MouseEnterEvent

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -400,6 +400,90 @@ namespace DynamoCoreWpfTests
             Assert.IsFalse(popup.IsOpen, "Disabled Group Style submenu should not open on hover.");
         }
 
+        /// <summary>
+        /// Validates that restoring default styles repopulates the Group Style submenu in the graph context menu
+        /// </summary>
+        [Test]
+        public void GroupStyleSubmenu_LoadsRestoredDefaults_AfterResetFromEmptyStyles()
+        {
+            Open(@"UI\GroupTest.dyn");
+
+            var dynamoViewModel = View.DataContext as DynamoViewModel;
+            Assert.IsNotNull(dynamoViewModel);
+            //Removes all the styles from preferences
+            dynamoViewModel.PreferenceSettings.GroupStyleItemsList = new List<GroupStyleItem>();
+
+            var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
+
+            //Creates the context menu and validates that Group Style submenu is disabled when there are no styles
+            annotationView.CreateAndAttachAnnotationPopup();
+            annotationView.GroupContextMenuPopup.IsOpen = true;
+            DispatcherUtil.DoEvents();
+
+            var emptyStylesSubmenu = annotationView.GroupStyleSelectorGrid as Grid;
+            Assert.IsNotNull(emptyStylesSubmenu, "Styles sub-menu grid not found.");
+            var emptyBorder = emptyStylesSubmenu.Children.OfType<Border>().FirstOrDefault();
+            var emptyPopup = emptyStylesSubmenu.Children.OfType<Popup>().FirstOrDefault();
+            Assert.IsNotNull(emptyBorder, "Sub-menu border not found.");
+            Assert.IsNotNull(emptyPopup, "Sub-menu popup not found.");
+
+            emptyBorder.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0)
+            {
+                RoutedEvent = Mouse.MouseEnterEvent
+            });
+            DispatcherUtil.DoEvents();
+            Assert.IsFalse(emptyPopup.IsOpen, "Disabled Group Style submenu should not open on hover.");
+
+            //Opens Preferences and restores the default styles
+            var preferencesWindow = new PreferencesView(View);
+            preferencesWindow.Show();
+            DispatcherUtil.DoEvents();
+            preferencesWindow.ResetStylesButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+            DispatcherUtil.DoEvents();
+
+            var prefViewModel = preferencesWindow.DataContext as PreferencesViewModel;
+            Assert.IsNotNull(prefViewModel);
+            Assert.AreEqual(GroupStyleItem.DefaultGroupStyleItems.Count, prefViewModel.StyleItemsList.Count);
+
+            //Close the Preferences Dialog
+            preferencesWindow.CloseButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+            DispatcherUtil.DoEvents();
+
+            //Recreates and opens the context menu to validate that Group Style submenu contains restored defaults
+            annotationView.CreateAndAttachAnnotationPopup();
+            annotationView.GroupContextMenuPopup.IsOpen = true;
+            DispatcherUtil.DoEvents();
+
+            var stylesSubmenu = annotationView.GroupStyleSelectorGrid as Grid;
+            Assert.IsNotNull(stylesSubmenu, "Styles sub-menu grid not found.");
+
+            var border = stylesSubmenu.Children.OfType<Border>().FirstOrDefault();
+            var popup = stylesSubmenu.Children.OfType<Popup>().FirstOrDefault();
+            Assert.IsNotNull(border, "Sub-menu border not found.");
+            Assert.IsNotNull(popup, "Sub-menu popup not found.");
+
+            border.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0)
+            {
+                RoutedEvent = Mouse.MouseEnterEvent
+            });
+            DispatcherUtil.DoEvents();
+
+            Assert.IsTrue(popup.IsOpen, "Group Style submenu did not open after restoring defaults.");
+            Assert.IsInstanceOf<Border>(popup.Child, "Popup content is not a Border.");
+
+            var wrapper = popup.Child as Border;
+            var stackPanel = wrapper.Child as StackPanel;
+            Assert.IsNotNull(stackPanel, "Could not find StackPanel inside popup.");
+
+            var restoredStylesCount = stackPanel.Children
+                .OfType<Border>()
+                .Select(b => b.Child)
+                .OfType<StackPanel>()
+                .Count();
+
+            Assert.AreEqual(GroupStyleItem.DefaultGroupStyleItems.Count, restoredStylesCount);
+        }
+
         private static void AssertGroupStylesMatchDefaults(IEnumerable<GroupStyleItem> actualStyles)
         {
             var actualList = actualStyles.ToList();

--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -265,5 +265,128 @@ namespace DynamoCoreWpfTests
             Assert.AreEqual(0, preferencesViewModel.StyleItemsList.Count);
             Assert.IsTrue(preferencesViewModel.CanResetGroupStyles);
         }
+
+        [Test]
+        public void ResetStylesButton_RestoresDefaults_WhenDefaultStyleIsEdited()
+        {
+            Open(@"UI\GroupTest.dyn");
+
+            var preferencesWindow = new PreferencesView(View);
+            preferencesWindow.Show();
+            DispatcherUtil.DoEvents();
+
+            var prefViewModel = preferencesWindow.DataContext as PreferencesViewModel;
+            Assert.IsNotNull(prefViewModel);
+            Assert.IsFalse(prefViewModel.CanResetGroupStyles);
+
+            var editedStyles = prefViewModel.StyleItemsList.Select(style => new GroupStyleItem
+            {
+                Name = style.Name,
+                HexColorString = style.HexColorString,
+                FontSize = style.FontSize,
+                GroupStyleId = style.GroupStyleId,
+                IsDefault = style.IsDefault
+            }).ToList();
+
+            var editedDefaultStyle = editedStyles.First(style => style.IsDefault);
+            editedDefaultStyle.Name = "Edited Default Style";
+            editedDefaultStyle.HexColorString = "ABCDEF";
+            editedDefaultStyle.FontSize = 14;
+
+            prefViewModel.StyleItemsList = editedStyles.ToObservableCollection();
+            DispatcherUtil.DoEvents();
+
+            Assert.IsTrue(prefViewModel.CanResetGroupStyles);
+            Assert.AreEqual(Visibility.Visible, preferencesWindow.ResetStylesButton.Visibility);
+
+            preferencesWindow.ResetStylesButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+            DispatcherUtil.DoEvents();
+
+            Assert.IsFalse(prefViewModel.CanResetGroupStyles);
+            AssertGroupStylesMatchDefaults(prefViewModel.StyleItemsList);
+        }
+
+        [Test]
+        public void ResetStylesButton_RestoresDefaults_WhenDefaultStyleIsDeleted()
+        {
+            Open(@"UI\GroupTest.dyn");
+
+            var preferencesWindow = new PreferencesView(View);
+            preferencesWindow.Show();
+            DispatcherUtil.DoEvents();
+
+            var prefViewModel = preferencesWindow.DataContext as PreferencesViewModel;
+            Assert.IsNotNull(prefViewModel);
+            Assert.IsFalse(prefViewModel.CanResetGroupStyles);
+
+            prefViewModel.StyleItemsList = prefViewModel.StyleItemsList.Skip(1).ToObservableCollection();
+            DispatcherUtil.DoEvents();
+
+            Assert.IsTrue(prefViewModel.CanResetGroupStyles);
+            Assert.AreEqual(Visibility.Visible, preferencesWindow.ResetStylesButton.Visibility);
+
+            preferencesWindow.ResetStylesButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+            DispatcherUtil.DoEvents();
+
+            Assert.IsFalse(prefViewModel.CanResetGroupStyles);
+            AssertGroupStylesMatchDefaults(prefViewModel.StyleItemsList);
+        }
+
+        [Test]
+        public void GroupStyleSubmenu_IsDisabledAndDoesNotOpen_WhenNoStylesExist()
+        {
+            Open(@"UI\GroupTest.dyn");
+
+            var dynamoViewModel = View.DataContext as DynamoViewModel;
+            Assert.IsNotNull(dynamoViewModel);
+            dynamoViewModel.PreferenceSettings.GroupStyleItemsList = new List<GroupStyleItem>();
+
+            var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
+
+            // Manually create and open the group context menu (normally triggered by right-click)
+            annotationView.CreateAndAttachAnnotationPopup();
+            annotationView.GroupContextMenuPopup.IsOpen = true;
+            DispatcherUtil.DoEvents();
+
+            var stylesSubmenu = annotationView.GroupStyleSelectorGrid as Grid;
+            Assert.IsNotNull(stylesSubmenu, "Styles sub-menu grid not found.");
+
+            var border = stylesSubmenu.Children.OfType<Border>().FirstOrDefault();
+            var popup = stylesSubmenu.Children.OfType<Popup>().FirstOrDefault();
+            Assert.IsNotNull(border, "Sub-menu border not found.");
+            Assert.IsNotNull(popup, "Sub-menu popup not found.");
+
+            var layoutGrid = border.Child as Grid;
+            Assert.IsNotNull(layoutGrid, "Could not find submenu layout grid.");
+            var submenuLabel = layoutGrid.Children.OfType<TextBlock>().FirstOrDefault();
+            Assert.IsNotNull(submenuLabel, "Could not find submenu label.");
+            Assert.AreEqual(0.5, submenuLabel.Opacity, 0.001, "Disabled submenu should be visually dimmed.");
+
+            border.RaiseEvent(new MouseEventArgs(Mouse.PrimaryDevice, 0)
+            {
+                RoutedEvent = Mouse.MouseEnterEvent
+            });
+            DispatcherUtil.DoEvents();
+
+            Assert.IsFalse(popup.IsOpen, "Disabled Group Style submenu should not open on hover.");
+        }
+
+        private static void AssertGroupStylesMatchDefaults(IEnumerable<GroupStyleItem> actualStyles)
+        {
+            var actualList = actualStyles.ToList();
+            var defaultList = GroupStyleItem.DefaultGroupStyleItems.ToList();
+
+            Assert.AreEqual(defaultList.Count, actualList.Count);
+
+            foreach (var defaultStyle in defaultList)
+            {
+                var currentStyle = actualList.FirstOrDefault(style => style.GroupStyleId == defaultStyle.GroupStyleId);
+                Assert.IsNotNull(currentStyle, $"Missing default style with id {defaultStyle.GroupStyleId}.");
+                Assert.IsTrue(currentStyle.IsDefault);
+                Assert.AreEqual(defaultStyle.Name, currentStyle.Name);
+                Assert.AreEqual(defaultStyle.FontSize, currentStyle.FontSize);
+                Assert.IsTrue(string.Equals(defaultStyle.HexColorString, currentStyle.HexColorString, StringComparison.OrdinalIgnoreCase));
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

Implements and validates **DYN-8951** so users can customize OOTB node group styles (Actions, Inputs, Outputs, Review), instead of being limited to adding custom styles.

Key changes since `16f149cf78`:
- Preferences UI updates for Group Styles:
  - Default styles are now editable/removable.
  - Added a **Reset Styles** button with tooltip and visibility bound to reset availability.
- Group style state/restore logic:
  - Added `CanResetGroupStyles` and `ResetCustomGroupStyles` in `PreferencesViewModel`.
  - Added `GroupStyleItem.CloneDefaultGroupStyleItems()` to restore clean defaults.
  - `PreferencesViewModel` no longer recreates default styles when the list is empty.
  - `DynamoModel` creates default styles only for brand-new settings.
  - `PreferenceSettings.Load/LoadContent` now handles null group-style lists safely.
  - Added XML documentation for `MatchesDefaultGroupStyles`.
- Context menu behavior improvements:
  - Group Style submenu is disabled when no group styles exist.
  - Separator is only shown when both default and custom styles are present.
  - Fixed reloading logic so restored styles are read from current preferences (prevents empty submenu after restoring defaults).
- Resources/API updates:
  - Added localized strings for reset button/tooltip and related API surface updates.
- Unit tests:
  - Added/updated `GroupStylesTests` to cover reset behavior, empty-list behavior, and disabled submenu behavior.
  - Added regression coverage for restoring defaults after an empty style list and validating submenu repopulation.
  - Added comments/annotations to new tests for consistency with the existing test style.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Users can now edit and remove default node group styles, and reset all group styles back to defaults from Preferences.

### Reviewers

(FILL ME IN) Reviewer 1

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bcf7c3a-2595-43e2-ab7c-8b23ac85ab4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bcf7c3a-2595-43e2-ab7c-8b23ac85ab4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

