### PR TITLE
DYN-7587 prevent partial package install on custom node conflict

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1147,19 +1147,19 @@ namespace Dynamo.ViewModels
             var packageLoader = PackageManagerExtension.PackageLoader;
 
             var shouldLoadPackage = true;
-            var extractionsState = packageDownloadHandle.Extract(
+            var extractionState = packageDownloadHandle.Extract(
                 DynamoViewModel.Model,
                 downloadPath,
                 package => ShouldFinalizePackageInstall(package, out shouldLoadPackage),
                 out dynPkg);
 
-            if (extractionsState == PackageDownloadHandle.ExtractionState.InvalidPackage)
+            if (extractionState == PackageDownloadHandle.ExtractionState.InvalidPackage)
             {
                 packageDownloadHandle.Error(Resources.MessageInvalidPackage);
                 return;
             }
 
-            if (extractionsState == PackageDownloadHandle.ExtractionState.Cancelled)
+            if (extractionState == PackageDownloadHandle.ExtractionState.Cancelled)
             {
                 packageDownloadHandle.Error(Resources.CannotDownloadPackageMessageBoxTitle);
                 return;

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1147,10 +1147,11 @@ namespace Dynamo.ViewModels
             var packageLoader = PackageManagerExtension.PackageLoader;
 
             var shouldLoadPackage = true;
+            Package packageToUninstall = null;
             var extractionState = packageDownloadHandle.Extract(
                 DynamoViewModel.Model,
                 downloadPath,
-                package => ShouldFinalizePackageInstall(package, out shouldLoadPackage),
+                package => ShouldFinalizePackageInstall(package, out shouldLoadPackage, out packageToUninstall),
                 out dynPkg);
 
             if (extractionState == PackageDownloadHandle.ExtractionState.InvalidPackage)
@@ -1166,6 +1167,7 @@ namespace Dynamo.ViewModels
             }
 
             DynamoViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.RemoveAll(x => x.Equals(dynPkg.RootDirectory));
+            packageToUninstall?.MarkForUninstall(DynamoViewModel.Model.PreferenceSettings);
 
             if (!shouldLoadPackage)
             {
@@ -1185,9 +1187,10 @@ namespace Dynamo.ViewModels
             packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
         }
 
-        private bool ShouldFinalizePackageInstall(Package pkg, out bool shouldLoadPackage)
+        private bool ShouldFinalizePackageInstall(Package pkg, out bool shouldLoadPackage, out Package packageToUninstall)
         {
             shouldLoadPackage = true;
+            packageToUninstall = null;
 
             var conflictingPkgs = FindConflictingCustomNodePackage(pkg);
             if (conflictingPkgs == null)
@@ -1197,6 +1200,7 @@ namespace Dynamo.ViewModels
                 return false;
 
             shouldLoadPackage = false;
+            packageToUninstall = conflictingPkgs;
             return true;
         }
 
@@ -1236,7 +1240,6 @@ namespace Dynamo.ViewModels
             if (dialogResult != MessageBoxResult.Yes)
                 return false;
 
-            installed.MarkForUninstall(DynamoViewModel.Model.PreferenceSettings);
             return true;
         }
 

--- a/src/DynamoPackages/PackageDownloadHandle.cs
+++ b/src/DynamoPackages/PackageDownloadHandle.cs
@@ -128,40 +128,60 @@ namespace Dynamo.PackageManager
                 throw new Exception(Properties.Resources.PackageEmpty);
             }
 
