### PR TITLE
DYN-7587 add package conflict cancellation regression test

### DIFF
--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
@@ -75,6 +75,29 @@ namespace DynamoCoreWpfTests.PackageManager
             return PackageDirectoryBuilder.NormalizePath(path1) == PackageDirectoryBuilder.NormalizePath(path2);
         }
 
+        private class TestDirectoryInfo : IDirectoryInfo
+        {
+            internal TestDirectoryInfo(string fullName)
+            {
+                FullName = fullName;
+            }
+
+            public string FullName { get; }
+        }
+
+        private static HashSet<string> GetGregPackageOutputDirectories()
+        {
+            var tempFolder = Greg.Utility.FileUtilities.GetTempFolder();
+            return Directory.Exists(tempFolder)
+                ? new HashSet<string>(Directory.GetDirectories(tempFolder, "gregPkgOutput*.zip*"))
+                : new HashSet<string>();
+        }
+
+        private static string GetPackageInstallDirectory(string packagesDirectory, string packageName)
+        {
+            return packagesDirectory + @"\" + packageName.Replace("/", "_").Replace(@"\", "_");
+        }
+
         public void AssertWindowOwnedByDynamoView<T>()
         {
             var windows = GetWindowEnumerable(View.OwnedWindows);
@@ -810,6 +833,94 @@ namespace DynamoCoreWpfTests.PackageManager
             dlgMock.Verify(x => x.Show(It.IsAny<Window>(), It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<MessageBoxButton>(), It.IsAny<MessageBoxImage>()), Times.Exactly(2));
             dlgMock.ResetCalls();
+        }
+
+        [Test]
+        [Description("User declines to install a downloaded package that conflicts with custom nodes from an existing package")]
+        public void PackageManagerCustomNodeConflictNoDoesNotInstallPackageOrLeaveTempExtraction()
+        {
+            var pkgLoader = GetPackageLoader();
+
+            var installedPackageLocation = Path.Combine(PackagesDirectory, "EvenOdd");
+            var installedPackage = pkgLoader.ScanPackageDirectory(installedPackageLocation);
+            Assert.IsNotNull(installedPackage);
+
+            pkgLoader.LoadPackages(new[] { installedPackage });
+
+            Assert.AreEqual(PackageLoadState.StateTypes.Loaded, installedPackage.LoadState.State);
+            Assert.IsTrue(installedPackage.LoadedCustomNodes.Any());
+
+            var mockGreg = new Mock<IGregClient>();
+            var client = new Dynamo.PackageManager.PackageManagerClient(mockGreg.Object, MockMaker.Empty<IPackageUploadBuilder>(), string.Empty);
+            var pmVm = new PackageManagerClientViewModel(ViewModel, client);
+
+            var dlgMock = new Mock<MessageBoxService.IMessageBox>();
+            dlgMock.Setup(m => m.Show(
+                    It.IsAny<string>(),
+                    Dynamo.Wpf.Properties.Resources.CannotDownloadPackageMessageBoxTitle,
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Error))
+                .Returns(MessageBoxResult.No);
+            MessageBoxService.OverrideMessageBoxDuringTests(dlgMock.Object);
+
+            var conflictingPackageName = "EvenOdd2";
+            var conflictingPackageLocation = Path.Combine(PackagesDirectory, conflictingPackageName);
+            var installDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var expectedInstallDirectory = GetPackageInstallDirectory(installDirectory, conflictingPackageName);
+            var packageOutputDirectoriesBeforeInstall = GetGregPackageOutputDirectories();
+            IFileInfo zippedPackage = null;
+
+            try
+            {
+                Directory.CreateDirectory(installDirectory);
+                zippedPackage = new MutatingFileCompressor().Zip(new TestDirectoryInfo(conflictingPackageLocation));
+
+                var packageDownloadHandle = new PackageDownloadHandle
+                {
+                    Id = conflictingPackageName,
+                    Name = conflictingPackageName,
+                    VersionName = "1.0.0"
+                };
+                packageDownloadHandle.Done(zippedPackage.Name);
+
+                pmVm.SetPackageState(packageDownloadHandle, installDirectory);
+
+                Assert.AreEqual(PackageDownloadHandle.State.Error, packageDownloadHandle.DownloadState);
+                Assert.AreEqual(Dynamo.Wpf.Properties.Resources.CannotDownloadPackageMessageBoxTitle, packageDownloadHandle.ErrorString);
+                Assert.IsFalse(Directory.Exists(expectedInstallDirectory));
+                Assert.IsFalse(pkgLoader.LocalPackages.Any(package => package.Name == conflictingPackageName));
+
+                var remainingPackageOutputDirectories = GetGregPackageOutputDirectories()
+                    .Except(packageOutputDirectoriesBeforeInstall)
+                    .ToList();
+                CollectionAssert.IsEmpty(remainingPackageOutputDirectories);
+
+                dlgMock.Verify(m => m.Show(
+                        It.IsAny<string>(),
+                        Dynamo.Wpf.Properties.Resources.CannotDownloadPackageMessageBoxTitle,
+                        MessageBoxButton.YesNo,
+                        MessageBoxImage.Error),
+                    Times.Once);
+            }
+            finally
+            {
+                MessageBoxService.OverrideMessageBoxDuringTests(null);
+
+                if (zippedPackage != null && File.Exists(zippedPackage.Name))
+                {
+                    File.Delete(zippedPackage.Name);
+                }
+
+                if (Directory.Exists(expectedInstallDirectory))
+                {
+                    Directory.Delete(expectedInstallDirectory, true);
+                }
+
+                if (Directory.Exists(installDirectory))
+                {
+                    Directory.Delete(installDirectory, true);
+                }
+            }
         }
 
         [Test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

Adds a regression test for the DYN-7587 package-manager fix where a downloaded package contains a custom node that conflicts with an already installed package. The test verifies that choosing **No** in the **Cannot Download Package** dialog cancels the install, keeps the conflicting package out of the package loader, and removes the temporary extraction directory.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

N/A - regression test only, no user-facing behavior change.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

Testing note: `git diff --check` and `git show --check` passed. The focused NUnit test was not run in this container because `dotnet`, `msbuild`, and `csc` are not available on PATH.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36d64722-3975-4c79-b6e8-f5b3ad1d7be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36d64722-3975-4c79-b6e8-f5b3ad1d7be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

