### PR TITLE
DYN-7587: Validate custom node conflicts before package install commit

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -440,6 +440,53 @@ namespace Dynamo.Core
         }
 
         /// <summary>
+        /// Determines whether custom nodes under <paramref name="customNodeDirectory"/> would conflict
+        /// with definitions already registered from a different package (the case that throws
+        /// <see cref="CustomNodePackageLoadException"/> in <see cref="SetNodeInfo"/>).
+        /// </summary>
+        /// <returns>True if any <c>.dyf</c> in the directory shares a function id with an existing
+        /// package member from another package name.</returns>
+        public bool TryGetConflictingPackageCustomNodeInfo(
+            string customNodeDirectory,
+            bool isTestMode,
+            PackageInfo incomingPackageInfo,
+            out CustomNodeInfo conflictingExistingInfo)
+        {
+            conflictingExistingInfo = null;
+            if (string.IsNullOrEmpty(customNodeDirectory)
+                || !Directory.Exists(customNodeDirectory)
+                || incomingPackageInfo == null)
+            {
+                return false;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(customNodeDirectory, "*.dyf"))
+            {
+                CustomNodeInfo newInfo;
+                if (!TryGetInfoFromPath(file, isTestMode, out newInfo))
+                {
+                    continue;
+                }
+
+                CustomNodeInfo existingInfo;
+                if (!NodeInfos.TryGetValue(newInfo.FunctionId, out existingInfo))
+                {
+                    continue;
+                }
+
+                if (existingInfo.IsPackageMember
+                    && existingInfo.PackageInfo != null
+                    && incomingPackageInfo.Name != existingInfo.PackageInfo.Name)
+                {
+                    conflictingExistingInfo = existingInfo;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         ///     Enumerates all of the files in the search path and get's their guids.
         ///     Does not instantiate the nodes.
         /// </summary>

--- a/src/DynamoCore/PublicAPI.Unshipped.txt
+++ b/src/DynamoCore/PublicAPI.Unshipped.txt
@@ -362,6 +362,7 @@ Dynamo.Core.CustomNodeManager.TryGetCustomNodeData(System.Guid id, string name, 
 Dynamo.Core.CustomNodeManager.TryGetFunctionDefinition(System.Guid id, bool isTestMode, out Dynamo.CustomNodeDefinition definition) -> bool
 Dynamo.Core.CustomNodeManager.TryGetFunctionWorkspace(System.Guid id, bool isTestMode, out Dynamo.Graph.Workspaces.CustomNodeWorkspaceModel ws) -> bool
 Dynamo.Core.CustomNodeManager.TryGetFunctionWorkspace(System.Guid id, bool isTestMode, out Dynamo.Graph.Workspaces.ICustomNodeWorkspaceModel ws) -> bool
+Dynamo.Core.CustomNodeManager.TryGetConflictingPackageCustomNodeInfo(string customNodeDirectory, bool isTestMode, Dynamo.Graph.Workspaces.PackageInfo incomingPackageInfo, out Dynamo.CustomNodeInfo conflictingExistingInfo) -> bool
 Dynamo.Core.IDSDKManager
 Dynamo.Core.IDSDKManager.Dispose() -> void
 Dynamo.Core.IDSDKManager.GetAccessToken() -> string

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4692,6 +4692,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package installation was cancelled because one or more custom nodes conflict with another installed package..
+        /// </summary>
+        public static string MessagePackageInstallCancelledDueToCustomNodeConflict {
+            get {
+                return ResourceManager.GetString("MessagePackageInstallCancelledDueToCustomNodeConflict", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to To load the built-in package {1}, {0} needs to first delete any conflicting packages.
         ///
         ///Delete the following packages: {2}?.

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4692,11 +4692,20 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package installation was cancelled because one or more custom nodes conflict with another installed package..
+        ///   Looks up a localized string similar to Installation cancelled due to custom node conflict..
         /// </summary>
         public static string MessagePackageInstallCancelledDueToCustomNodeConflict {
             get {
                 return ResourceManager.GetString("MessagePackageInstallCancelledDueToCustomNodeConflict", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Installed. Restart Dynamo to remove the conflicting package and load this one..
+        /// </summary>
+        public static string MessagePackageInstallRestartToCompleteCustomNodeReplace {
+            get {
+                return ResourceManager.GetString("MessagePackageInstallRestartToCompleteCustomNodeReplace", resourceCulture);
             }
         }
         

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1330,7 +1330,10 @@ You can always redownload the package.</value>
     <value>Failed to load an invalid package.</value>
   </data>
   <data name="MessagePackageInstallCancelledDueToCustomNodeConflict" xml:space="preserve">
-    <value>Package installation was cancelled because one or more custom nodes conflict with another installed package.</value>
+    <value>Installation cancelled due to custom node conflict.</value>
+  </data>
+  <data name="MessagePackageInstallRestartToCompleteCustomNodeReplace" xml:space="preserve">
+    <value>Installed. Restart Dynamo to remove the conflicting package and load this one.</value>
   </data>
   <data name="MessageFailedToFindNodeById" xml:space="preserve">
     <value>No node could be found with that Id.</value>

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1329,6 +1329,9 @@ You can always redownload the package.</value>
   <data name="MessageInvalidPackage" xml:space="preserve">
     <value>Failed to load an invalid package.</value>
   </data>
+  <data name="MessagePackageInstallCancelledDueToCustomNodeConflict" xml:space="preserve">
+    <value>Package installation was cancelled because one or more custom nodes conflict with another installed package.</value>
+  </data>
   <data name="MessageFailedToFindNodeById" xml:space="preserve">
     <value>No node could be found with that Id.</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -979,6 +979,9 @@ You can always redownload the package.</value>
   <data name="MessageInvalidPackage" xml:space="preserve">
     <value>Failed to load an invalid package.</value>
   </data>
+  <data name="MessagePackageInstallCancelledDueToCustomNodeConflict" xml:space="preserve">
+    <value>Package installation was cancelled because one or more custom nodes conflict with another installed package.</value>
+  </data>
   <data name="MessageFailedToDelete" xml:space="preserve">
     <value>{0} failed to delete the package.  You may need to delete the package's root directory manually.</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -980,7 +980,10 @@ You can always redownload the package.</value>
     <value>Failed to load an invalid package.</value>
   </data>
   <data name="MessagePackageInstallCancelledDueToCustomNodeConflict" xml:space="preserve">
-    <value>Package installation was cancelled because one or more custom nodes conflict with another installed package.</value>
+    <value>Installation cancelled due to custom node conflict.</value>
+  </data>
+  <data name="MessagePackageInstallRestartToCompleteCustomNodeReplace" xml:space="preserve">
+    <value>Installed. Restart Dynamo to remove the conflicting package and load this one.</value>
   </data>
   <data name="MessageFailedToDelete" xml:space="preserve">
     <value>{0} failed to delete the package.  You may need to delete the package's root directory manually.</value>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1160,6 +1160,7 @@ namespace Dynamo.ViewModels
 
                         packageDownloadHandle.CompleteInstallation(dynPkg, stagingDirectory, packagesRoot);
                         packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
+                        packageDownloadHandle.ErrorString = Resources.MessagePackageInstallRestartToCompleteCustomNodeReplace;
                         return;
                     }
                 }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1150,7 +1150,7 @@ namespace Dynamo.ViewModels
                         }
 
                         var userChoseReplace =
-                            PackageManagerExtension.PackageLoader.NotifyUserOfConflictingCustomNodePackage(installedPkg, dynPkg);
+                            PackageManagerExtension.PackageLoader.OnConflictingPackageLoaded(installedPkg, dynPkg);
 
                         if (!userChoseReplace)
                         {

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1170,7 +1170,7 @@ namespace Dynamo.ViewModels
             }
             finally
             {
-                PackageDownloadHandle.DiscardStagingDirectory(stagingDirectory);
+                PackageDownloadHandle.DiscardStagingDirectory(stagingDirectory, DynamoViewModel.Model.Logger);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1114,7 +1114,7 @@ namespace Dynamo.ViewModels
         /// Check Dynamo package install state
         /// </summary>
         /// <param name="packageDownloadHandle">package download handle</param>
-        /// <param name="downloadPath">package download path</param>
+        /// <param name="packagesRootDirectory">Root folder for package installation (custom path or empty for default)</param>
         internal void SetPackageState(PackageDownloadHandle packageDownloadHandle, string packagesRootDirectory)
         {
             string stagingDirectory = null;

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1122,7 +1122,6 @@ namespace Dynamo.ViewModels
             {
                 if (!packageDownloadHandle.TryPrepareInstallation(DynamoViewModel.Model, out var dynPkg, out stagingDirectory))
                 {
-                    packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
                     packageDownloadHandle.Error(Resources.MessageInvalidPackage);
                     return;
                 }
@@ -1146,7 +1145,6 @@ namespace Dynamo.ViewModels
 
                         if (installedPkg == null)
                         {
-                            packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
                             packageDownloadHandle.Error(Resources.MessagePackageInstallCancelledDueToCustomNodeConflict);
                             return;
                         }
@@ -1156,7 +1154,6 @@ namespace Dynamo.ViewModels
 
                         if (!userChoseReplace)
                         {
-                            packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
                             packageDownloadHandle.Error(Resources.MessagePackageInstallCancelledDueToCustomNodeConflict);
                             return;
                         }

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1135,7 +1135,7 @@ namespace Dynamo.ViewModels
                     var incomingInfo = new PackageInfo(dynPkg.Name, new Version(dynPkg.VersionName));
                     if (DynamoViewModel.Model.CustomNodeManager.TryGetConflictingPackageCustomNodeInfo(
                             dynPkg.CustomNodeDirectory,
-                            DynamoViewModel.Model.IsTestMode,
+                            DynamoModel.IsTestMode,
                             incomingInfo,
                             out var conflictingExisting))
                     {

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1115,18 +1115,65 @@ namespace Dynamo.ViewModels
         /// </summary>
         /// <param name="packageDownloadHandle">package download handle</param>
         /// <param name="downloadPath">package download path</param>
-        internal void SetPackageState(PackageDownloadHandle packageDownloadHandle, string downloadPath)
+        internal void SetPackageState(PackageDownloadHandle packageDownloadHandle, string packagesRootDirectory)
         {
-            Package dynPkg;
-            if (packageDownloadHandle.Extract(DynamoViewModel.Model, downloadPath, out dynPkg))
+            string stagingDirectory = null;
+            try
             {
+                if (!packageDownloadHandle.TryPrepareInstallation(DynamoViewModel.Model, out var dynPkg, out stagingDirectory))
+                {
+                    packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
+                    packageDownloadHandle.Error(Resources.MessageInvalidPackage);
+                    return;
+                }
+
+                var packagesRoot = string.IsNullOrEmpty(packagesRootDirectory)
+                    ? DynamoViewModel.Model.PathManager.DefaultPackagesDirectory
+                    : packagesRootDirectory;
+
+                if (Directory.Exists(dynPkg.CustomNodeDirectory))
+                {
+                    var incomingInfo = new PackageInfo(dynPkg.Name, new Version(dynPkg.VersionName));
+                    if (DynamoViewModel.Model.CustomNodeManager.TryGetConflictingPackageCustomNodeInfo(
+                            dynPkg.CustomNodeDirectory,
+                            DynamoViewModel.Model.IsTestMode,
+                            incomingInfo,
+                            out var conflictingExisting))
+                    {
+                        var existingDyfDir = Path.GetDirectoryName(conflictingExisting.Path);
+                        var installedPkg = PackageManagerExtension.PackageLoader.LocalPackages.FirstOrDefault(
+                            p => string.Equals(p.CustomNodeDirectory, existingDyfDir, StringComparison.OrdinalIgnoreCase));
+
+                        if (installedPkg == null)
+                        {
+                            packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
+                            packageDownloadHandle.Error(Resources.MessagePackageInstallCancelledDueToCustomNodeConflict);
+                            return;
+                        }
+
+                        var userChoseReplace =
+                            PackageManagerExtension.PackageLoader.NotifyUserOfConflictingCustomNodePackage(installedPkg, dynPkg);
+
+                        if (!userChoseReplace)
+                        {
+                            packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
+                            packageDownloadHandle.Error(Resources.MessagePackageInstallCancelledDueToCustomNodeConflict);
+                            return;
+                        }
+
+                        packageDownloadHandle.CompleteInstallation(dynPkg, stagingDirectory, packagesRoot);
+                        packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
+                        return;
+                    }
+                }
+
+                packageDownloadHandle.CompleteInstallation(dynPkg, stagingDirectory, packagesRoot);
                 PackageManagerExtension.PackageLoader.LoadPackages(new List<Package> { dynPkg });
                 packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
             }
-            else
+            finally
             {
-                packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
-                packageDownloadHandle.Error(Resources.MessageInvalidPackage);
+                PackageDownloadHandle.DiscardStagingDirectory(stagingDirectory);
             }
         }
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -1424,7 +1424,7 @@ namespace Dynamo.PackageManager
         {
             SearchResults.CollectionChanged += SearchResultsOnCollectionChanged;
             PackageManagerClientViewModel.Downloads.CollectionChanged += DownloadsOnCollectionChanged;
-            PackageManagerClientViewModel.PackageManagerExtension.PackageLoader.ConflictingCustomNodePackageLoaded +=
+            PackageManagerClientViewModel.PackageManagerExtension.PackageLoader.ConflictingCustomNodePackageResolutionCallback =
                 ConflictingCustomNodePackageLoaded;
         }
 
@@ -1432,8 +1432,7 @@ namespace Dynamo.PackageManager
         {
             SearchResults.CollectionChanged -= SearchResultsOnCollectionChanged;
             PackageManagerClientViewModel.Downloads.CollectionChanged -= DownloadsOnCollectionChanged;
-            PackageManagerClientViewModel.PackageManagerExtension.PackageLoader.ConflictingCustomNodePackageLoaded -=
-                ConflictingCustomNodePackageLoaded;
+            PackageManagerClientViewModel.PackageManagerExtension.PackageLoader.ConflictingCustomNodePackageResolutionCallback = null;
         }
 
         /// <summary>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerSearchViewModel.cs
@@ -1268,8 +1268,13 @@ namespace Dynamo.PackageManager
             return String.Join("\r\n", packages.Select(x => x.Item1.name + " " + x.Item2.version));
         }
 
-        private void ConflictingCustomNodePackageLoaded(Package installed, Package conflicting)
+        private bool ConflictingCustomNodePackageLoaded(Package installed, Package conflicting)
         {
+            if (installed == null || conflicting == null)
+            {
+                return false;
+            }
+
             var message = string.Format(Resources.MessageUninstallCustomNodeToContinue,
                 installed.Name + " " + installed.VersionName, conflicting.Name + " " + conflicting.VersionName);
 
@@ -1282,7 +1287,10 @@ namespace Dynamo.PackageManager
                 // mark for uninstallation
                 var settings = PackageManagerClientViewModel.DynamoViewModel.Model.PreferenceSettings;
                 installed.MarkForUninstall(settings);
+                return true;
             }
+
+            return false;
         }
 
         private void DownloadsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)

--- a/src/DynamoPackages/PackageDownloadHandle.cs
+++ b/src/DynamoPackages/PackageDownloadHandle.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Dynamo.Logging;
 using Dynamo.Models;
 
 using Greg.Responses;
@@ -98,7 +99,7 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// Unzips the downloaded package to a staging directory and parses <c>pkg.json</c>.
         /// The caller must delete <paramref name="stagingDirectory"/> with
-        /// <see cref="DiscardStagingDirectory"/> when installation is aborted or after
+        /// <see cref="DiscardStagingDirectory"/> (pass <paramref name="dynamoModel"/>.Logger) when installation is aborted or after
         /// <see cref="CompleteInstallation"/> (which leaves the staging folder in place — discard afterward).
         /// </summary>
         public bool TryPrepareInstallation(DynamoModel dynamoModel, out Package pkg, out string stagingDirectory)
@@ -154,7 +155,9 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// Deletes a staging directory created by <see cref="TryPrepareInstallation"/>.
         /// </summary>
-        public static void DiscardStagingDirectory(string stagingDirectory)
+        /// <param name="stagingDirectory">Path to remove.</param>
+        /// <param name="logger">Optional logger for delete failures (same style as other package directory cleanup).</param>
+        public static void DiscardStagingDirectory(string stagingDirectory, ILogger logger)
         {
             if (string.IsNullOrEmpty(stagingDirectory) || !Directory.Exists(stagingDirectory))
             {
@@ -165,11 +168,23 @@ namespace Dynamo.PackageManager
             {
                 Directory.Delete(stagingDirectory, true);
             }
-            catch (IOException)
+            catch (IOException ex)
             {
+                logger?.LogWarning(
+                    string.Format(
+                        "Failed to delete package staging directory at \"{0}\". {1}",
+                        stagingDirectory,
+                        ex.Message),
+                    WarningLevel.Moderate);
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException ex)
             {
+                logger?.LogWarning(
+                    string.Format(
+                        "Failed to delete package staging directory at \"{0}\". {1}",
+                        stagingDirectory,
+                        ex.Message),
+                    WarningLevel.Moderate);
             }
         }
 
@@ -200,7 +215,7 @@ namespace Dynamo.PackageManager
             }
             finally
             {
-                DiscardStagingDirectory(stagingDirectory);
+                DiscardStagingDirectory(stagingDirectory, dynamoModel.Logger);
             }
         }
 

--- a/src/DynamoPackages/PackageDownloadHandle.cs
+++ b/src/DynamoPackages/PackageDownloadHandle.cs
@@ -165,9 +165,11 @@ namespace Dynamo.PackageManager
             {
                 Directory.Delete(stagingDirectory, true);
             }
-            catch
+            catch (IOException)
             {
-                // Best-effort cleanup; avoid blocking package manager UX on locked files.
+            }
+            catch (UnauthorizedAccessException)
+            {
             }
         }
 

--- a/src/DynamoPackages/PackageDownloadHandle.cs
+++ b/src/DynamoPackages/PackageDownloadHandle.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using Dynamo.Core;
 using Dynamo.Models;
 
 using Greg.Responses;
@@ -97,6 +96,82 @@ namespace Dynamo.PackageManager
         }
 
         /// <summary>
+        /// Unzips the downloaded package to a staging directory and parses <c>pkg.json</c>.
+        /// The caller must delete <paramref name="stagingDirectory"/> with
+        /// <see cref="DiscardStagingDirectory"/> when installation is aborted or after
+        /// <see cref="CompleteInstallation"/> (which leaves the staging folder in place — discard afterward).
+        /// </summary>
+        public bool TryPrepareInstallation(DynamoModel dynamoModel, out Package pkg, out string stagingDirectory)
+        {
+            pkg = null;
+            stagingDirectory = null;
+            this.DownloadState = State.Installing;
+
+            var unzipPath = Greg.Utility.FileUtilities.UnZip(DownloadPath);
+            if (!Directory.Exists(unzipPath))
+            {
+                throw new Exception(Properties.Resources.PackageEmpty);
+            }
+
+            stagingDirectory = unzipPath;
+            pkg = Package.FromDirectory(unzipPath, dynamoModel.Logger);
+            return pkg != null;
+        }
+
+        /// <summary>
+        /// Copies a staged package into the Dynamo packages directory tree and sets <paramref name="pkg"/>.RootDirectory.
+        /// </summary>
+        /// <param name="pkg">Package metadata (initially rooted at the staging folder).</param>
+        /// <param name="stagingDirectory">Path returned from <see cref="TryPrepareInstallation"/>.</param>
+        /// <param name="packagesRootDirectory">Root packages folder (e.g. default or custom package path).</param>
+        public void CompleteInstallation(Package pkg, string stagingDirectory, string packagesRootDirectory)
+        {
+            if (pkg == null)
+            {
+                throw new ArgumentNullException(nameof(pkg));
+            }
+            if (string.IsNullOrEmpty(stagingDirectory))
+            {
+                throw new ArgumentException("Staging directory is required.", nameof(stagingDirectory));
+            }
+
+            var installedPath = BuildInstallDirectoryString(packagesRootDirectory, pkg.Name);
+            Directory.CreateDirectory(installedPath);
+
+            foreach (string dirPath in Directory.GetDirectories(stagingDirectory, "*", SearchOption.AllDirectories))
+            {
+                Directory.CreateDirectory(dirPath.Replace(stagingDirectory, installedPath));
+            }
+
+            foreach (string newPath in Directory.GetFiles(stagingDirectory, "*.*", SearchOption.AllDirectories))
+            {
+                File.Copy(newPath, newPath.Replace(stagingDirectory, installedPath));
+            }
+
+            pkg.RootDirectory = installedPath;
+        }
+
+        /// <summary>
+        /// Deletes a staging directory created by <see cref="TryPrepareInstallation"/>.
+        /// </summary>
+        public static void DiscardStagingDirectory(string stagingDirectory)
+        {
+            if (string.IsNullOrEmpty(stagingDirectory) || !Directory.Exists(stagingDirectory))
+            {
+                return;
+            }
+
+            try
+            {
+                Directory.Delete(stagingDirectory, true);
+            }
+            catch
+            {
+                // Best-effort cleanup; avoid blocking package manager UX on locked files.
+            }
+        }
+
+        /// <summary>
         /// Extracts and parses the metadata of a downloaded package
         /// </summary>
         /// <param name="dynamoModel">Dynamo model</param>
@@ -105,41 +180,26 @@ namespace Dynamo.PackageManager
         /// <returns>Whether the operation succeeded or not</returns>
         public bool Extract(DynamoModel dynamoModel, string installDirectory, out Package pkg)
         {
-            this.DownloadState = State.Installing;
-
-            // unzip, place files
-            var unzipPath = Greg.Utility.FileUtilities.UnZip(DownloadPath);
-            if (!Directory.Exists(unzipPath))
+            string stagingDirectory = null;
+            try
             {
-                throw new Exception(Properties.Resources.PackageEmpty);
+                if (!TryPrepareInstallation(dynamoModel, out pkg, out stagingDirectory))
+                {
+                    return false;
+                }
+
+                if (String.IsNullOrEmpty(installDirectory))
+                {
+                    installDirectory = dynamoModel.PathManager.DefaultPackagesDirectory;
+                }
+
+                CompleteInstallation(pkg, stagingDirectory, installDirectory);
+                return true;
             }
-
-            // provide handle to installed package 
-            pkg = Package.FromDirectory(unzipPath, dynamoModel.Logger);
-
-            if (pkg == null)
+            finally
             {
-                return false;
+                DiscardStagingDirectory(stagingDirectory);
             }
-
-            if (String.IsNullOrEmpty(installDirectory))
-                installDirectory = dynamoModel.PathManager.DefaultPackagesDirectory;
-
-            var installedPath = BuildInstallDirectoryString(installDirectory, pkg.Name);
-            Directory.CreateDirectory(installedPath);
-
-            // Now create all of the directories
-            foreach (string dirPath in Directory.GetDirectories(unzipPath, "*", SearchOption.AllDirectories))
-                Directory.CreateDirectory(dirPath.Replace(unzipPath, installedPath));
-
-            // Copy all the files
-            foreach (string newPath in Directory.GetFiles(unzipPath, "*.*", SearchOption.AllDirectories))
-                File.Copy(newPath, newPath.Replace(unzipPath, installedPath));
-
-            // Update root directory to final path
-            pkg.RootDirectory = installedPath;
-
-            return true;
         }
 
         // cancel, install, redownload

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -329,9 +329,9 @@ namespace Dynamo.PackageManager
             }
 
             var acceptReplace = false;
-            foreach (Func<Package, Package, bool> del in handler.GetInvocationList())
+            foreach (Delegate del in handler.GetInvocationList())
             {
-                if (del.Invoke(installed, conflicting))
+                if (del is Func<Package, Package, bool> callback && callback(installed, conflicting))
                 {
                     acceptReplace = true;
                 }

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -312,25 +312,30 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// Event raised when a custom node package containing conflicting node definition
         /// with an existing package is tried to load.
-        /// Handlers return true if the user accepts replacing the installed package after restart (Yes).
         /// </summary>
-        public event Func<Package, Package, bool> ConflictingCustomNodePackageLoaded;
+        public event Action<Package, Package> ConflictingCustomNodePackageLoaded;
 
         /// <summary>
-        /// Invokes <see cref="ConflictingCustomNodePackageLoaded"/> (e.g. conflict dialog). Does not change package load state.
+        /// Optional resolver (e.g. Package Manager UI). When set, it runs instead of only firing
+        /// <see cref="ConflictingCustomNodePackageLoaded"/> and supplies whether the user accepts
+        /// replacing the installed package after restart (true = Yes). When null, subscribers are
+        /// notified via the event and the conflict handler returns false.
+        /// </summary>
+        public Func<Package, Package, bool> ConflictingCustomNodePackageResolutionCallback { get; set; }
+
+        /// <summary>
+        /// Invokes conflict resolution / notification. Does not change package load state.
         /// </summary>
         /// <returns>True if the user accepts replacing the installed package after restart (Yes).</returns>
         internal bool OnConflictingPackageLoaded(Package installed, Package conflicting)
         {
-            var handler = ConflictingCustomNodePackageLoaded;
-            if (handler == null)
+            if (ConflictingCustomNodePackageResolutionCallback != null)
             {
-                return false;
+                return ConflictingCustomNodePackageResolutionCallback(installed, conflicting);
             }
 
-            return handler.GetInvocationList()
-                .OfType<Func<Package, Package, bool>>()
-                .Any(func => func(installed, conflicting));
+            ConflictingCustomNodePackageLoaded?.Invoke(installed, conflicting);
+            return false;
         }
 
         /// <summary>

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -328,16 +328,9 @@ namespace Dynamo.PackageManager
                 return false;
             }
 
-            var acceptReplace = false;
-            foreach (Delegate del in handler.GetInvocationList())
-            {
-                if (del is Func<Package, Package, bool> callback && callback(installed, conflicting))
-                {
-                    acceptReplace = true;
-                }
-            }
-
-            return acceptReplace;
+            return handler.GetInvocationList()
+                .OfType<Func<Package, Package, bool>>()
+                .Any(func => func(installed, conflicting));
         }
 
         /// <summary>

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -292,7 +292,7 @@ namespace Dynamo.PackageManager
             {
                 Package originalPackage =
                     localPackages.FirstOrDefault(x => x.CustomNodeDirectory == e.InstalledPath);
-                OnConflictingPackageLoaded(originalPackage, package);
+                NotifyUserOfConflictingCustomNodePackage(originalPackage, package);
 
                 package.LoadState.SetAsError(e.Message);
             }
@@ -312,12 +312,37 @@ namespace Dynamo.PackageManager
         /// <summary>
         /// Event raised when a custom node package containing conflicting node definition
         /// with an existing package is tried to load.
+        /// Handlers return true if the user accepts replacing the installed package after restart (Yes).
         /// </summary>
-        public event Action<Package, Package> ConflictingCustomNodePackageLoaded;
-        private void OnConflictingPackageLoaded(Package installed, Package conflicting)
+        public event Func<Package, Package, bool> ConflictingCustomNodePackageLoaded;
+
+        private bool OnConflictingPackageLoaded(Package installed, Package conflicting)
         {
             var handler = ConflictingCustomNodePackageLoaded;
-            handler?.Invoke(installed, conflicting);
+            if (handler == null)
+            {
+                return false;
+            }
+
+            var acceptReplace = false;
+            foreach (Func<Package, Package, bool> del in handler.GetInvocationList())
+            {
+                if (del.Invoke(installed, conflicting))
+                {
+                    acceptReplace = true;
+                }
+            }
+
+            return acceptReplace;
+        }
+
+        /// <summary>
+        /// Runs the same conflict UI as a failed custom node load, without mutating package load state.
+        /// </summary>
+        /// <returns>True if the user chose to replace the installed package after restart.</returns>
+        public bool NotifyUserOfConflictingCustomNodePackage(Package installedPackage, Package conflictingPackage)
+        {
+            return OnConflictingPackageLoaded(installedPackage, conflictingPackage);
         }
 
         /// <summary>

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -292,7 +292,7 @@ namespace Dynamo.PackageManager
             {
                 Package originalPackage =
                     localPackages.FirstOrDefault(x => x.CustomNodeDirectory == e.InstalledPath);
-                NotifyUserOfConflictingCustomNodePackage(originalPackage, package);
+                OnConflictingPackageLoaded(originalPackage, package);
 
                 package.LoadState.SetAsError(e.Message);
             }
@@ -316,7 +316,11 @@ namespace Dynamo.PackageManager
         /// </summary>
         public event Func<Package, Package, bool> ConflictingCustomNodePackageLoaded;
 
-        private bool OnConflictingPackageLoaded(Package installed, Package conflicting)
+        /// <summary>
+        /// Invokes <see cref="ConflictingCustomNodePackageLoaded"/> (e.g. conflict dialog). Does not change package load state.
+        /// </summary>
+        /// <returns>True if the user accepts replacing the installed package after restart (Yes).</returns>
+        internal bool OnConflictingPackageLoaded(Package installed, Package conflicting)
         {
             var handler = ConflictingCustomNodePackageLoaded;
             if (handler == null)
@@ -334,15 +338,6 @@ namespace Dynamo.PackageManager
             }
 
             return acceptReplace;
-        }
-
-        /// <summary>
-        /// Runs the same conflict UI as a failed custom node load, without mutating package load state.
-        /// </summary>
-        /// <returns>True if the user chose to replace the installed package after restart.</returns>
-        public bool NotifyUserOfConflictingCustomNodePackage(Package installedPackage, Package conflictingPackage)
-        {
-            return OnConflictingPackageLoaded(installedPackage, conflictingPackage);
         }
 
         /// <summary>

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -607,6 +607,83 @@ namespace Dynamo.PackageManager.Tests
         }
 
         [Test]
+        public void TryGetConflictingPackageCustomNodeInfoDetectsDifferentPackageSameGuid()
+        {
+            var pathManager = new Mock<IPathManager>();
+            pathManager.SetupGet(x => x.PackagesDirectories).Returns(
+                () => new List<string> { PackagesDirectory });
+
+            var loader = new PackageLoader(pathManager.Object);
+            var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
+
+            loader.PackagesLoaded += libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary += libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+
+            Func<string, PackageInfo, IEnumerable<CustomNodeInfo>> reqLoadCNDelegate = (dir, pkgInfo) =>
+                CurrentDynamoModel.CustomNodeManager.AddUninitializedCustomNodesInPath(dir, isTestMode: false, packageInfo: pkgInfo);
+            loader.RequestLoadCustomNodeDirectory += reqLoadCNDelegate;
+
+            loader.LoadAll(new LoadPackageParams
+            {
+                Preferences = CurrentDynamoModel.PreferenceSettings,
+            });
+
+            var evenOdd2Dyf = Path.Combine(TestDirectory, "pkgs", "EvenOdd2", "dyf");
+            var incomingInfo = new PackageInfo("EvenOdd2", new System.Version(1, 0, 0));
+            var hasConflict = CurrentDynamoModel.CustomNodeManager.TryGetConflictingPackageCustomNodeInfo(
+                evenOdd2Dyf,
+                false,
+                incomingInfo,
+                out var conflicting);
+
+            Assert.IsTrue(hasConflict);
+            Assert.IsNotNull(conflicting);
+            Assert.AreEqual("EvenOdd", conflicting.PackageInfo.Name);
+
+            loader.PackagesLoaded -= libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary -= libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+            loader.RequestLoadCustomNodeDirectory -= reqLoadCNDelegate;
+        }
+
+        [Test]
+        public void TryGetConflictingPackageCustomNodeInfoReturnsFalseForSamePackageName()
+        {
+            var pathManager = new Mock<IPathManager>();
+            pathManager.SetupGet(x => x.PackagesDirectories).Returns(
+                () => new List<string> { PackagesDirectory });
+
+            var loader = new PackageLoader(pathManager.Object);
+            var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
+
+            loader.PackagesLoaded += libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary += libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+
+            Func<string, PackageInfo, IEnumerable<CustomNodeInfo>> reqLoadCNDelegate = (dir, pkgInfo) =>
+                CurrentDynamoModel.CustomNodeManager.AddUninitializedCustomNodesInPath(dir, isTestMode: false, packageInfo: pkgInfo);
+            loader.RequestLoadCustomNodeDirectory += reqLoadCNDelegate;
+
+            loader.LoadAll(new LoadPackageParams
+            {
+                Preferences = CurrentDynamoModel.PreferenceSettings,
+            });
+
+            var evenOddDyf = Path.Combine(TestDirectory, "pkgs", "EvenOdd", "dyf");
+            var incomingInfo = new PackageInfo("EvenOdd", new System.Version(1, 0, 0));
+            var hasConflict = CurrentDynamoModel.CustomNodeManager.TryGetConflictingPackageCustomNodeInfo(
+                evenOddDyf,
+                false,
+                incomingInfo,
+                out var conflicting);
+
+            Assert.IsFalse(hasConflict);
+            Assert.IsNull(conflicting);
+
+            loader.PackagesLoaded -= libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary -= libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+            loader.RequestLoadCustomNodeDirectory -= reqLoadCNDelegate;
+        }
+
+        [Test]
         public void PlacingCustomNodeInstanceFromPackageRetainsCorrectPackageInfoState()
         {
             var loader = GetPackageLoader();

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -610,9 +610,9 @@ namespace Dynamo.PackageManager.Tests
         [Test]
         public void StagedCustomNodeConflict_UserDeclinesInstall_DoesNotCopyPackageAndRemovesStaging()
         {
+            // Load test packages (EvenOdd has a custom node that EvenOdd2 duplicates by GUID).
             var pathManager = new Mock<IPathManager>();
-            pathManager.SetupGet(x => x.PackagesDirectories).Returns(
-                () => new List<string> { PackagesDirectory });
+            pathManager.SetupGet(x => x.PackagesDirectories).Returns(() => new List<string> { PackagesDirectory });
 
             var loader = new PackageLoader(pathManager.Object);
             var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
@@ -630,11 +630,12 @@ namespace Dynamo.PackageManager.Tests
             });
 
             var evenOddInstalled = loader.LocalPackages.FirstOrDefault(p => p.Name == "EvenOdd");
-            Assert.IsNotNull(evenOddInstalled, "Test requires EvenOdd package in test/pkgs.");
+            Assert.IsNotNull(evenOddInstalled);
             var prefs = CurrentDynamoModel.PreferenceSettings;
             var evenOddRoot = evenOddInstalled.RootDirectory;
             var uninstallListedEvenOddBefore = prefs.PackageDirectoriesToUninstall.Contains(evenOddRoot);
 
+            // Simulate a downloaded package: zip EvenOdd2, then stage (unzip) like PackageDownloadHandle.
             var evenOdd2Source = Path.Combine(PackagesDirectory, "EvenOdd2");
             var compressor = new MutatingFileCompressor();
             var zipFile = compressor.Zip(new RealDirectoryInfo(new DirectoryInfo(evenOdd2Source)));
@@ -646,6 +647,7 @@ namespace Dynamo.PackageManager.Tests
             Assert.IsTrue(downloadHandle.TryPrepareInstallation(CurrentDynamoModel, out var stagedPkg, out var stagingDir));
             Assert.IsTrue(Directory.Exists(stagingDir));
 
+            // Precheck: same rule as PackageManagerClientViewModel before CompleteInstallation.
             var incomingInfo = new PackageInfo("EvenOdd2", new System.Version(1, 0, 0));
             Assert.IsTrue(CurrentDynamoModel.CustomNodeManager.TryGetConflictingPackageCustomNodeInfo(
                 stagedPkg.CustomNodeDirectory,
@@ -654,16 +656,13 @@ namespace Dynamo.PackageManager.Tests
                 out var conflicting));
             Assert.AreEqual("EvenOdd", conflicting.PackageInfo.Name);
 
-            // User chose No: do not commit; remove staging (mirrors PackageManagerClientViewModel finally).
+            // User chose No: do not commit, remove staging (matches production finally).
             PackageDownloadHandle.DiscardStagingDirectory(stagingDir, CurrentDynamoModel.Logger);
 
             var committedPath = Path.Combine(packagesInstallRoot, "EvenOdd2");
-            Assert.IsFalse(Directory.Exists(committedPath), "Package must not be copied when install is declined.");
-            Assert.IsFalse(Directory.Exists(stagingDir), "Staging directory should be deleted.");
-            Assert.AreEqual(
-                uninstallListedEvenOddBefore,
-                prefs.PackageDirectoriesToUninstall.Contains(evenOddRoot),
-                "Declining install must not mark the existing package for uninstall.");
+            Assert.IsFalse(Directory.Exists(committedPath));
+            Assert.IsFalse(Directory.Exists(stagingDir));
+            Assert.AreEqual(uninstallListedEvenOddBefore, prefs.PackageDirectoriesToUninstall.Contains(evenOddRoot));
 
             loader.PackagesLoaded -= libraryLoader.LoadPackages;
             loader.RequestLoadNodeLibrary -= libraryLoader.LoadLibraryAndSuppressZTSearchImport;
@@ -674,8 +673,7 @@ namespace Dynamo.PackageManager.Tests
         public void StagedCustomNodeConflict_UserAcceptsReplace_CopiesNewPackageAndMarksExistingForUninstallOnRestart()
         {
             var pathManager = new Mock<IPathManager>();
-            pathManager.SetupGet(x => x.PackagesDirectories).Returns(
-                () => new List<string> { PackagesDirectory });
+            pathManager.SetupGet(x => x.PackagesDirectories).Returns(() => new List<string> { PackagesDirectory });
 
             var loader = new PackageLoader(pathManager.Object);
             var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
@@ -693,9 +691,11 @@ namespace Dynamo.PackageManager.Tests
             });
 
             var evenOddInstalled = loader.LocalPackages.FirstOrDefault(p => p.Name == "EvenOdd");
