### PR TITLE
DYN-7587 Clean up package conflict validation

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1144,39 +1144,36 @@ namespace Dynamo.ViewModels
         internal void SetPackageState(PackageDownloadHandle packageDownloadHandle, string downloadPath)
         {
             Package dynPkg;
-
             var packageLoader = PackageManagerExtension.PackageLoader;
 
-
             var shouldLoadPackage = true;
-            var extractionsState = packageDownloadHandle.Extract(
+            var extractionState = packageDownloadHandle.Extract(
                 DynamoViewModel.Model,
                 downloadPath,
                 package => ShouldFinalizePackageInstall(package, out shouldLoadPackage),
                 out dynPkg);
 
-            if (extractionsState == PackageDownloadHandle.ExtractionState.InvalidPackage)
+            if (extractionState == PackageDownloadHandle.ExtractionState.InvalidPackage)
             {
                 packageDownloadHandle.Error(Resources.MessageInvalidPackage);
                 return;
             }
 
-            if (extractionsState == PackageDownloadHandle.ExtractionState.Cancelled)
+            if (extractionState == PackageDownloadHandle.ExtractionState.Cancelled)
             {
                 packageDownloadHandle.Error(Resources.CannotDownloadPackageMessageBoxTitle);
                 return;
             }
 
-            DynamoViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.RemoveAll(x => x.Equals(dynPkg.RootDirectory));
-
             if (!shouldLoadPackage)
             {
-                // The package will load after restart when the conflicting package is removed
+                ClearPackageUninstallMarker(dynPkg);
+                // The package will load after restart when the conflicting package is removed.
                 packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
                 return;
             }
 
-            packageLoader.LoadPackages(new List<Package>() { dynPkg });
+            packageLoader.LoadPackages(new List<Package> { dynPkg });
             if (dynPkg.LoadState.State == PackageLoadState.StateTypes.Error)
             {
                 CleanupFailedPackageInstall(dynPkg, packageLoader);
@@ -1184,42 +1181,66 @@ namespace Dynamo.ViewModels
                 return;
             }
 
+            ClearPackageUninstallMarker(dynPkg);
             packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
         }
 
-        private bool ShouldFinalizePackageInstall(Package pkg, out bool shouldLoadPackage)
+        private void ClearPackageUninstallMarker(Package package)
+        {
+            if (package == null)
+            {
+                return;
+            }
+
+            DynamoViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.RemoveAll(x => x.Equals(package.RootDirectory));
+        }
+
+        private bool ShouldFinalizePackageInstall(Package package, out bool shouldLoadPackage)
         {
             shouldLoadPackage = true;
 
-            var conflictingPkgs = FindConflictingCustomNodePackage(pkg);
-            if (conflictingPkgs == null)
+            var conflictingPackage = FindConflictingCustomNodePackage(package);
+            if (conflictingPackage == null)
+            {
                 return true;
+            }
 
-            if (!ConfirmConflictingCustomNodePackageUninstall(conflictingPkgs, pkg))
+            if (!ConfirmConflictingCustomNodePackageUninstall(conflictingPackage, package))
+            {
                 return false;
+            }
 
             shouldLoadPackage = false;
             return true;
         }
 
-        private Package FindConflictingCustomNodePackage(Package pkg)
+        private Package FindConflictingCustomNodePackage(Package package)
         {
-            if (pkg == null || !Directory.Exists(pkg.CustomNodeDirectory)) return null;
+            if (package == null || !Directory.Exists(package.CustomNodeDirectory))
+            {
+                return null;
+            }
 
-            var customNodemanager = DynamoViewModel.Model.CustomNodeManager;
+            var customNodeManager = DynamoViewModel.Model.CustomNodeManager;
             var packageLoader = PackageManagerExtension.PackageLoader;
 
-            foreach (var customNodePath in Directory.EnumerateFiles(pkg.CustomNodeDirectory, "*.dyf"))
+            foreach (var customNodePath in Directory.EnumerateFiles(package.CustomNodeDirectory, "*.dyf"))
             {
-                if (!customNodemanager.TryGetInfoFromPath(customNodePath, DynamoModel.IsTestMode, out var newInfo))
+                if (!customNodeManager.TryGetInfoFromPath(customNodePath, DynamoModel.IsTestMode, out var newInfo))
+                {
                     continue;
+                }
 
-                if (!customNodemanager.NodeInfos.TryGetValue(newInfo.FunctionId, out var existingInfo))
+                if (!customNodeManager.NodeInfos.TryGetValue(newInfo.FunctionId, out var existingInfo))
+                {
                     continue;
+                }
 
-                var existingPkg = packageLoader.GetOwnerPackage(existingInfo.Path);
-                if (existingPkg != null && existingPkg.Name != pkg.Name)
-                    return existingPkg;
+                var existingPackage = packageLoader.GetOwnerPackage(existingInfo.Path);
+                if (existingPackage != null && existingPackage.Name != package.Name)
+                {
+                    return existingPackage;
+                }
             }
 
             return null;
@@ -1235,33 +1256,38 @@ namespace Dynamo.ViewModels
                 MessageBoxButton.YesNo, MessageBoxImage.Error);
 
             if (dialogResult != MessageBoxResult.Yes)
+            {
                 return false;
+            }
 
             installed.MarkForUninstall(DynamoViewModel.Model.PreferenceSettings);
             return true;
         }
 
