### PR TITLE
DYN-7587 Add package conflict No regression test

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1164,6 +1164,8 @@ namespace Dynamo.ViewModels
                 return;
             }
 
+            DynamoViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.RemoveAll(x => x.Equals(dynPkg.RootDirectory));
+
             if (!shouldLoadPackage)
             {
                 // The package will load after restart when the conflicting package is removed.

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1145,8 +1145,13 @@ namespace Dynamo.ViewModels
         {
             Package dynPkg;
             var packageLoader = PackageManagerExtension.PackageLoader;
+            var shouldLoadPackage = true;
 
-            var extractionState = packageDownloadHandle.Extract(DynamoViewModel.Model, downloadPath, ShouldFinalizePackageInstall, out dynPkg);
+            var extractionState = packageDownloadHandle.Extract(
+                DynamoViewModel.Model,
+                downloadPath,
+                package => ShouldFinalizePackageInstall(package, out shouldLoadPackage),
+                out dynPkg);
             if (extractionState == PackageDownloadHandle.ExtractionState.InvalidPackage)
             {
                 packageDownloadHandle.Error(Resources.MessageInvalidPackage);
@@ -1156,6 +1161,13 @@ namespace Dynamo.ViewModels
             if (extractionState == PackageDownloadHandle.ExtractionState.Cancelled)
             {
                 packageDownloadHandle.Error(Resources.CannotDownloadPackageMessageBoxTitle);
+                return;
+            }
+
+            if (!shouldLoadPackage)
+            {
+                // The package will load after restart when the conflicting package is removed.
+                packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
                 return;
             }
 
@@ -1170,16 +1182,23 @@ namespace Dynamo.ViewModels
             packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
         }
 
-        private bool ShouldFinalizePackageInstall(Package package)
+        private bool ShouldFinalizePackageInstall(Package package, out bool shouldLoadPackage)
         {
+            shouldLoadPackage = true;
+
             var conflictingPackage = FindConflictingCustomNodePackage(package);
             if (conflictingPackage == null)
             {
                 return true;
             }
 
-            ConfirmConflictingCustomNodePackageUninstall(conflictingPackage, package);
-            return false;
+            if (!ConfirmConflictingCustomNodePackageUninstall(conflictingPackage, package))
+            {
+                return false;
+            }
+
+            shouldLoadPackage = false;
+            return true;
         }
 
         private Package FindConflictingCustomNodePackage(Package package)

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1164,10 +1164,9 @@ namespace Dynamo.ViewModels
                 return;
             }
 
-            DynamoViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.RemoveAll(x => x.Equals(dynPkg.RootDirectory));
-
             if (!shouldLoadPackage)
             {
+                ClearPackageUninstallMarker(dynPkg);
                 // The package will load after restart when the conflicting package is removed.
                 packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
                 return;
@@ -1181,7 +1180,18 @@ namespace Dynamo.ViewModels
                 return;
             }
 
+            ClearPackageUninstallMarker(dynPkg);
             packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
+        }
+
+        private void ClearPackageUninstallMarker(Package package)
+        {
+            if (package == null)
+            {
+                return;
+            }
+
+            DynamoViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.RemoveAll(x => x.Equals(package.RootDirectory));
         }
 
         private bool ShouldFinalizePackageInstall(Package package, out bool shouldLoadPackage)
@@ -1252,33 +1262,30 @@ namespace Dynamo.ViewModels
             return true;
         }
 
-        private static void CleanupFailedPackageInstall(Package package, PackageLoader packageLoader)
+        private void CleanupFailedPackageInstall(Package package, PackageLoader packageLoader)
         {
             if (package == null)
             {
                 return;
             }
 
-            packageLoader.Remove(package);
-            TryDeletePackageDirectory(package.RootDirectory);
-        }
+            var packageDirectory = package.RootDirectory;
+            packageLoader?.Remove(package);
 