-            Assert.IsNotNull(evenOddInstalled, "Test requires EvenOdd package in test/pkgs.");
+            Assert.IsNotNull(evenOddInstalled);
+
             var prefs = CurrentDynamoModel.PreferenceSettings;
             var evenOddRoot = evenOddInstalled.RootDirectory;
+            // Isolate uninstall-list assertion for this test.
             prefs.PackageDirectoriesToUninstall.RemoveAll(x => x.Equals(evenOddRoot));
 
             var evenOdd2Source = Path.Combine(PackagesDirectory, "EvenOdd2");
@@ -714,21 +714,19 @@ namespace Dynamo.PackageManager.Tests
                 incomingInfo,
                 out _));
 
-            // User chose Yes: same as ConflictingCustomNodePackageLoaded handler — mark existing for removal after restart.
+            // User chose Yes — same side effect as ConflictingCustomNodePackageLoaded (Yes): schedule old package removal.
             evenOddInstalled.MarkForUninstall(prefs);
+            // Commit to disk; production skips LoadPackages until restart.
             downloadHandle.CompleteInstallation(stagedPkg, stagingDir, packagesInstallRoot);
             PackageDownloadHandle.DiscardStagingDirectory(stagingDir, CurrentDynamoModel.Logger);
 
             var committedPath = Path.Combine(packagesInstallRoot, "EvenOdd2");
