### PR TITLE
Suppress CBN function body warnings during precompile

### DIFF
--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -908,15 +908,37 @@ namespace Dynamo.Graph.Nodes
             // only needs these nodes to register the function signature.
             return ParseParam.ParsedNodes
                 .OfType<FunctionDefinitionNode>()
-                .Any(functionDefinition => IsWarningWithinNodeRange(warning, functionDefinition));
+                .Any(functionDefinition => FunctionBodyContainsWarningCall(functionDefinition.FunctionBody, warning));
         }
 
-        private static bool IsWarningWithinNodeRange(WarningEntry warning, Node node)
+        private static bool FunctionBodyContainsWarningCall(Node node, WarningEntry warning)
         {
-            if (warning.Line < 0 || node == null)
+            if (node == null)
                 return false;
 
-            return warning.Line >= node.line && warning.Line <= node.endLine;
+            var functionCall = node as FunctionCallNode;
+            if (functionCall != null && IsWarningForFunctionCall(functionCall, warning))
+                return true;
+
+            return node.Children().Any(child => FunctionBodyContainsWarningCall(child, warning));
+        }
+
+        private static bool IsWarningForFunctionCall(FunctionCallNode functionCall, WarningEntry warning)
+        {
+            var functionName = GetFunctionCallName(functionCall);
+            var sameLocation =
+                (warning.Line < 0 || functionCall.line < 0 || warning.Line == functionCall.line)
+                    && (warning.Column < 0 || functionCall.col < 0 || warning.Column == functionCall.col);
+            var sameFunction = string.IsNullOrEmpty(functionName)
+                || warning.Message.IndexOf(functionName, StringComparison.Ordinal) >= 0;
+
+            return sameLocation && sameFunction;
+        }
+
+        private static string GetFunctionCallName(FunctionCallNode functionCall)
+        {
+            var identifier = functionCall.Function as IdentifierNode;
+            return identifier?.Name ?? functionCall.Function?.Name ?? functionCall.Function?.ToString();
         }
 
         private void SetPreviewVariable(IEnumerable<Node> parsedNodes)

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -749,11 +749,7 @@ namespace Dynamo.Graph.Nodes
                 // To check function redefinition, we need to check other
                 // CBN to find out if it has been defined yet. Now just
                 // skip this warning.
