### PR TITLE
Stabilize GroupStyle submenu reset UI test

### DIFF
--- a/test/DynamoCoreWpfTests/GroupStylesTests.cs
+++ b/test/DynamoCoreWpfTests/GroupStylesTests.cs
@@ -378,6 +378,21 @@ namespace DynamoCoreWpfTests
         {
             Open(@"UI\GroupTest.dyn");
 
+            void OpenGroupContextMenu(AnnotationView groupAnnotationView)
+            {
+                groupAnnotationView.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Right)
+                {
+                    RoutedEvent = UIElement.MouseRightButtonDownEvent
+                });
+                groupAnnotationView.RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Right)
+                {
+                    RoutedEvent = UIElement.MouseRightButtonUpEvent
+                });
+                DispatcherUtil.DoEvents();
+                Assert.IsNotNull(groupAnnotationView.GroupContextMenuPopup, "Group context menu popup was not created.");
+                Assert.IsTrue(groupAnnotationView.GroupContextMenuPopup.IsOpen, "Group context menu popup did not open.");
+            }
+
             var dynamoViewModel = View.DataContext as DynamoViewModel;
             Assert.IsNotNull(dynamoViewModel);
             //Remove all the styles from preferences
@@ -386,9 +401,7 @@ namespace DynamoCoreWpfTests
             var annotationView = NodeViewWithGuid("a432d63f-7a36-45ad-b30a-7924beb20e90");
 
             //Create the context menu and validates that Group Style submenu is disabled when there are no styles
-            annotationView.CreateAndAttachAnnotationPopup();
-            annotationView.GroupContextMenuPopup.IsOpen = true;
-            DispatcherUtil.DoEvents();
+            OpenGroupContextMenu(annotationView);
 
             var emptyStylesSubmenu = annotationView.GroupStyleSelectorGrid as Grid;
             Assert.IsNotNull(emptyStylesSubmenu, "Styles sub-menu grid not found.");
@@ -420,9 +433,7 @@ namespace DynamoCoreWpfTests
             DispatcherUtil.DoEvents();
 
             //Recreate and open the context menu to validate that Group Style submenu contains restored defaults
-            annotationView.CreateAndAttachAnnotationPopup();
-            annotationView.GroupContextMenuPopup.IsOpen = true;
-            DispatcherUtil.DoEvents();
+            OpenGroupContextMenu(annotationView);
 
             var stylesSubmenu = annotationView.GroupStyleSelectorGrid as Grid;
             Assert.IsNotNull(stylesSubmenu, "Styles sub-menu grid not found.");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

Stabilize `GroupStyleSubmenu_LoadsRestoredDefaults_AfterResetFromEmptyStyles` by opening the group context menu through the real right-click event flow so menu content is rebuilt between assertions.

The failure was caused by test setup reusing a previously created popup/menu instance that had been created when styles were empty (disabled), so the stale submenu state could persist and `popup.IsOpen` would remain false after restoring defaults.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

Adjusted only a UI test to use deterministic context-menu opening behavior (no product code changes).

### FYIs

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36ddfe56-9be4-48b1-a231-646adc2cdcd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36ddfe56-9be4-48b1-a231-646adc2cdcd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