-        private static void TryDeletePackageDirectory(string directory)
-        {
             try
             {
-                if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
+                if (!string.IsNullOrEmpty(packageDirectory) && Directory.Exists(packageDirectory))
                 {
-                    Directory.Delete(directory, true);
+                    Directory.Delete(packageDirectory, true);
                 }
             }
             catch (IOException ex)
             {
-                DynamoConsoleLogger.OnLogMessageToDynamoConsole($"Failed to delete package directory {directory}: {ex}");
+                DynamoViewModel.Model.Logger.Log($"Failed to delete package directory {packageDirectory}: {ex}");
             }
             catch (UnauthorizedAccessException ex)
             {
-                DynamoConsoleLogger.OnLogMessageToDynamoConsole($"Failed to delete package directory {directory}: {ex}");
+                DynamoViewModel.Model.Logger.Log($"Failed to delete package directory {packageDirectory}: {ex}");
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1144,15 +1144,120 @@ namespace Dynamo.ViewModels
         internal void SetPackageState(PackageDownloadHandle packageDownloadHandle, string downloadPath)
         {
             Package dynPkg;
-            if (packageDownloadHandle.Extract(DynamoViewModel.Model, downloadPath, out dynPkg))
+            var packageLoader = PackageManagerExtension.PackageLoader;
+
+            var extractionState = packageDownloadHandle.Extract(DynamoViewModel.Model, downloadPath, ShouldFinalizePackageInstall, out dynPkg);
+            if (extractionState == PackageDownloadHandle.ExtractionState.InvalidPackage)
             {
-                PackageManagerExtension.PackageLoader.LoadPackages(new List<Package> { dynPkg });
-                packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
-            }
-            else
-            {
-                packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
                 packageDownloadHandle.Error(Resources.MessageInvalidPackage);
+                return;
+            }
+
+            if (extractionState == PackageDownloadHandle.ExtractionState.Cancelled)
+            {
+                packageDownloadHandle.Error(Resources.CannotDownloadPackageMessageBoxTitle);
+                return;
+            }
+
+            packageLoader.LoadPackages(new List<Package> { dynPkg });
+            if (dynPkg.LoadState.State == PackageLoadState.StateTypes.Error)
+            {
+                CleanupFailedPackageInstall(dynPkg, packageLoader);
+                packageDownloadHandle.Error(dynPkg.LoadState.ErrorMessage);
+                return;
+            }
+
+            packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
+        }
+
+        private bool ShouldFinalizePackageInstall(Package package)
+        {
+            var conflictingPackage = FindConflictingCustomNodePackage(package);
+            if (conflictingPackage == null)
+            {
+                return true;
+            }
+
+            ConfirmConflictingCustomNodePackageUninstall(conflictingPackage, package);
+            return false;
+        }
+
+        private Package FindConflictingCustomNodePackage(Package package)
+        {
+            if (package == null || !Directory.Exists(package.CustomNodeDirectory))
+            {
+                return null;
+            }
+
+            var customNodeManager = DynamoViewModel.Model.CustomNodeManager;
+            var packageLoader = PackageManagerExtension.PackageLoader;
+            foreach (var customNodePath in Directory.EnumerateFiles(package.CustomNodeDirectory, "*.dyf"))
+            {
+                if (!customNodeManager.TryGetInfoFromPath(customNodePath, DynamoModel.IsTestMode, out var newInfo))
+                {
+                    continue;
+                }
+
+                if (!customNodeManager.NodeInfos.TryGetValue(newInfo.FunctionId, out var existingInfo))
+                {
+                    continue;
+                }
+
+                var existingPackage = packageLoader.GetOwnerPackage(existingInfo.Path);
+                if (existingPackage != null && existingPackage.Name != package.Name)
+                {
+                    return existingPackage;
+                }
+            }
+
+            return null;
+        }
+
+        private bool ConfirmConflictingCustomNodePackageUninstall(Package installed, Package conflicting)
+        {
+            var message = string.Format(Resources.MessageUninstallCustomNodeToContinue,
+                installed.Name + " " + installed.VersionName, conflicting.Name + " " + conflicting.VersionName);
+
+            var dialogResult = MessageBoxService.Show(message,
+                Resources.CannotDownloadPackageMessageBoxTitle,
+                MessageBoxButton.YesNo, MessageBoxImage.Error);
+
+            if (dialogResult != MessageBoxResult.Yes)
+            {
+                return false;
+            }
+
+            installed.MarkForUninstall(DynamoViewModel.Model.PreferenceSettings);
+            return true;
+        }
+
+        private static void CleanupFailedPackageInstall(Package package, PackageLoader packageLoader)
+        {
+            if (package == null)
+            {
+                return;
+            }
+
+            packageLoader.Remove(package);
+            TryDeletePackageDirectory(package.RootDirectory);
+        }
+
+        private static void TryDeletePackageDirectory(string directory)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, true);
+                }
+            }
+            catch (IOException ex)
+            {
+                DynamoConsoleLogger.OnLogMessageToDynamoConsole($"Failed to delete package directory {directory}: {ex}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                DynamoConsoleLogger.OnLogMessageToDynamoConsole($"Failed to delete package directory {directory}: {ex}");
             }
         }
 