-            Assert.IsTrue(Directory.Exists(committedPath), "Staged package should be committed when user accepts replace.");
+            Assert.IsTrue(Directory.Exists(committedPath));
             Assert.IsTrue(File.Exists(Path.Combine(committedPath, "pkg.json")));
-            Assert.IsFalse(Directory.Exists(stagingDir), "Staging directory should be deleted after commit.");
-            Assert.IsTrue(
-                prefs.PackageDirectoriesToUninstall.Contains(evenOddRoot),
-                "Existing package root should be scheduled for uninstall on next startup.");
-            Assert.IsFalse(
-                loader.LocalPackages.Any(p => p.Name == "EvenOdd2"),
-                "New package must not be added to LocalPackages this session (loads after restart).");
+            Assert.IsFalse(Directory.Exists(stagingDir));
+            Assert.IsTrue(prefs.PackageDirectoriesToUninstall.Contains(evenOddRoot));
+            // New package is not registered in this session (SetPackageState does not call LoadPackages here).
+            Assert.IsFalse(loader.LocalPackages.Any(p => p.Name == "EvenOdd2"));
 
             loader.PackagesLoaded -= libraryLoader.LoadPackages;
             loader.RequestLoadNodeLibrary -= libraryLoader.LoadLibraryAndSuppressZTSearchImport;