-                var warnings =
-                    ParseParam.Warnings.Where(
-                        w =>
-                            w.ID != WarningID.IdUnboundIdentifier
-                                && w.ID != WarningID.FunctionAlreadyDefined);
+                var warnings = GetReportableWarnings(ParseParam.Warnings);
 
                 if (warnings.Any())
                 {
@@ -842,11 +838,7 @@ namespace Dynamo.Graph.Nodes
                     // To check function redefinition, we need to check other
                     // CBN to find out if it has been defined yet. Now just
                     // skip this warning.
-                    var warnings =
-                        ParseParam.Warnings.Where(
-                            w =>
-                                w.ID != WarningID.IdUnboundIdentifier
-                                    && w.ID != WarningID.FunctionAlreadyDefined);
+                    var warnings = GetReportableWarnings(ParseParam.Warnings);
 
                     if (warnings.Any())
                     {
@@ -897,6 +889,34 @@ namespace Dynamo.Graph.Nodes
         private static bool IsTempIdentifier(string name)
         {
             return name.StartsWith(Constants.kTempVarForNonAssignment);
+        }
+
+        private IEnumerable<WarningEntry> GetReportableWarnings(IEnumerable<WarningEntry> warnings)
+        {
+            return warnings.Where(w =>
+                w.ID != WarningID.IdUnboundIdentifier
+                    && w.ID != WarningID.FunctionAlreadyDefined
+                    && !IsFunctionDefinitionBodyWarning(w));
+        }
+
+        private bool IsFunctionDefinitionBodyWarning(WarningEntry warning)
+        {
+            if (warning.ID != WarningID.FunctionNotFound || ParseParam?.ParsedNodes == null)
+                return false;
+
+            // Function bodies are compiled again when the function is invoked; CBN precompile
+            // only needs these nodes to register the function signature.
+            return ParseParam.ParsedNodes
+                .OfType<FunctionDefinitionNode>()
+                .Any(functionDefinition => IsWarningWithinNodeRange(warning, functionDefinition));
+        }
+
+        private static bool IsWarningWithinNodeRange(WarningEntry warning, Node node)
+        {
+            if (warning.Line < 0 || node == null)
+                return false;
+
+            return warning.Line >= node.line && warning.Line <= node.endLine;
         }
 
         private void SetPreviewVariable(IEnumerable<Node> parsedNodes)

--- a/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
+++ b/src/DynamoCore/Graph/Nodes/CodeBlockNode.cs
@@ -749,7 +749,11 @@ namespace Dynamo.Graph.Nodes
                 // To check function redefinition, we need to check other
                 // CBN to find out if it has been defined yet. Now just
                 // skip this warning.
-                var warnings = GetReportableWarnings(ParseParam.Warnings);
+                var warnings =
+                    ParseParam.Warnings.Where(
+                        w =>
+                            w.ID != WarningID.IdUnboundIdentifier
+                                && w.ID != WarningID.FunctionAlreadyDefined);
 
                 if (warnings.Any())
                 {
@@ -838,7 +842,11 @@ namespace Dynamo.Graph.Nodes
                     // To check function redefinition, we need to check other
                     // CBN to find out if it has been defined yet. Now just
                     // skip this warning.
-                    var warnings = GetReportableWarnings(ParseParam.Warnings);
+                    var warnings =
+                        ParseParam.Warnings.Where(
+                            w =>
+                                w.ID != WarningID.IdUnboundIdentifier
+                                    && w.ID != WarningID.FunctionAlreadyDefined);
 
                     if (warnings.Any())
                     {
@@ -889,56 +897,6 @@ namespace Dynamo.Graph.Nodes
         private static bool IsTempIdentifier(string name)
         {
             return name.StartsWith(Constants.kTempVarForNonAssignment);
-        }
-
-        private IEnumerable<WarningEntry> GetReportableWarnings(IEnumerable<WarningEntry> warnings)
-        {
-            return warnings.Where(w =>
-                w.ID != WarningID.IdUnboundIdentifier
-                    && w.ID != WarningID.FunctionAlreadyDefined
-                    && !IsFunctionDefinitionBodyWarning(w));
-        }
-
-        private bool IsFunctionDefinitionBodyWarning(WarningEntry warning)
-        {
-            if (warning.ID != WarningID.FunctionNotFound || ParseParam?.ParsedNodes == null)
-                return false;
-
-            // Function bodies are compiled again when the function is invoked; CBN precompile
-            // only needs these nodes to register the function signature.
-            return ParseParam.ParsedNodes
-                .OfType<FunctionDefinitionNode>()
-                .Any(functionDefinition => FunctionBodyContainsWarningCall(functionDefinition.FunctionBody, warning));
-        }
-
-        private static bool FunctionBodyContainsWarningCall(Node node, WarningEntry warning)
-        {
-            if (node == null)
-                return false;
-
-            var functionCall = node as FunctionCallNode;
-            if (functionCall != null && IsWarningForFunctionCall(functionCall, warning))
-                return true;
-
-            return node.Children().Any(child => FunctionBodyContainsWarningCall(child, warning));
-        }
-
-        private static bool IsWarningForFunctionCall(FunctionCallNode functionCall, WarningEntry warning)
-        {
-            var functionName = GetFunctionCallName(functionCall);
-            var sameLocation =
-                (warning.Line < 0 || functionCall.line < 0 || warning.Line == functionCall.line)
-                    && (warning.Column < 0 || functionCall.col < 0 || warning.Column == functionCall.col);
-            var sameFunction = string.IsNullOrEmpty(functionName)
-                || warning.Message.IndexOf(functionName, StringComparison.Ordinal) >= 0;
-
-            return sameLocation && sameFunction;
-        }
-
-        private static string GetFunctionCallName(FunctionCallNode functionCall)
-        {
-            var identifier = functionCall.Function as IdentifierNode;
-            return identifier?.Name ?? functionCall.Function?.Name ?? functionCall.Function?.ToString();
         }
 
         private void SetPreviewVariable(IEnumerable<Node> parsedNodes)

--- a/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
+++ b/src/Engine/ProtoCore/Lang/BuiltInMethods.cs
@@ -787,6 +787,17 @@ namespace ProtoCore.Lang
                 new BuiltInMethod
                 {
                     ReturnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.String, 0),
+                    Parameters = new List<KeyValuePair<string, ProtoCore.Type>>
+                    {
+                        new KeyValuePair<string, ProtoCore.Type>("object", TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.Var, 0)),
+                    },
+                    ID = BuiltInMethods.MethodID.ToString,
+                    MethodAttributes = new MethodAttributes(true, false, "This node is obsolete, please use \"String from Object\""),
+                },
+
+                new BuiltInMethod
+                {
+                    ReturnType = TypeSystem.BuildPrimitiveTypeObject(PrimitiveType.String, 0),
 
                     Parameters = new [] 
                     {

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -502,6 +502,24 @@ b = c[w][x][y][z];";
 
         [Test]
         [Category("UnitTests")]
+        public void FunctionDefinitionCBN_DoesNotReportFunctionBodyWarnings()
+        {
+            var cbn = CreateCodeBlockNode();
+
+            (CurrentDynamoModel.CurrentWorkspace as HomeWorkspaceModel).RunSettings =
+                new RunSettings(RunType.Manual, RunSettings.DefaultRunPeriod);
+            UpdateCodeBlockNodeContent(cbn,
+                "def tostr(pt:Point)" +
+                "{" +
+                    "return = ToString(pt.X) \",\" ToString(pt.Y) \",\" ToString(pt.Z);" +
+                "};");
+
+            Assert.AreEqual(ElementState.Active, cbn.State);
+            Assert.AreEqual(0, cbn.Infos.Count);
+        }
+
+        [Test]
+        [Category("UnitTests")]
         public void TestOutputPortUpdateWithFunctionDef()
         {
             var cbn = CreateCodeBlockNode();

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -516,6 +516,16 @@ b = c[w][x][y][z];";
 
             Assert.AreEqual(ElementState.Active, cbn.State);
             Assert.AreEqual(0, cbn.Infos.Count);
+
+            UpdateCodeBlockNodeContent(cbn,
+                "def tostr()" +
+                "{" +
+                    "return = ToString(1.2) \",\" ToString(3.4) \",\" ToString(5.6);" +
+                "};" +
+                "result = tostr();");
+
+            Assert.AreEqual(ElementState.Active, cbn.State);
+            Assert.AreEqual(0, cbn.Infos.Count);
         }
 
         [Test]

--- a/test/DynamoCoreTests/CodeBlockNodeTests.cs
+++ b/test/DynamoCoreTests/CodeBlockNodeTests.cs
@@ -502,7 +502,7 @@ b = c[w][x][y][z];";
 
         [Test]
         [Category("UnitTests")]
-        public void FunctionDefinitionCBN_DoesNotReportFunctionBodyWarnings()
+        public void FunctionDefinitionCBN_ResolvesScalarToStringInFunctionBody()
         {
             var cbn = CreateCodeBlockNode();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

Fixes a regression where a code block node function body could show `Method 'ToString()' not found` for scalar calls such as `ToString(pt.X)` or `ToString(1.2)` during CBN precompile.

The root cause is that the legacy `ToString` builtin was registered with an arbitrary-rank `var` parameter, matching the old node form (`ToString@var[]..[]`) but not scalar calls during compile-time endpoint lookup. This PR adds a scalar `ToString(var)` builtin overload while keeping the existing arbitrary-rank overload for compatibility. `BuiltInFunctionEndPoint` already dispatches `MethodID.ToString`, so no endpoint switch change is needed.

Top-level unresolved calls remain reportable; this avoids suppressing CBN warnings and fixes the builtin signature resolution instead.

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.

### Release Notes

Legacy `ToString` now resolves scalar arguments in code block node function bodies.

### Reviewers

Dynamo team

### FYIs

Testing note: `git diff --check` passes. Targeted `dotnet test test/DynamoCoreTests/DynamoCoreTests.csproj --filter "FullyQualifiedName~CodeBlockNodeTests.FunctionDefinitionCBN_ResolvesScalarToStringInFunctionBody|FullyQualifiedName~CodeBlockNodeTests.FunctionCallCBN_NoFunctionDef_Warning"` could not be run in this Cloud image because no .NET/MSBuild tooling is installed on PATH.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a1b801e-2b0a-4ee7-b3b1-4e54af8a65d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a1b801e-2b0a-4ee7-b3b1-4e54af8a65d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