-        private void CleanupFailedPackageInstall(Package pkg, PackageLoader pkgLoader)
+        private void CleanupFailedPackageInstall(Package package, PackageLoader packageLoader)
         {
-            if (pkg == null) return;
+            if (package == null)
+            {
+                return;
+            }
 
-            var pkgDirectory = pkg.RootDirectory;
-            pkgLoader?.Remove(pkg);
+            var packageDirectory = package.RootDirectory;
+            packageLoader?.Remove(package);
 
             try
             {
-                if (!string.IsNullOrEmpty(pkgDirectory) && Directory.Exists(pkgDirectory))
+                if (!string.IsNullOrEmpty(packageDirectory) && Directory.Exists(packageDirectory))
                 {
-                    Directory.Delete(pkgDirectory, true);
+                    Directory.Delete(packageDirectory, true);
                 }
             }
             catch (IOException ex)
             {
-                DynamoViewModel.Model.Logger.Log($"Failed to delete package directory {pkgDirectory}: {ex}");
+                DynamoViewModel.Model.Logger.Log($"Failed to delete package directory {packageDirectory}: {ex}");
             }
             catch (UnauthorizedAccessException ex)
             {
-                DynamoViewModel.Model.Logger.Log($"Failed to delete package directory {pkgDirectory}: {ex}");
+                DynamoViewModel.Model.Logger.Log($"Failed to delete package directory {packageDirectory}: {ex}");
             }
         }
 

--- a/src/DynamoPackages/PackageDownloadHandle.cs
+++ b/src/DynamoPackages/PackageDownloadHandle.cs
@@ -22,11 +22,13 @@ namespace Dynamo.PackageManager
         }
 
         /// <summary>
-        /// Possible states for the extraction of a package after download
+        /// Possible states for the extraction of a package after download.
         /// </summary>
         internal enum ExtractionState
         {
-            Success, InvalidPackage, Cancelled
+            Success,
+            InvalidPackage,
+            Cancelled
         }
 
         private string _errorString = "";
@@ -131,7 +133,7 @@ namespace Dynamo.PackageManager
             // provide handle to installed package 
             pkg = Package.FromDirectory(unzipPath, dynamoModel.Logger);
 
-            // Validate package metadata before installing
+            // validate package metadata before installing
             if (pkg == null)
             {
                 TryDeleteDirectory(unzipPath, dynamoModel.Logger);
@@ -141,6 +143,7 @@ namespace Dynamo.PackageManager
             if (String.IsNullOrEmpty(installDirectory))
                 installDirectory = dynamoModel.PathManager.DefaultPackagesDirectory;
 
+            // validate staged package before final copy
             if (validatePackage != null && !validatePackage(pkg))
             {
                 TryDeleteDirectory(unzipPath, dynamoModel.Logger);
@@ -173,16 +176,14 @@ namespace Dynamo.PackageManager
                     Directory.Delete(directory, true);
                 }
             }
-            catch (IOException)
+            catch (IOException ex)
             {
-                logger?.Log($"Failed to delete package staging directory {directory}");
+                logger?.Log($"Failed to delete package staging directory {directory}: {ex}");
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException ex)
             {
-                logger?.Log($"Failed to delete package staging directory {directory}");
+                logger?.Log($"Failed to delete package staging directory {directory}: {ex}");
             }
         }
     }
-
-     // cancel, install, redownload
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

Cleans up the DYN-7587 package conflict validation draft from commit `9fbf6b477a`.

Changes include:
- Clear stale `PackageDirectoriesToUninstall` entries only after the package is successfully finalized.
- Keep the restart-load path for accepted custom-node conflicts intact.
- Improve naming/readability in the conflict validation helpers.
- Add the missing staged-package validation comment.
- Log staging cleanup exceptions with exception details.
- Remove the leftover redundant comment from `PackageDownloadHandle`.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Prevents package conflict cleanup from deleting finalized installs.

### Reviewers

TBD

Targeted test command was attempted but could not run in this environment because `dotnet` is not installed on PATH.

### FYIs

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-451cba88-ccb9-489a-ad9f-4d43266bb210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-451cba88-ccb9-489a-ad9f-4d43266bb210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