-            // provide handle to installed package 
-            pkg = Package.FromDirectory(unzipPath, dynamoModel.Logger);
+            try
+            {
+                // provide handle to installed package
+                pkg = Package.FromDirectory(unzipPath, dynamoModel.Logger);
 
-            // Validate package metadata before installing
-            if (pkg == null)
+                // Validate package metadata before installing
+                if (pkg == null)
+                {
+                    return ExtractionState.InvalidPackage;
+                }
+
+                if (String.IsNullOrEmpty(installDirectory))
+                    installDirectory = dynamoModel.PathManager.DefaultPackagesDirectory;
+
+                if (validatePackage != null && !validatePackage(pkg))
+                {
+                    pkg = null;
+                    return ExtractionState.Cancelled;
+                }
+
+                var installedPath = BuildInstallDirectoryString(installDirectory, pkg.Name);
+                var installedPathAlreadyExists = Directory.Exists(installedPath);
+
+                try
+                {
+                    Directory.CreateDirectory(installedPath);
+
+                    // Now create all of the directories
+                    foreach (string dirPath in Directory.GetDirectories(unzipPath, "*", SearchOption.AllDirectories))
+                        Directory.CreateDirectory(dirPath.Replace(unzipPath, installedPath));
+
+                    // Copy all the files
+                    foreach (string newPath in Directory.GetFiles(unzipPath, "*.*", SearchOption.AllDirectories))
+                        File.Copy(newPath, newPath.Replace(unzipPath, installedPath));
+                }
+                catch
+                {
+                    if (!installedPathAlreadyExists)
+                    {
+                        TryDeleteDirectory(installedPath, dynamoModel.Logger);
+                    }
+
+                    throw;
+                }
+
+                // Update root directory to final path
+                pkg.RootDirectory = installedPath;
+
+                return ExtractionState.Success;
+            }
+            finally
             {
                 TryDeleteDirectory(unzipPath, dynamoModel.Logger);
-                return ExtractionState.InvalidPackage;
             }
-
-            if (String.IsNullOrEmpty(installDirectory))
-                installDirectory = dynamoModel.PathManager.DefaultPackagesDirectory;
-
-            if (validatePackage != null && !validatePackage(pkg))
-            {
-                TryDeleteDirectory(unzipPath, dynamoModel.Logger);
-                return ExtractionState.Cancelled;
-            }
-
-            var installedPath = BuildInstallDirectoryString(installDirectory, pkg.Name);
-            Directory.CreateDirectory(installedPath);
-
-            // Now create all of the directories
-            foreach (string dirPath in Directory.GetDirectories(unzipPath, "*", SearchOption.AllDirectories))
-                Directory.CreateDirectory(dirPath.Replace(unzipPath, installedPath));
-
-            // Copy all the files
-            foreach (string newPath in Directory.GetFiles(unzipPath, "*.*", SearchOption.AllDirectories))
-                File.Copy(newPath, newPath.Replace(unzipPath, installedPath));
-
-            // Update root directory to final path
-            pkg.RootDirectory = installedPath;
-
-            return ExtractionState.Success;
         }
 
         private static void TryDeleteDirectory(string directory, ILogger logger)
@@ -183,6 +203,4 @@ namespace Dynamo.PackageManager
             }
         }
     }
-
-     // cancel, install, redownload
 }

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -59,6 +60,38 @@ namespace DynamoCoreWpfTests.PackageManager
             }
 
             return null;