--- a/src/DynamoPackages/PackageDownloadHandle.cs
+++ b/src/DynamoPackages/PackageDownloadHandle.cs
@@ -130,6 +130,7 @@ namespace Dynamo.PackageManager
             // provide handle to installed package 
             pkg = Package.FromDirectory(unzipPath, dynamoModel.Logger);
 
+            // validate package metadata before installing
             if (pkg == null)
             {
                 TryDeleteDirectory(unzipPath);
@@ -139,6 +140,7 @@ namespace Dynamo.PackageManager
             if (String.IsNullOrEmpty(installDirectory))
                 installDirectory = dynamoModel.PathManager.DefaultPackagesDirectory;
 
+            // validate staged package before final copy
             if (validatePackage != null && !validatePackage(pkg))
             {
                 TryDeleteDirectory(unzipPath);

--- a/src/DynamoPackages/PackageDownloadHandle.cs
+++ b/src/DynamoPackages/PackageDownloadHandle.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using Dynamo.Core;
 using Dynamo.Models;
@@ -18,6 +19,13 @@ namespace Dynamo.PackageManager
         public enum State
         {
             Uninitialized, Downloading, Downloaded, Installing, Installed, Error
+        }
+
+        internal enum ExtractionState
+        {
+            Success,
+            InvalidPackage,
+            Cancelled
         }
 
         private string _errorString = "";
@@ -105,6 +113,11 @@ namespace Dynamo.PackageManager
         /// <returns>Whether the operation succeeded or not</returns>
         public bool Extract(DynamoModel dynamoModel, string installDirectory, out Package pkg)
         {
+            return Extract(dynamoModel, installDirectory, null, out pkg) == ExtractionState.Success;
+        }
+
+        internal ExtractionState Extract(DynamoModel dynamoModel, string installDirectory, Func<Package, bool> validatePackage, out Package pkg)
+        {
             this.DownloadState = State.Installing;
 
             // unzip, place files
@@ -119,11 +132,18 @@ namespace Dynamo.PackageManager
 
             if (pkg == null)
             {
-                return false;
+                TryDeleteDirectory(unzipPath);
+                return ExtractionState.InvalidPackage;
             }
 
             if (String.IsNullOrEmpty(installDirectory))
                 installDirectory = dynamoModel.PathManager.DefaultPackagesDirectory;
+
+            if (validatePackage != null && !validatePackage(pkg))
+            {
+                TryDeleteDirectory(unzipPath);
+                return ExtractionState.Cancelled;
+            }
 
             var installedPath = BuildInstallDirectoryString(installDirectory, pkg.Name);
             Directory.CreateDirectory(installedPath);
@@ -139,7 +159,26 @@ namespace Dynamo.PackageManager
             // Update root directory to final path
             pkg.RootDirectory = installedPath;
 
-            return true;
+            return ExtractionState.Success;
+        }
+
+        private static void TryDeleteDirectory(string directory)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, true);
+                }
+            }
+            catch (IOException)
+            {
+                Debug.WriteLine($"Failed to delete package staging directory {directory}");
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Debug.WriteLine($"Failed to delete package staging directory {directory}");
+            }
         }
 
         // cancel, install, redownload