@@ -738,9 +736,9 @@ namespace Dynamo.PackageManager.Tests
         [Test]
         public void TryGetConflictingPackageCustomNodeInfoReturnsFalseForSamePackageName()
         {
+            // Same package name re-scan should not count as a cross-package conflict.
             var pathManager = new Mock<IPathManager>();
-            pathManager.SetupGet(x => x.PackagesDirectories).Returns(
-                () => new List<string> { PackagesDirectory });
+            pathManager.SetupGet(x => x.PackagesDirectories).Returns(() => new List<string> { PackagesDirectory });
 
             var loader = new PackageLoader(pathManager.Object);
             var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -608,7 +608,7 @@ namespace Dynamo.PackageManager.Tests
         }
 
         [Test]
-        public void StagedCustomNodeConflict_UserDeclinesInstall_DoesNotCopyPackageAndRemovesStaging()
+        public void DecliningStagedCustomNodeConflictPackageDoesNotCommitAndRemovesStaging()
         {
             // Load test packages (EvenOdd has a custom node that EvenOdd2 duplicates by GUID).
             var pathManager = new Mock<IPathManager>();
@@ -670,7 +670,7 @@ namespace Dynamo.PackageManager.Tests
         }
 
         [Test]
-        public void StagedCustomNodeConflict_UserAcceptsReplace_CopiesNewPackageAndMarksExistingForUninstallOnRestart()
+        public void AcceptingStagedCustomNodeConflictPackageCommitsAndMarksExistingForUninstall()
         {
             var pathManager = new Mock<IPathManager>();
             pathManager.SetupGet(x => x.PackagesDirectories).Returns(() => new List<string> { PackagesDirectory });

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -660,9 +660,20 @@ namespace Dynamo.PackageManager.Tests
             PackageDownloadHandle.DiscardStagingDirectory(stagingDir, CurrentDynamoModel.Logger);
 
             var committedPath = Path.Combine(packagesInstallRoot, "EvenOdd2");
-            Assert.IsFalse(Directory.Exists(committedPath));
             Assert.IsFalse(Directory.Exists(stagingDir));
             Assert.AreEqual(uninstallListedEvenOddBefore, prefs.PackageDirectoriesToUninstall.Contains(evenOddRoot));
+
+            // Without CompleteInstallation, EvenOdd2 would not appear under packagesInstallRoot anyway.
+            // Prove the install root is valid by committing the same package in a second pass: if this
+            // succeeds, the earlier absence of committedPath was due to skipping commit on decline, not a bad path.
+            Assert.IsFalse(Directory.Exists(committedPath));
+            var zipFileControl = compressor.Zip(new RealDirectoryInfo(new DirectoryInfo(evenOdd2Source)));
+            var downloadHandleControl = new PackageDownloadHandle { DownloadPath = zipFileControl.Name };
+            Assert.IsTrue(downloadHandleControl.TryPrepareInstallation(CurrentDynamoModel, out var stagedPkgControl, out var stagingDirControl));
+            downloadHandleControl.CompleteInstallation(stagedPkgControl, stagingDirControl, packagesInstallRoot);
+            PackageDownloadHandle.DiscardStagingDirectory(stagingDirControl, CurrentDynamoModel.Logger);
+            Assert.IsTrue(Directory.Exists(committedPath));
+            Assert.IsTrue(File.Exists(Path.Combine(committedPath, "pkg.json")));
 
             loader.PackagesLoaded -= libraryLoader.LoadPackages;
             loader.RequestLoadNodeLibrary -= libraryLoader.LoadLibraryAndSuppressZTSearchImport;

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -13,6 +13,7 @@ using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.Interfaces;
 using Dynamo.Search.SearchElements;
+using Dynamo.PackageManager;
 using Moq;
 using NUnit.Framework;
 
@@ -607,7 +608,7 @@ namespace Dynamo.PackageManager.Tests
         }
 
         [Test]