+        }
+
+        private Package LoadCustomRoundingPackage(PackageLoader pkgLoader)
+        {
+            var packageLocation = Path.Combine(PackagesDirectory, "Custom Rounding");
+            var pkg = pkgLoader.ScanPackageDirectory(packageLocation);
+            pkgLoader.LoadPackages(new List<Package> { pkg });
+
+            return pkg;
+        }
+
+        private string CreateConflictingCustomNodePackageZip(string packageName)
+        {
+            var packageRoot = Path.Combine(TempFolder, packageName);
+            var customNodeDirectory = Path.Combine(packageRoot, "dyf");
+            Directory.CreateDirectory(customNodeDirectory);
+
+            var packageJson = @"{""file_hash"":null,""name"":""" + packageName + @""",""version"":""1.0.0"",""description"":""Test package with a conflicting custom node."",""group"":""DynamoTests"",""keywords"":[],""dependencies"":[],""license"":""MIT"",""contents"":"""",""engine_version"":""0.5.2.10107"",""engine_metadata"":"""",""engine"":""dynamo""}";
+            File.WriteAllText(Path.Combine(packageRoot, "pkg.json"), packageJson);
+
+            File.Copy(
+                Path.Combine(PackagesDirectory, "Custom Rounding", "dyf", "CustomRound.dyf"),
+                Path.Combine(customNodeDirectory, "ConflictingCustomRound.dyf"));
+
+            var zipPath = Path.Combine(TempFolder, packageName + ".zip");
+            ZipFile.CreateFromDirectory(packageRoot, zipPath);
+            return zipPath;
+        }
+
+        private static string GetPackageInstallDirectory(string packageDirectory, string packageName)
+        {
+            return packageDirectory + @"\" + packageName.Replace("/", "_").Replace(@"\", "_");
         }
 
         public IEnumerable<Window> GetWindowEnumerable(WindowCollection windows)
@@ -1570,6 +1603,115 @@ namespace DynamoCoreWpfTests.PackageManager
                 // 2. That a package with the same name and version already exists.
                 dlgMock.Verify(x => x.Show(It.IsAny<Window>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButton>(), It.IsAny<MessageBoxImage>()), Times.Exactly(1));
                 dlgMock.ResetCalls();
+            }
+        }
+
+        [Test]
+        [Description("User rejects replacing an installed package that owns a conflicting custom node GUID")]
+        public void SetPackageStateWhenConflictingCustomNodeInstallRejectedDoesNotInstallPackage()
+        {
+            var pkgLoader = GetPackageLoader();
+            var installedPackage = LoadCustomRoundingPackage(pkgLoader);
+            var conflictingPackageName = "Conflicting Custom Rounding";
+            var installRoot = Path.Combine(TempFolder, "packages");
+            var zipPath = CreateConflictingCustomNodePackageZip(conflictingPackageName);
+            var expectedInstallPath = GetPackageInstallDirectory(installRoot, conflictingPackageName);
+            var packageDownloadHandle = new PackageDownloadHandle
+            {
+                Name = conflictingPackageName,
+                VersionName = "1.0.0"
+            };
+            packageDownloadHandle.Done(zipPath);
+
+            var dlgMock = new Mock<MessageBoxService.IMessageBox>();
+            dlgMock.Setup(m => m.Show(
+                    It.Is<string>(x => x.Contains(installedPackage.Name) && x.Contains(conflictingPackageName)),
+                    It.IsAny<string>(),
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Error))
+                .Returns(MessageBoxResult.No);
+            MessageBoxService.OverrideMessageBoxDuringTests(dlgMock.Object);
+
+            try
+            {
+                var scheduledUninstallsBeforeInstall = ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.ToList();
+
+                var mockGreg = new Mock<IGregClient>();
+                var client = new Dynamo.PackageManager.PackageManagerClient(
+                    mockGreg.Object,
+                    MockMaker.Empty<IPackageUploadBuilder>(),
+                    string.Empty);
+                var pmVm = new PackageManagerClientViewModel(ViewModel, client);
+                pmVm.SetPackageState(packageDownloadHandle, installRoot);
+
+                Assert.AreEqual(PackageDownloadHandle.State.Error, packageDownloadHandle.DownloadState);
+                Assert.IsFalse(Directory.Exists(expectedInstallPath));
+                Assert.IsFalse(pkgLoader.LocalPackages.Any(x => x.Name == conflictingPackageName));
+                Assert.AreEqual(PackageLoadState.ScheduledTypes.None, installedPackage.LoadState.ScheduledState);
+                CollectionAssert.AreEquivalent(scheduledUninstallsBeforeInstall, ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall);
+                dlgMock.Verify(m => m.Show(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Error), Times.Once);
+            }
+            finally
+            {
+                MessageBoxService.OverrideMessageBoxDuringTests(null);
+            }
+        }
+
+        [Test]
+        [Description("User accepts replacing an installed package that owns a conflicting custom node GUID")]
+        public void SetPackageStateWhenConflictingCustomNodeInstallAcceptedInstallsPackageForRestart()
+        {
+            var pkgLoader = GetPackageLoader();
+            var installedPackage = LoadCustomRoundingPackage(pkgLoader);
+            var conflictingPackageName = "Conflicting Custom Rounding";
+            var installRoot = Path.Combine(TempFolder, "packages");
+            var zipPath = CreateConflictingCustomNodePackageZip(conflictingPackageName);
+            var expectedInstallPath = GetPackageInstallDirectory(installRoot, conflictingPackageName);
+            var packageDownloadHandle = new PackageDownloadHandle
+            {
+                Name = conflictingPackageName,
+                VersionName = "1.0.0"
+            };
+            packageDownloadHandle.Done(zipPath);
+
+            var dlgMock = new Mock<MessageBoxService.IMessageBox>();
+            dlgMock.Setup(m => m.Show(
+                    It.Is<string>(x => x.Contains(installedPackage.Name) && x.Contains(conflictingPackageName)),
+                    It.IsAny<string>(),
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Error))
+                .Returns(MessageBoxResult.Yes);
+            MessageBoxService.OverrideMessageBoxDuringTests(dlgMock.Object);
+
+            try
+            {
+                var mockGreg = new Mock<IGregClient>();
+                var client = new Dynamo.PackageManager.PackageManagerClient(
+                    mockGreg.Object,
+                    MockMaker.Empty<IPackageUploadBuilder>(),
+                    string.Empty);
+                var pmVm = new PackageManagerClientViewModel(ViewModel, client);
+                pmVm.SetPackageState(packageDownloadHandle, installRoot);
+
+                Assert.AreEqual(PackageDownloadHandle.State.Installed, packageDownloadHandle.DownloadState);
+                Assert.IsTrue(Directory.Exists(expectedInstallPath));
+                Assert.IsTrue(ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.Contains(installedPackage.RootDirectory));
+                Assert.AreEqual(PackageLoadState.ScheduledTypes.ScheduledForDeletion, installedPackage.LoadState.ScheduledState);
+                Assert.IsFalse(pkgLoader.LocalPackages.Any(x => x.Name == conflictingPackageName));
+                Assert.IsFalse(ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.Contains(expectedInstallPath));
+                dlgMock.Verify(m => m.Show(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Error), Times.Once);
+            }
+            finally
+            {
+                MessageBoxService.OverrideMessageBoxDuringTests(null);
             }
         }
 

--- a/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
+++ b/test/DynamoCoreWpf2Tests/PackageManager/PackageManagerUITests.cs
@@ -1716,6 +1716,57 @@ namespace DynamoCoreWpfTests.PackageManager
         }
 
         [Test]
+        [Description("Accepted custom node conflict does not schedule the installed package if extraction cannot finish")]
+        public void SetPackageStateWhenAcceptedConflictingCustomNodeInstallFailsDoesNotScheduleUninstall()
+        {
+            var pkgLoader = GetPackageLoader();
+            var installedPackage = LoadCustomRoundingPackage(pkgLoader);
+            var conflictingPackageName = "Conflicting Custom Rounding";
+            var installRoot = Path.Combine(TempFolder, "packages");
+            var zipPath = CreateConflictingCustomNodePackageZip(conflictingPackageName);
+            var expectedInstallPath = GetPackageInstallDirectory(installRoot, conflictingPackageName);
+            var packageDownloadHandle = new PackageDownloadHandle
+            {
+                Name = conflictingPackageName,
+                VersionName = "1.0.0"
+            };
+            packageDownloadHandle.Done(zipPath);
+
+            Directory.CreateDirectory(expectedInstallPath);
+            File.WriteAllText(Path.Combine(expectedInstallPath, "pkg.json"), "existing file");
+
+            var dlgMock = new Mock<MessageBoxService.IMessageBox>();
+            dlgMock.Setup(m => m.Show(
+                    It.Is<string>(x => x.Contains(installedPackage.Name) && x.Contains(conflictingPackageName)),
+                    It.IsAny<string>(),
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Error))
+                .Returns(MessageBoxResult.Yes);
+            MessageBoxService.OverrideMessageBoxDuringTests(dlgMock.Object);
+
+            try
+            {
+                var scheduledUninstallsBeforeInstall = ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall.ToList();
+                var mockGreg = new Mock<IGregClient>();
+                var client = new Dynamo.PackageManager.PackageManagerClient(
+                    mockGreg.Object,
+                    MockMaker.Empty<IPackageUploadBuilder>(),
+                    string.Empty);
+                var pmVm = new PackageManagerClientViewModel(ViewModel, client);
+
+                Assert.Throws<IOException>(() => pmVm.SetPackageState(packageDownloadHandle, installRoot));
+
+                Assert.AreEqual(PackageLoadState.ScheduledTypes.None, installedPackage.LoadState.ScheduledState);
+                CollectionAssert.AreEquivalent(scheduledUninstallsBeforeInstall, ViewModel.Model.PreferenceSettings.PackageDirectoriesToUninstall);
+                Assert.IsFalse(pkgLoader.LocalPackages.Any(x => x.Name == conflictingPackageName));
+            }
+            finally
+            {
+                MessageBoxService.OverrideMessageBoxDuringTests(null);
+            }
+        }
+
+        [Test]
         [Description("User tries to download package in Dynamo 3.x which was published in Dynamo 2.x")]
         public void PackageManagerShowsWarningWhenDownloadingLegacyPackage()
         {

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -31,6 +32,55 @@ namespace Dynamo.PackageManager.Tests
             libraries.Add("DesignScriptBuiltin.dll");
             libraries.Add("DSCoreNodes.dll");
             base.GetLibrariesToPreload(libraries);
+        }
+
+        [Test]
+        public void ExtractWhenValidationCancelledDeletesStagingDirectory()
+        {
+            var packageName = "CancelledPackage";
+            var zipPath = CreatePackageZip(packageName);
+            var installRoot = Path.Combine(TempFolder, "packages");
+            string stagingPath = null;
+            var handle = new PackageDownloadHandle
+            {
+                Name = packageName,
+                VersionName = "1.0.0"
+            };
+            handle.Done(zipPath);
+
+            var extractionState = handle.Extract(
+                CurrentDynamoModel,
+                installRoot,
+                package =>
+                {
+                    stagingPath = package.RootDirectory;
+                    return false;
+                },
+                out var package);
+
+            Assert.AreEqual(PackageDownloadHandle.ExtractionState.Cancelled, extractionState);
+            Assert.IsNull(package);
+            Assert.IsNotNull(stagingPath);
+            Assert.IsFalse(Directory.Exists(stagingPath));
+            Assert.IsFalse(Directory.Exists(GetPackageInstallDirectory(installRoot, packageName)));
+        }
+
+        private string CreatePackageZip(string packageName)
+        {
+            var packageRoot = Path.Combine(TempFolder, packageName);
+            Directory.CreateDirectory(packageRoot);
+
+            var packageJson = @"{""file_hash"":null,""name"":""" + packageName + @""",""version"":""1.0.0"",""description"":""Test package."",""group"":""DynamoTests"",""keywords"":[],""dependencies"":[],""license"":""MIT"",""contents"":"""",""engine_version"":""0.5.2.10107"",""engine_metadata"":"""",""engine"":""dynamo""}";
+            File.WriteAllText(Path.Combine(packageRoot, "pkg.json"), packageJson);
+
+            var zipPath = Path.Combine(TempFolder, packageName + ".zip");
+            ZipFile.CreateFromDirectory(packageRoot, zipPath);
+            return zipPath;
+        }
+
+        private static string GetPackageInstallDirectory(string packageDirectory, string packageName)
+        {
+            return packageDirectory + @"\" + packageName.Replace("/", "_").Replace(@"\", "_");
         }
 
         [Test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

DYN-7587: Adds focused coverage and cleanup hardening for the package-install path where a staged package contains custom nodes whose GUIDs conflict with an already-loaded package.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Prevents package installs from leaving files behind after rejecting custom node conflicts.

### Reviewers

(FILL ME IN) Reviewer 1 (If possible, assign the Reviewer for the PR)

Focused tests cover rejecting and accepting the custom-node conflict dialog, direct extraction cancellation cleanup, and avoiding stale uninstall scheduling if extraction fails after accepting a conflict.

### FYIs

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bd869a8-dbe2-403e-9fb0-acf4bf860af4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bd869a8-dbe2-403e-9fb0-acf4bf860af4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