--- a/src/DynamoPackages/PackageDownloadHandle.cs
+++ b/src/DynamoPackages/PackageDownloadHandle.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using Dynamo.Core;
+using Dynamo.Logging;
 using Dynamo.Models;
 
 using Greg.Responses;
@@ -133,7 +133,7 @@ namespace Dynamo.PackageManager
             // validate package metadata before installing
             if (pkg == null)
             {
-                TryDeleteDirectory(unzipPath);
+                TryDeleteDirectory(unzipPath, dynamoModel.Logger);
                 return ExtractionState.InvalidPackage;
             }
 
@@ -143,7 +143,7 @@ namespace Dynamo.PackageManager
             // validate staged package before final copy
             if (validatePackage != null && !validatePackage(pkg))
             {
-                TryDeleteDirectory(unzipPath);
+                TryDeleteDirectory(unzipPath, dynamoModel.Logger);
                 return ExtractionState.Cancelled;
             }
 
@@ -164,7 +164,7 @@ namespace Dynamo.PackageManager
             return ExtractionState.Success;
         }
 
-        private static void TryDeleteDirectory(string directory)
+        private static void TryDeleteDirectory(string directory, ILogger logger)
         {
             try
             {
@@ -173,18 +173,15 @@ namespace Dynamo.PackageManager
                     Directory.Delete(directory, true);
                 }
             }
-            catch (IOException)
+            catch (IOException ex)
             {
-                Debug.WriteLine($"Failed to delete package staging directory {directory}");
+                logger?.Log($"Failed to delete package staging directory {directory}: {ex}");
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException ex)
             {
-                Debug.WriteLine($"Failed to delete package staging directory {directory}");
+                logger?.Log($"Failed to delete package staging directory {directory}: {ex}");
             }
         }
-
-        // cancel, install, redownload
-
     }
 
 }

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
@@ -943,6 +943,7 @@ namespace DynamoCoreWpfTests.PackageManager
             var conflictingPackageZip = CreatePackageZip(conflictingPackageDirectory);
             var installDirectory = Path.Combine(packageRootDirectory, "install");
             var expectedConflictingPackageInstallDirectory = Path.Combine(installDirectory, "DynamoFormaBeta for 2.x");