-        public void TryGetConflictingPackageCustomNodeInfoDetectsDifferentPackageSameGuid()
+        public void StagedCustomNodeConflict_UserDeclinesInstall_DoesNotCopyPackageAndRemovesStaging()
         {
             var pathManager = new Mock<IPathManager>();
             pathManager.SetupGet(x => x.PackagesDirectories).Returns(
@@ -628,17 +629,106 @@ namespace Dynamo.PackageManager.Tests
                 Preferences = CurrentDynamoModel.PreferenceSettings,
             });
 
-            var evenOdd2Dyf = Path.Combine(TestDirectory, "pkgs", "EvenOdd2", "dyf");
+            var evenOddInstalled = loader.LocalPackages.FirstOrDefault(p => p.Name == "EvenOdd");
+            Assert.IsNotNull(evenOddInstalled, "Test requires EvenOdd package in test/pkgs.");
+            var prefs = CurrentDynamoModel.PreferenceSettings;
+            var evenOddRoot = evenOddInstalled.RootDirectory;
+            var uninstallListedEvenOddBefore = prefs.PackageDirectoriesToUninstall.Contains(evenOddRoot);
+
+            var evenOdd2Source = Path.Combine(PackagesDirectory, "EvenOdd2");
+            var compressor = new MutatingFileCompressor();
+            var zipFile = compressor.Zip(new RealDirectoryInfo(new DirectoryInfo(evenOdd2Source)));
+            var downloadHandle = new PackageDownloadHandle { DownloadPath = zipFile.Name };
+
+            var packagesInstallRoot = Path.Combine(TempFolder, "decline_install_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(packagesInstallRoot);
+
+            Assert.IsTrue(downloadHandle.TryPrepareInstallation(CurrentDynamoModel, out var stagedPkg, out var stagingDir));
+            Assert.IsTrue(Directory.Exists(stagingDir));
+
             var incomingInfo = new PackageInfo("EvenOdd2", new System.Version(1, 0, 0));
-            var hasConflict = CurrentDynamoModel.CustomNodeManager.TryGetConflictingPackageCustomNodeInfo(
-                evenOdd2Dyf,
+            Assert.IsTrue(CurrentDynamoModel.CustomNodeManager.TryGetConflictingPackageCustomNodeInfo(
+                stagedPkg.CustomNodeDirectory,
                 false,
                 incomingInfo,
-                out var conflicting);
-
-            Assert.IsTrue(hasConflict);
-            Assert.IsNotNull(conflicting);
+                out var conflicting));
             Assert.AreEqual("EvenOdd", conflicting.PackageInfo.Name);
+
+            // User chose No: do not commit; remove staging (mirrors PackageManagerClientViewModel finally).
+            PackageDownloadHandle.DiscardStagingDirectory(stagingDir, CurrentDynamoModel.Logger);
+
+            var committedPath = Path.Combine(packagesInstallRoot, "EvenOdd2");
+            Assert.IsFalse(Directory.Exists(committedPath), "Package must not be copied when install is declined.");
+            Assert.IsFalse(Directory.Exists(stagingDir), "Staging directory should be deleted.");
+            Assert.AreEqual(
+                uninstallListedEvenOddBefore,
+                prefs.PackageDirectoriesToUninstall.Contains(evenOddRoot),
+                "Declining install must not mark the existing package for uninstall.");
+
+            loader.PackagesLoaded -= libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary -= libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+            loader.RequestLoadCustomNodeDirectory -= reqLoadCNDelegate;
+        }
+
+        [Test]
+        public void StagedCustomNodeConflict_UserAcceptsReplace_CopiesNewPackageAndMarksExistingForUninstallOnRestart()
+        {
+            var pathManager = new Mock<IPathManager>();
+            pathManager.SetupGet(x => x.PackagesDirectories).Returns(
+                () => new List<string> { PackagesDirectory });
+
+            var loader = new PackageLoader(pathManager.Object);
+            var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
+
+            loader.PackagesLoaded += libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary += libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+
+            Func<string, PackageInfo, IEnumerable<CustomNodeInfo>> reqLoadCNDelegate = (dir, pkgInfo) =>
+                CurrentDynamoModel.CustomNodeManager.AddUninitializedCustomNodesInPath(dir, isTestMode: false, packageInfo: pkgInfo);
+            loader.RequestLoadCustomNodeDirectory += reqLoadCNDelegate;
+
+            loader.LoadAll(new LoadPackageParams
+            {
+                Preferences = CurrentDynamoModel.PreferenceSettings,
+            });
+
+            var evenOddInstalled = loader.LocalPackages.FirstOrDefault(p => p.Name == "EvenOdd");
+            Assert.IsNotNull(evenOddInstalled, "Test requires EvenOdd package in test/pkgs.");
+            var prefs = CurrentDynamoModel.PreferenceSettings;
+            var evenOddRoot = evenOddInstalled.RootDirectory;
+            prefs.PackageDirectoriesToUninstall.RemoveAll(x => x.Equals(evenOddRoot));
+
+            var evenOdd2Source = Path.Combine(PackagesDirectory, "EvenOdd2");
+            var compressor = new MutatingFileCompressor();
+            var zipFile = compressor.Zip(new RealDirectoryInfo(new DirectoryInfo(evenOdd2Source)));
+            var downloadHandle = new PackageDownloadHandle { DownloadPath = zipFile.Name };
+
+            var packagesInstallRoot = Path.Combine(TempFolder, "accept_install_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(packagesInstallRoot);
+
+            Assert.IsTrue(downloadHandle.TryPrepareInstallation(CurrentDynamoModel, out var stagedPkg, out var stagingDir));
+            var incomingInfo = new PackageInfo("EvenOdd2", new System.Version(1, 0, 0));
+            Assert.IsTrue(CurrentDynamoModel.CustomNodeManager.TryGetConflictingPackageCustomNodeInfo(
+                stagedPkg.CustomNodeDirectory,
+                false,
+                incomingInfo,
+                out _));
+
+            // User chose Yes: same as ConflictingCustomNodePackageLoaded handler — mark existing for removal after restart.
+            evenOddInstalled.MarkForUninstall(prefs);
+            downloadHandle.CompleteInstallation(stagedPkg, stagingDir, packagesInstallRoot);
+            PackageDownloadHandle.DiscardStagingDirectory(stagingDir, CurrentDynamoModel.Logger);
+
+            var committedPath = Path.Combine(packagesInstallRoot, "EvenOdd2");
+            Assert.IsTrue(Directory.Exists(committedPath), "Staged package should be committed when user accepts replace.");
+            Assert.IsTrue(File.Exists(Path.Combine(committedPath, "pkg.json")));
+            Assert.IsFalse(Directory.Exists(stagingDir), "Staging directory should be deleted after commit.");
+            Assert.IsTrue(
+                prefs.PackageDirectoriesToUninstall.Contains(evenOddRoot),
+                "Existing package root should be scheduled for uninstall on next startup.");
+            Assert.IsFalse(
+                loader.LocalPackages.Any(p => p.Name == "EvenOdd2"),
+                "New package must not be added to LocalPackages this session (loads after restart).");
 
             loader.PackagesLoaded -= libraryLoader.LoadPackages;
             loader.RequestLoadNodeLibrary -= libraryLoader.LoadLibraryAndSuppressZTSearchImport;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Package installs from the Package Manager used to unzip and copy into the packages folder before `LoadPackages` ran custom node registration. A GUID collision with another package’s `.dyf` files then threw `CustomNodePackageLoadException`, leaving a partial install and still showing the conflict dialog.

This change **stages** the download (unzip + parse `pkg.json`), **validates** staged `.dyf` function ids against `CustomNodeManager` using the same rules as `SetNodeInfo` (different package name + same function id), then **commits** the copy only when there is no conflict or the user accepts replacement.

## Behavior

- **No conflict:** Same as before — commit to packages directory, `LoadPackages`, mark installed.
- **Conflict + No:** Discard staging folder only; do not copy; error state with a clear message; **do not** call `MarkForUninstall` on the existing package.
- **Conflict + Yes:** Existing dialog unchanged — `MarkForUninstall` on the installed package; commit new files; **skip** `LoadPackages` for this session so the new package is picked up after restart once `DoCachedPackageUninstalls` removes the old folder.

## Implementation notes

- `PackageDownloadHandle`: `TryPrepareInstallation`, `CompleteInstallation`, `DiscardStagingDirectory`; `Extract` now wraps staging + commit + discard.
- `CustomNodeManager.TryGetConflictingPackageCustomNodeInfo`: read-only scan of a directory’s `.dyf` headers vs `NodeInfos`.
- `PackageLoader.ConflictingCustomNodePackageLoaded` is now `Func<Package, Package, bool>`; handler returns `true` when the user chooses Yes. Added `NotifyUserOfConflictingCustomNodePackage` for the pre-commit path. The post-load exception path still notifies the user (return value ignored).
- `PackageManagerSearchViewModel`: null-safe handler; returns whether the user accepted replacement.

## Tests

- `TryGetConflictingPackageCustomNodeInfoDetectsDifferentPackageSameGuid` (EvenOdd vs EvenOdd2 fixture).
- `TryGetConflictingPackageCustomNodeInfoReturnsFalseForSamePackageName`.

## Follow-up (optional)

- UI/integration test that simulates `SetPackageState` with a fake conflict resolution callback (full WPF path).
- Manual test: install conflicting package, verify disk state for No/Yes and restart behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd8e34bc-8930-488c-a09f-981abb88eee6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd8e34bc-8930-488c-a09f-981abb88eee6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