+            ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.Add(expectedConflictingPackageInstallDirectory);
 
             var dlgMock = new Mock<MessageBoxService.IMessageBox>();
             dlgMock.Setup(m => m.Show(
@@ -987,6 +988,7 @@ namespace DynamoCoreWpfTests.PackageManager
                 Assert.IsFalse(ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.Contains(installedPackage.RootDirectory));
                 Assert.AreEqual(PackageDownloadHandle.State.Error, downloadHandle.DownloadState);
                 Assert.IsFalse(Directory.Exists(expectedConflictingPackageInstallDirectory));
+                Assert.IsTrue(ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.Contains(expectedConflictingPackageInstallDirectory));
                 Assert.IsFalse(loader.LocalPackages.Any(package => package.Name == "DynamoFormaBeta for 2.x"));
             }
             finally
@@ -1021,6 +1023,7 @@ namespace DynamoCoreWpfTests.PackageManager
             var conflictingPackageZip = CreatePackageZip(conflictingPackageDirectory);
             var installDirectory = Path.Combine(packageRootDirectory, "install");
             var expectedConflictingPackageInstallDirectory = Path.Combine(installDirectory, "DynamoFormaBeta for 2.x");
+            ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.Add(expectedConflictingPackageInstallDirectory);
 
             var dlgMock = new Mock<MessageBoxService.IMessageBox>();
             dlgMock.Setup(m => m.Show(
@@ -1063,6 +1066,7 @@ namespace DynamoCoreWpfTests.PackageManager
 
                 Assert.AreEqual(PackageLoadState.ScheduledTypes.ScheduledForDeletion, installedPackage.LoadState.ScheduledState);
                 Assert.IsTrue(ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.Contains(installedPackage.RootDirectory));
+                Assert.IsFalse(ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.Contains(expectedConflictingPackageInstallDirectory));
                 Assert.AreEqual(PackageDownloadHandle.State.Installed, downloadHandle.DownloadState);
                 Assert.IsTrue(Directory.Exists(expectedConflictingPackageInstallDirectory));
                 Assert.IsFalse(loader.LocalPackages.Any(package => package.Name == "DynamoFormaBeta for 2.x"));

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.IO.Compression;
 using Dynamo.Core;
 using Dynamo.Extensions;
 using Dynamo.Models;
@@ -108,6 +109,13 @@ namespace DynamoCoreWpfTests.PackageManager
             File.WriteAllText(packageJsonPath, packageJson);
 
             return destinationDirectory;
+        }
+
+        private static string CreatePackageZip(string packageDirectory)
+        {
+            var zipPath = packageDirectory + ".zip";
+            ZipFile.CreateFromDirectory(packageDirectory, zipPath);
+            return zipPath;
         }
 
         public void AssertWindowOwnedByDynamoView<T>()
@@ -932,7 +940,9 @@ namespace DynamoCoreWpfTests.PackageManager
                 "3.0.0");
 
             var installedPackage = Package.FromDirectory(installedPackageDirectory, ViewModel.Model.Logger);
-            var conflictingPackage = Package.FromDirectory(conflictingPackageDirectory, ViewModel.Model.Logger);
+            var conflictingPackageZip = CreatePackageZip(conflictingPackageDirectory);
+            var installDirectory = Path.Combine(packageRootDirectory, "install");
+            var expectedConflictingPackageInstallDirectory = Path.Combine(installDirectory, "DynamoFormaBeta for 2.x");
 
             var dlgMock = new Mock<MessageBoxService.IMessageBox>();
             dlgMock.Setup(m => m.Show(
@@ -950,15 +960,20 @@ namespace DynamoCoreWpfTests.PackageManager
                 MockMaker.Empty<IPackageUploadBuilder>(),
                 string.Empty);
             var packageManagerClientViewModel = new PackageManagerClientViewModel(ViewModel, client);
-            var packageSearchViewModel = new PackageManagerSearchViewModel(packageManagerClientViewModel);
-            packageSearchViewModel.RegisterTransientHandlers();
 
             try
             {
                 loader.LoadPackages(new[] { installedPackage });
                 Assert.AreEqual(PackageLoadState.StateTypes.Loaded, installedPackage.LoadState.State);
 
-                loader.LoadPackages(new[] { conflictingPackage });
+                var downloadHandle = new PackageDownloadHandle
+                {
+                    DownloadPath = conflictingPackageZip,
+                    Name = "DynamoFormaBeta for 2.x",
+                    VersionName = "3.0.0"
+                };
+
+                packageManagerClientViewModel.SetPackageState(downloadHandle, installDirectory);
 
                 dlgMock.Verify(m => m.Show(
                     It.Is<string>(message => message.Contains("DynamoFormaBeta 1.0.0") &&
@@ -970,11 +985,12 @@ namespace DynamoCoreWpfTests.PackageManager
 
                 Assert.AreEqual(PackageLoadState.ScheduledTypes.None, installedPackage.LoadState.ScheduledState);
                 Assert.IsFalse(ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.Contains(installedPackage.RootDirectory));
-                Assert.AreEqual(PackageLoadState.StateTypes.Error, conflictingPackage.LoadState.State);
+                Assert.AreEqual(PackageDownloadHandle.State.Error, downloadHandle.DownloadState);
+                Assert.IsFalse(Directory.Exists(expectedConflictingPackageInstallDirectory));
+                Assert.IsFalse(loader.LocalPackages.Any(package => package.Name == "DynamoFormaBeta for 2.x"));
             }
             finally
             {
-                packageSearchViewModel.UnregisterTransientHandlers();
                 MessageBoxService.OverrideMessageBoxDuringTests(null);
                 if (Directory.Exists(packageRootDirectory))
                 {

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
@@ -14,6 +14,7 @@ using Dynamo.PackageManager;
 using Dynamo.PackageManager.Interfaces;
 using Dynamo.PackageManager.Tests;
 using Dynamo.PackageManager.UI;
+using Dynamo.PackageManager.ViewModels;
 using Dynamo.Tests;
 using Dynamo.UI.Prompts;
 using Dynamo.Utilities;
@@ -73,6 +74,40 @@ namespace DynamoCoreWpfTests.PackageManager
         public static bool ComparePaths(string path1, string path2)
         {
             return PackageDirectoryBuilder.NormalizePath(path1) == PackageDirectoryBuilder.NormalizePath(path2);
+        }
+
+        private static void CopyDirectory(string sourceDirectory, string destinationDirectory)
+        {
+            Directory.CreateDirectory(destinationDirectory);
+
+            foreach (var filePath in Directory.GetFiles(sourceDirectory))
+            {
+                File.Copy(filePath, Path.Combine(destinationDirectory, Path.GetFileName(filePath)));
+            }
+
+            foreach (var directoryPath in Directory.GetDirectories(sourceDirectory))
+            {
+                CopyDirectory(directoryPath, Path.Combine(destinationDirectory, Path.GetFileName(directoryPath)));
+            }
+        }
+
+        private static string CreateDynamoFormaPackageFixture(
+            string sourceDirectory,
+            string packageRootDirectory,
+            string packageName,
+            string packageVersion)
+        {
+            var destinationDirectory = Path.Combine(packageRootDirectory, packageName);
+            CopyDirectory(sourceDirectory, destinationDirectory);
+
+            var packageJsonPath = Path.Combine(destinationDirectory, "pkg.json");
+            var packageJson = File.ReadAllText(packageJsonPath)
+                .Replace("\"name\":\"EvenOdd\"", $"\"name\":\"{packageName}\"")
+                .Replace("\"name\":\"EvenOdd2\"", $"\"name\":\"{packageName}\"")
+                .Replace("\"version\":\"1.0.0\"", $"\"version\":\"{packageVersion}\"");
+            File.WriteAllText(packageJsonPath, packageJson);
+
+            return destinationDirectory;
         }
 
         public void AssertWindowOwnedByDynamoView<T>()
@@ -876,6 +911,76 @@ namespace DynamoCoreWpfTests.PackageManager
 
             messageBox.OkButton.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
             Assert.AreEqual(MessageBoxResult.OK, messageBox.CustomDialogResult);
+        }
+
+        [Test]
+        [Description("DYN-7587: User chooses No when installing a DynamoForma package with conflicting custom nodes")]
+        public void InstallingDynamoFormaConflictingPackage_WhenUserChoosesNo_DoesNotUninstallExistingPackage()
+        {
+            var loader = GetPackageLoader();
+            var packageRootDirectory = Path.Combine(Path.GetTempPath(), $"DYN7587_{Guid.NewGuid():N}");
+
+            var installedPackageDirectory = CreateDynamoFormaPackageFixture(
+                Path.Combine(PackagesDirectory, "EvenOdd"),
+                packageRootDirectory,
+                "DynamoFormaBeta",
+                "1.0.0");
+            var conflictingPackageDirectory = CreateDynamoFormaPackageFixture(
+                Path.Combine(PackagesDirectory, "EvenOdd2"),
+                packageRootDirectory,
+                "DynamoFormaBeta for 2.x",
+                "3.0.0");
+
+            var installedPackage = Package.FromDirectory(installedPackageDirectory, ViewModel.Model.Logger);
+            var conflictingPackage = Package.FromDirectory(conflictingPackageDirectory, ViewModel.Model.Logger);
+
+            var dlgMock = new Mock<MessageBoxService.IMessageBox>();
+            dlgMock.Setup(m => m.Show(
+                It.Is<string>(message => message.Contains("DynamoFormaBeta 1.0.0") &&
+                                         message.Contains("DynamoFormaBeta for 2.x 3.0.0")),
+                Dynamo.Wpf.Properties.Resources.CannotDownloadPackageMessageBoxTitle,
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Error))
+                .Returns(MessageBoxResult.No);
+            MessageBoxService.OverrideMessageBoxDuringTests(dlgMock.Object);
+
+            var mockGreg = new Mock<IGregClient>();
+            var client = new Dynamo.PackageManager.PackageManagerClient(
+                mockGreg.Object,
+                MockMaker.Empty<IPackageUploadBuilder>(),
+                string.Empty);
+            var packageManagerClientViewModel = new PackageManagerClientViewModel(ViewModel, client);
+            var packageSearchViewModel = new PackageManagerSearchViewModel(packageManagerClientViewModel);
+            packageSearchViewModel.RegisterTransientHandlers();
+
+            try
+            {
+                loader.LoadPackages(new[] { installedPackage });
+                Assert.AreEqual(PackageLoadState.StateTypes.Loaded, installedPackage.LoadState.State);
+
+                loader.LoadPackages(new[] { conflictingPackage });
+
+                dlgMock.Verify(m => m.Show(
+                    It.Is<string>(message => message.Contains("DynamoFormaBeta 1.0.0") &&
+                                             message.Contains("DynamoFormaBeta for 2.x 3.0.0")),
+                    Dynamo.Wpf.Properties.Resources.CannotDownloadPackageMessageBoxTitle,
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Error),
+                    Times.Once);
+
+                Assert.AreEqual(PackageLoadState.ScheduledTypes.None, installedPackage.LoadState.ScheduledState);
+                Assert.IsFalse(ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.Contains(installedPackage.RootDirectory));
+                Assert.AreEqual(PackageLoadState.StateTypes.Error, conflictingPackage.LoadState.State);
+            }
+            finally
+            {
+                packageSearchViewModel.UnregisterTransientHandlers();
+                MessageBoxService.OverrideMessageBoxDuringTests(null);
+                if (Directory.Exists(packageRootDirectory))
+                {
+                    Directory.Delete(packageRootDirectory, true);
+                }
+            }
         }
 
 

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
@@ -999,6 +999,84 @@ namespace DynamoCoreWpfTests.PackageManager
             }
         }
 
+        [Test]
+        [Description("DYN-7587: User chooses Yes when installing a DynamoForma package with conflicting custom nodes")]
+        public void InstallingDynamoFormaConflictingPackage_WhenUserChoosesYes_FinalizesNewPackageAndSchedulesExistingPackageForUninstall()
+        {
+            var loader = GetPackageLoader();
+            var packageRootDirectory = Path.Combine(Path.GetTempPath(), $"DYN7587_{Guid.NewGuid():N}");
+
+            var installedPackageDirectory = CreateDynamoFormaPackageFixture(
+                Path.Combine(PackagesDirectory, "EvenOdd"),
+                packageRootDirectory,
+                "DynamoFormaBeta",
+                "1.0.0");
+            var conflictingPackageDirectory = CreateDynamoFormaPackageFixture(
+                Path.Combine(PackagesDirectory, "EvenOdd2"),
+                packageRootDirectory,
+                "DynamoFormaBeta for 2.x",
+                "3.0.0");
+
+            var installedPackage = Package.FromDirectory(installedPackageDirectory, ViewModel.Model.Logger);
+            var conflictingPackageZip = CreatePackageZip(conflictingPackageDirectory);
+            var installDirectory = Path.Combine(packageRootDirectory, "install");
+            var expectedConflictingPackageInstallDirectory = Path.Combine(installDirectory, "DynamoFormaBeta for 2.x");
+
+            var dlgMock = new Mock<MessageBoxService.IMessageBox>();
+            dlgMock.Setup(m => m.Show(
+                It.Is<string>(message => message.Contains("DynamoFormaBeta 1.0.0") &&
+                                         message.Contains("DynamoFormaBeta for 2.x 3.0.0")),
+                Dynamo.Wpf.Properties.Resources.CannotDownloadPackageMessageBoxTitle,
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Error))
+                .Returns(MessageBoxResult.Yes);
+            MessageBoxService.OverrideMessageBoxDuringTests(dlgMock.Object);
+
+            var mockGreg = new Mock<IGregClient>();
+            var client = new Dynamo.PackageManager.PackageManagerClient(
+                mockGreg.Object,
+                MockMaker.Empty<IPackageUploadBuilder>(),
+                string.Empty);
+            var packageManagerClientViewModel = new PackageManagerClientViewModel(ViewModel, client);
+
+            try
+            {
+                loader.LoadPackages(new[] { installedPackage });
+                Assert.AreEqual(PackageLoadState.StateTypes.Loaded, installedPackage.LoadState.State);
+
+                var downloadHandle = new PackageDownloadHandle
+                {
+                    DownloadPath = conflictingPackageZip,
+                    Name = "DynamoFormaBeta for 2.x",
+                    VersionName = "3.0.0"
+                };
+
+                packageManagerClientViewModel.SetPackageState(downloadHandle, installDirectory);
+
+                dlgMock.Verify(m => m.Show(
+                    It.Is<string>(message => message.Contains("DynamoFormaBeta 1.0.0") &&
+                                             message.Contains("DynamoFormaBeta for 2.x 3.0.0")),
+                    Dynamo.Wpf.Properties.Resources.CannotDownloadPackageMessageBoxTitle,
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Error),
+                    Times.Once);
+
+                Assert.AreEqual(PackageLoadState.ScheduledTypes.ScheduledForDeletion, installedPackage.LoadState.ScheduledState);
+                Assert.IsTrue(ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.Contains(installedPackage.RootDirectory));
+                Assert.AreEqual(PackageDownloadHandle.State.Installed, downloadHandle.DownloadState);
+                Assert.IsTrue(Directory.Exists(expectedConflictingPackageInstallDirectory));
+                Assert.IsFalse(loader.LocalPackages.Any(package => package.Name == "DynamoFormaBeta for 2.x"));
+            }
+            finally
+            {
+                MessageBoxService.OverrideMessageBoxDuringTests(null);
+                if (Directory.Exists(packageRootDirectory))
+                {
+                    Directory.Delete(packageRootDirectory, true);
+                }
+            }
+        }
+
 
 
         [Test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

Adds a long-term fix for DYN-7587 by validating package custom-node `.dyf` GUID conflicts before a downloaded package is copied into the final install location.

The package is inspected while still in the extracted staging location. If its custom-node GUIDs conflict with an already loaded package from a different package name, Dynamo shows the existing `Cannot Download Package` prompt before finalizing the install.

- Choosing `No` cancels the install and cleans the staged extraction without adding the new package to the package loader or final install directory.
- Choosing `Yes` preserves the intended existing flow: Dynamo schedules the currently loaded package for uninstall/restart, finalizes the new package files into the package folder, clears any stale uninstall marker for that finalized package directory, and does not attempt to load the conflicting package again in the same session.

The regression tests create temporary DynamoForma-named fixtures with conflicting `.dyf` GUIDs and cover both `No` and `Yes` responses.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Prevents cancelled package conflict installs from being finalized.

### Reviewers

TBD

Targeted test command was attempted but could not run in this environment because `dotnet` is not installed on PATH.

### FYIs

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-451cba88-ccb9-489a-ad9f-4d43266bb210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-451cba88-ccb9-489a-ad9f-4d43266bb210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

