### PR TITLE
DYN-7587 Validate custom node guid conflicts before extracting downloaded package

### DIFF
--- a/src/DynamoCore/Core/CustomNodeManager.cs
+++ b/src/DynamoCore/Core/CustomNodeManager.cs
@@ -597,6 +597,49 @@ namespace Dynamo.Core
         }
 
         /// <summary>
+        /// Returns the existing <see cref="CustomNodeInfo"/> entries that would conflict with
+        /// custom nodes found in <paramref name="customNodeDirectory"/> if they were registered
+        /// against the package described by <paramref name="newPackageInfo"/>.
+        /// A conflict is reported when a .dyf in the directory shares a function id with an
+        /// already-registered custom node that belongs to a different package.
+        /// This method only inspects metadata; it does not register or load any custom nodes.
+        /// </summary>
+        /// <param name="customNodeDirectory">Directory to scan for staged .dyf files.</param>
+        /// <param name="newPackageInfo">Identity of the package whose custom nodes are being staged.</param>
+        /// <param name="isTestMode">Test-mode flag forwarded to the .dyf header reader.</param>
+        /// <returns>Existing CustomNodeInfos from a different package that conflict by function id.</returns>
+        internal IEnumerable<CustomNodeInfo> GetConflictingCustomNodeInfos(
+            string customNodeDirectory,
+            PackageInfo newPackageInfo,
+            bool isTestMode)
+        {
+            if (string.IsNullOrEmpty(customNodeDirectory) || !Directory.Exists(customNodeDirectory))
+            {
+                yield break;
+            }
+
+            foreach (var stagedInfo in ScanNodeHeadersInDirectory(customNodeDirectory, isTestMode))
+            {
+                if (!NodeInfos.TryGetValue(stagedInfo.FunctionId, out CustomNodeInfo existingInfo))
+                {
+                    continue;
+                }
+
+                // Mirrors the conflict logic in SetNodeInfo: only report a conflict when both
+                // sides come from packages with different names. Same-package different-version
+                // and loose-vs-package overrides are intentionally tolerated here, just as the
+                // existing load-time check tolerates them.
+                if (existingInfo.IsPackageMember
+                    && existingInfo.PackageInfo != null
+                    && newPackageInfo != null
+                    && existingInfo.PackageInfo.Name != newPackageInfo.Name)
+                {
+                    yield return existingInfo;
+                }
+            }
+        }
+
+        /// <summary>
         ///     Enumerates all of the files in the search path and get's their guids.
         ///     Does not instantiate the nodes.
         /// </summary>

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1147,25 +1147,25 @@ namespace Dynamo.ViewModels
             // against the already-loaded custom node packages before copying anything into the
             // Dynamo packages folder. This prevents partial installs when the user declines a
             // conflict prompt below.
-            var staged = packageDownloadHandle.BuildStagedPackage(DynamoViewModel.Model, downloadPath);
-            if (staged == null)
+            var stagedPkg = packageDownloadHandle.BuildStagedPackage(DynamoViewModel.Model, downloadPath);
+            if (stagedPkg == null)
             {
                 packageDownloadHandle.Error(Resources.MessageInvalidPackage);
                 return;
             }
 
-            if (!ResolvePreInstallCustomNodeConflicts(staged))
+            if (!ResolvePreInstallCustomNodeConflicts(stagedPkg))
             {
                 // The user declined the conflict prompt. Clean up the staged temp folder and
                 // leave the Dynamo packages folder, the loaded package list, and the
                 // PackageDirectoriesToUninstall preference list untouched.
-                PackageDownloadHandle.CleanupStaging(staged);
+                packageDownloadHandle.CleanupStaging();
                 packageDownloadHandle.Error(Resources.CannotDownloadPackageMessageBoxTitle);
                 return;
             }
 
-            PackageDownloadHandle.FinalizeExtraction(staged);
-            PackageManagerExtension.PackageLoader.LoadPackages(new List<Package> { staged.Package });
+            packageDownloadHandle.FinalizeExtraction(stagedPkg);
+            PackageManagerExtension.PackageLoader.LoadPackages(new List<Package> { stagedPkg });
             packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
         }
 
@@ -1175,15 +1175,15 @@ namespace Dynamo.ViewModels
         /// "Cannot Download Package" dialog so the user can choose whether to mark the loaded
         /// package(s) for uninstall and continue, or cancel the install.
         /// </summary>
-        /// <param name="staged">Staged package to validate.</param>
+        /// <param name="stagedPkg">Staged package to validate.</param>
         /// <returns>True if the install should proceed; false if the user cancelled.</returns>
-        private bool ResolvePreInstallCustomNodeConflicts(StagedPackage staged)
+        private bool ResolvePreInstallCustomNodeConflicts(Package stagedPkg)
         {
             var packageLoader = PackageManagerExtension.PackageLoader;
             var customNodeManager = DynamoViewModel.Model.CustomNodeManager;
 
             var conflictingPackages = packageLoader
-                .GetPackagesConflictingWithStagedPackage(staged.Package, customNodeManager, DynamoModel.IsTestMode)
+                .GetPackagesConflictingWithStagedPackage(stagedPkg, customNodeManager, DynamoModel.IsTestMode)
                 .ToList();
 
             if (conflictingPackages.Count == 0)
@@ -1192,7 +1192,7 @@ namespace Dynamo.ViewModels
             }
 
             var conflictingNames = JoinPackageNames(conflictingPackages);
-            var stagedName = staged.Package.Name + " " + staged.Package.VersionName;
+            var stagedName = stagedPkg.Name + " " + stagedPkg.VersionName;
             var message = string.Format(Resources.MessageUninstallCustomNodeToContinue,
                 conflictingNames, stagedName);
 

--- a/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/PackageManager/PackageManagerClientViewModel.cs
@@ -1143,17 +1143,74 @@ namespace Dynamo.ViewModels
         /// <param name="downloadPath">package download path</param>
         internal void SetPackageState(PackageDownloadHandle packageDownloadHandle, string downloadPath)
         {
-            Package dynPkg;
-            if (packageDownloadHandle.Extract(DynamoViewModel.Model, downloadPath, out dynPkg))
+            // Stage the package into a temp folder so we can validate its custom node definitions
+            // against the already-loaded custom node packages before copying anything into the
+            // Dynamo packages folder. This prevents partial installs when the user declines a
+            // conflict prompt below.
+            var staged = packageDownloadHandle.BuildStagedPackage(DynamoViewModel.Model, downloadPath);
+            if (staged == null)
             {
-                PackageManagerExtension.PackageLoader.LoadPackages(new List<Package> { dynPkg });
-                packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
-            }
-            else
-            {
-                packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Error;
                 packageDownloadHandle.Error(Resources.MessageInvalidPackage);
+                return;
             }
+
+            if (!ResolvePreInstallCustomNodeConflicts(staged))
+            {
+                // The user declined the conflict prompt. Clean up the staged temp folder and
+                // leave the Dynamo packages folder, the loaded package list, and the
+                // PackageDirectoriesToUninstall preference list untouched.
+                PackageDownloadHandle.CleanupStaging(staged);
+                packageDownloadHandle.Error(Resources.CannotDownloadPackageMessageBoxTitle);
+                return;
+            }
+
+            PackageDownloadHandle.FinalizeExtraction(staged);
+            PackageManagerExtension.PackageLoader.LoadPackages(new List<Package> { staged.Package });
+            packageDownloadHandle.DownloadState = PackageDownloadHandle.State.Installed;
+        }
+
+        /// <summary>
+        /// Inspects the staged package's .dyf files for custom node guid conflicts with packages
+        /// already loaded by Dynamo. If conflicts are found, surfaces the existing
+        /// "Cannot Download Package" dialog so the user can choose whether to mark the loaded
+        /// package(s) for uninstall and continue, or cancel the install.
+        /// </summary>
+        /// <param name="staged">Staged package to validate.</param>
+        /// <returns>True if the install should proceed; false if the user cancelled.</returns>
+        private bool ResolvePreInstallCustomNodeConflicts(StagedPackage staged)
+        {
+            var packageLoader = PackageManagerExtension.PackageLoader;
+            var customNodeManager = DynamoViewModel.Model.CustomNodeManager;
+
+            var conflictingPackages = packageLoader
+                .GetPackagesConflictingWithStagedPackage(staged.Package, customNodeManager, DynamoModel.IsTestMode)
+                .ToList();
+
+            if (conflictingPackages.Count == 0)
+            {
+                return true;
+            }
+
+            var conflictingNames = JoinPackageNames(conflictingPackages);
+            var stagedName = staged.Package.Name + " " + staged.Package.VersionName;
+            var message = string.Format(Resources.MessageUninstallCustomNodeToContinue,
+                conflictingNames, stagedName);
+
+            var dialogResult = MessageBoxService.Show(ViewModelOwner, message,
+                Resources.CannotDownloadPackageMessageBoxTitle,
+                MessageBoxButton.YesNo, MessageBoxImage.Error);
+
+            if (dialogResult != MessageBoxResult.Yes)
+            {
+                return false;
+            }
+
+            var settings = DynamoViewModel.Model.PreferenceSettings;
+            foreach (var pkg in conflictingPackages)
+            {
+                pkg.MarkForUninstall(settings);
+            }
+            return true;
         }
 
         public void ClearCompletedDownloads()

--- a/src/DynamoPackages/PackageDownloadHandle.cs
+++ b/src/DynamoPackages/PackageDownloadHandle.cs
@@ -96,6 +96,12 @@ namespace Dynamo.PackageManager
             return packagesDirectory + @"\" + name.Replace("/", "_").Replace(@"\", "_");
         }
 
+        // Paths populated by BuildStagedPackage and consumed by FinalizeExtraction / CleanupStaging.
+        // Treated as transient install-lifecycle state, mirroring the other mutable fields on this
+        // class (DownloadPath, DownloadState, ErrorString).
+        private string stagingPath;
+        private string installedPath;
+
         /// <summary>
         /// Extracts and parses the metadata of a downloaded package.
         /// Calls <see cref="BuildStagedPackage"/> followed by <see cref="FinalizeExtraction"/>.
@@ -106,29 +112,28 @@ namespace Dynamo.PackageManager
         /// <returns>Whether the operation succeeded or not</returns>
         public bool Extract(DynamoModel dynamoModel, string installDirectory, out Package pkg)
         {
-            var staged = BuildStagedPackage(dynamoModel, installDirectory);
-            if (staged == null)
+            pkg = BuildStagedPackage(dynamoModel, installDirectory);
+            if (pkg == null)
             {
-                pkg = null;
                 return false;
             }
 
-            FinalizeExtraction(staged);
-            pkg = staged.Package;
+            FinalizeExtraction(pkg);
             return true;
         }
 
         /// <summary>
         /// Unzips the downloaded package into a temporary staging folder and parses its
         /// metadata, but does not yet copy any files into Dynamo's package folder. The returned
-        /// <see cref="StagedPackage"/> can be inspected (for example, for conflicting custom node
+        /// <see cref="Package"/> can be inspected (for example, for conflicting custom node
         /// definitions) before either calling <see cref="FinalizeExtraction"/> to install the
-        /// package or <see cref="CleanupStaging"/> to discard it.
+        /// package or <see cref="CleanupStaging"/> to discard it. The staged package's
+        /// <see cref="Package.RootDirectory"/> initially points at the staging folder.
         /// </summary>
         /// <param name="dynamoModel">Dynamo model</param>
         /// <param name="installDirectory">If specified, overrides Dynamo's default base folder for packages</param>
-        /// <returns>A staged package handle, or null if the package metadata could not be parsed</returns>
-        internal StagedPackage BuildStagedPackage(DynamoModel dynamoModel, string installDirectory)
+        /// <returns>The staged package, or null if the package metadata could not be parsed</returns>
+        internal Package BuildStagedPackage(DynamoModel dynamoModel, string installDirectory)
         {
             this.DownloadState = State.Installing;
 
@@ -148,46 +153,52 @@ namespace Dynamo.PackageManager
             if (String.IsNullOrEmpty(installDirectory))
                 installDirectory = dynamoModel.PathManager.DefaultPackagesDirectory;
 
-            var installedPath = BuildInstallDirectoryString(installDirectory, stagedPkg.Name);
-
-            return new StagedPackage(stagedPkg, unzipPath, installedPath);
+            stagingPath = unzipPath;
+            installedPath = BuildInstallDirectoryString(installDirectory, stagedPkg.Name);
+            return stagedPkg;
         }
 
         /// <summary>
         /// Copies the staged package contents into Dynamo's package folder and updates
         /// <see cref="Package.RootDirectory"/> to point at the final installed location.
+        /// Must be preceded by a successful call to <see cref="BuildStagedPackage"/>.
         /// </summary>
-        /// <param name="staged">Staged package returned from <see cref="BuildStagedPackage"/>.</param>
-        internal static void FinalizeExtraction(StagedPackage staged)
+        /// <param name="stagedPkg">Package returned from <see cref="BuildStagedPackage"/>.</param>
+        internal void FinalizeExtraction(Package stagedPkg)
         {
-            if (staged == null) throw new ArgumentNullException(nameof(staged));
+            if (stagedPkg == null) throw new ArgumentNullException(nameof(stagedPkg));
+            if (string.IsNullOrEmpty(stagingPath) || string.IsNullOrEmpty(installedPath))
+            {
+                throw new InvalidOperationException(
+                    "BuildStagedPackage must be called successfully before FinalizeExtraction.");
+            }
 
-            Directory.CreateDirectory(staged.InstalledPath);
+            Directory.CreateDirectory(installedPath);
 
-            foreach (string dirPath in Directory.GetDirectories(staged.StagingPath, "*", SearchOption.AllDirectories))
-                Directory.CreateDirectory(dirPath.Replace(staged.StagingPath, staged.InstalledPath));
+            foreach (string dirPath in Directory.GetDirectories(stagingPath, "*", SearchOption.AllDirectories))
+                Directory.CreateDirectory(dirPath.Replace(stagingPath, installedPath));
 
-            foreach (string newPath in Directory.GetFiles(staged.StagingPath, "*.*", SearchOption.AllDirectories))
-                File.Copy(newPath, newPath.Replace(staged.StagingPath, staged.InstalledPath));
+            foreach (string newPath in Directory.GetFiles(stagingPath, "*.*", SearchOption.AllDirectories))
+                File.Copy(newPath, newPath.Replace(stagingPath, installedPath));
 
-            staged.Package.RootDirectory = staged.InstalledPath;
+            stagedPkg.RootDirectory = installedPath;
         }
 
         /// <summary>
         /// Deletes the temporary staging folder created by <see cref="BuildStagedPackage"/>.
         /// Used to back out an install when, for example, the user cancels after a conflict
-        /// with an already-loaded package is detected.
+        /// with an already-loaded package is detected. Safe to call when the staging folder is
+        /// already gone or was never created.
         /// </summary>
-        /// <param name="staged">Staged package returned from <see cref="BuildStagedPackage"/>.</param>
-        internal static void CleanupStaging(StagedPackage staged)
+        internal void CleanupStaging()
         {
-            if (staged == null) return;
+            if (string.IsNullOrEmpty(stagingPath)) return;
 
             try
             {
-                if (Directory.Exists(staged.StagingPath))
+                if (Directory.Exists(stagingPath))
                 {
-                    Directory.Delete(staged.StagingPath, true);
+                    Directory.Delete(stagingPath, true);
                 }
             }
             catch (IOException) { }
@@ -196,39 +207,6 @@ namespace Dynamo.PackageManager
 
         // cancel, install, redownload
 
-    }
-
-    /// <summary>
-    /// Represents a downloaded package that has been unzipped to a temporary staging folder
-    /// but has not yet been copied into Dynamo's package folder. Returned by
-    /// <see cref="PackageDownloadHandle.BuildStagedPackage"/>.
-    /// </summary>
-    internal class StagedPackage
-    {
-        /// <summary>
-        /// Package metadata parsed from the staged pkg.json. Its <see cref="Package.RootDirectory"/>
-        /// initially points at <see cref="StagingPath"/> and is updated to <see cref="InstalledPath"/>
-        /// once <see cref="PackageDownloadHandle.FinalizeExtraction"/> is called.
-        /// </summary>
-        public Package Package { get; }
-
-        /// <summary>
-        /// Temporary folder containing the unzipped package contents.
-        /// </summary>
-        public string StagingPath { get; }
-
-        /// <summary>
-        /// Final installation folder under Dynamo's packages directory. Created and populated
-        /// by <see cref="PackageDownloadHandle.FinalizeExtraction"/>.
-        /// </summary>
-        public string InstalledPath { get; }
-
-        internal StagedPackage(Package package, string stagingPath, string installedPath)
-        {
-            Package = package;
-            StagingPath = stagingPath;
-            InstalledPath = installedPath;
-        }
     }
 
 }

--- a/src/DynamoPackages/PackageDownloadHandle.cs
+++ b/src/DynamoPackages/PackageDownloadHandle.cs
@@ -97,7 +97,8 @@ namespace Dynamo.PackageManager
         }
 
         /// <summary>
-        /// Extracts and parses the metadata of a downloaded package
+        /// Extracts and parses the metadata of a downloaded package.
+        /// Calls <see cref="BuildStagedPackage"/> followed by <see cref="FinalizeExtraction"/>.
         /// </summary>
         /// <param name="dynamoModel">Dynamo model</param>
         /// <param name="installDirectory">If specified, overrides Dynamo's default base folder for packages</param>
@@ -105,45 +106,129 @@ namespace Dynamo.PackageManager
         /// <returns>Whether the operation succeeded or not</returns>
         public bool Extract(DynamoModel dynamoModel, string installDirectory, out Package pkg)
         {
+            var staged = BuildStagedPackage(dynamoModel, installDirectory);
+            if (staged == null)
+            {
+                pkg = null;
+                return false;
+            }
+
+            FinalizeExtraction(staged);
+            pkg = staged.Package;
+            return true;
+        }
+
+        /// <summary>
+        /// Unzips the downloaded package into a temporary staging folder and parses its
+        /// metadata, but does not yet copy any files into Dynamo's package folder. The returned
+        /// <see cref="StagedPackage"/> can be inspected (for example, for conflicting custom node
+        /// definitions) before either calling <see cref="FinalizeExtraction"/> to install the
+        /// package or <see cref="CleanupStaging"/> to discard it.
+        /// </summary>
+        /// <param name="dynamoModel">Dynamo model</param>
+        /// <param name="installDirectory">If specified, overrides Dynamo's default base folder for packages</param>
+        /// <returns>A staged package handle, or null if the package metadata could not be parsed</returns>
+        internal StagedPackage BuildStagedPackage(DynamoModel dynamoModel, string installDirectory)
+        {
             this.DownloadState = State.Installing;
 
-            // unzip, place files
+            // unzip into a temp staging folder; nothing is written to the Dynamo packages folder yet.
             var unzipPath = Greg.Utility.FileUtilities.UnZip(DownloadPath);
             if (!Directory.Exists(unzipPath))
             {
                 throw new Exception(Properties.Resources.PackageEmpty);
             }
 
-            // provide handle to installed package 
-            pkg = Package.FromDirectory(unzipPath, dynamoModel.Logger);
-
-            if (pkg == null)
+            var stagedPkg = Package.FromDirectory(unzipPath, dynamoModel.Logger);
+            if (stagedPkg == null)
             {
-                return false;
+                return null;
             }
 
             if (String.IsNullOrEmpty(installDirectory))
                 installDirectory = dynamoModel.PathManager.DefaultPackagesDirectory;
 
-            var installedPath = BuildInstallDirectoryString(installDirectory, pkg.Name);
-            Directory.CreateDirectory(installedPath);
+            var installedPath = BuildInstallDirectoryString(installDirectory, stagedPkg.Name);
 
-            // Now create all of the directories
-            foreach (string dirPath in Directory.GetDirectories(unzipPath, "*", SearchOption.AllDirectories))
-                Directory.CreateDirectory(dirPath.Replace(unzipPath, installedPath));
+            return new StagedPackage(stagedPkg, unzipPath, installedPath);
+        }
 
-            // Copy all the files
-            foreach (string newPath in Directory.GetFiles(unzipPath, "*.*", SearchOption.AllDirectories))
-                File.Copy(newPath, newPath.Replace(unzipPath, installedPath));
+        /// <summary>
+        /// Copies the staged package contents into Dynamo's package folder and updates
+        /// <see cref="Package.RootDirectory"/> to point at the final installed location.
+        /// </summary>
+        /// <param name="staged">Staged package returned from <see cref="BuildStagedPackage"/>.</param>
+        internal static void FinalizeExtraction(StagedPackage staged)
+        {
+            if (staged == null) throw new ArgumentNullException(nameof(staged));
 
-            // Update root directory to final path
-            pkg.RootDirectory = installedPath;
+            Directory.CreateDirectory(staged.InstalledPath);
 
-            return true;
+            foreach (string dirPath in Directory.GetDirectories(staged.StagingPath, "*", SearchOption.AllDirectories))
+                Directory.CreateDirectory(dirPath.Replace(staged.StagingPath, staged.InstalledPath));
+
+            foreach (string newPath in Directory.GetFiles(staged.StagingPath, "*.*", SearchOption.AllDirectories))
+                File.Copy(newPath, newPath.Replace(staged.StagingPath, staged.InstalledPath));
+
+            staged.Package.RootDirectory = staged.InstalledPath;
+        }
+
+        /// <summary>
+        /// Deletes the temporary staging folder created by <see cref="BuildStagedPackage"/>.
+        /// Used to back out an install when, for example, the user cancels after a conflict
+        /// with an already-loaded package is detected.
+        /// </summary>
+        /// <param name="staged">Staged package returned from <see cref="BuildStagedPackage"/>.</param>
+        internal static void CleanupStaging(StagedPackage staged)
+        {
+            if (staged == null) return;
+
+            try
+            {
+                if (Directory.Exists(staged.StagingPath))
+                {
+                    Directory.Delete(staged.StagingPath, true);
+                }
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
         }
 
         // cancel, install, redownload
 
+    }
+
+    /// <summary>
+    /// Represents a downloaded package that has been unzipped to a temporary staging folder
+    /// but has not yet been copied into Dynamo's package folder. Returned by
+    /// <see cref="PackageDownloadHandle.BuildStagedPackage"/>.
+    /// </summary>
+    internal class StagedPackage
+    {
+        /// <summary>
+        /// Package metadata parsed from the staged pkg.json. Its <see cref="Package.RootDirectory"/>
+        /// initially points at <see cref="StagingPath"/> and is updated to <see cref="InstalledPath"/>
+        /// once <see cref="PackageDownloadHandle.FinalizeExtraction"/> is called.
+        /// </summary>
+        public Package Package { get; }
+
+        /// <summary>
+        /// Temporary folder containing the unzipped package contents.
+        /// </summary>
+        public string StagingPath { get; }
+
+        /// <summary>
+        /// Final installation folder under Dynamo's packages directory. Created and populated
+        /// by <see cref="PackageDownloadHandle.FinalizeExtraction"/>.
+        /// </summary>
+        public string InstalledPath { get; }
+
+        internal StagedPackage(Package package, string stagingPath, string installedPath)
+        {
+            Package = package;
+            StagingPath = stagingPath;
+            InstalledPath = installedPath;
+        }
     }
 
 }

--- a/src/DynamoPackages/PackageLoader.cs
+++ b/src/DynamoPackages/PackageLoader.cs
@@ -311,8 +311,87 @@ namespace Dynamo.PackageManager
         public event Action<Package, Package> ConflictingCustomNodePackageLoaded;
         private void OnConflictingPackageLoaded(Package installed, Package conflicting)
         {
+            // If the installed package is already scheduled for uninstall/unload, the user has
+            // already been prompted about this conflict (typically via the pre-install conflict
+            // check in PackageManagerClientViewModel.SetPackageState) and accepted. Avoid showing
+            // the same dialog a second time when the package then fails to load due to the still
+            // -registered CustomNodeInfo entries.
+            if (installed != null
+                && installed.LoadState != null
+                && installed.LoadState.ScheduledState != PackageLoadState.ScheduledTypes.None)
+            {
+                return;
+            }
+
             var handler = ConflictingCustomNodePackageLoaded;
             handler?.Invoke(installed, conflicting);
+        }
+
+        /// <summary>
+        /// Returns the loaded local packages whose custom node definitions conflict with the
+        /// .dyf files staged for <paramref name="stagedPackage"/>. Used by the package install
+        /// flow to surface the "Cannot Download Package" dialog before the staged package is
+        /// copied into Dynamo's package folder.
+        /// </summary>
+        /// <param name="stagedPackage">Package whose <see cref="Package.CustomNodeDirectory"/> contains the staged .dyf files.</param>
+        /// <param name="customNodeManager">Custom node manager used to look up existing custom node info.</param>
+        /// <param name="isTestMode">Test-mode flag forwarded to the .dyf header reader.</param>
+        /// <returns>Distinct local packages that own a conflicting custom node definition.</returns>
+        internal IEnumerable<Package> GetPackagesConflictingWithStagedPackage(
+            Package stagedPackage,
+            CustomNodeManager customNodeManager,
+            bool isTestMode)
+        {
+            if (stagedPackage == null) throw new ArgumentNullException(nameof(stagedPackage));
+            if (customNodeManager == null) throw new ArgumentNullException(nameof(customNodeManager));
+
+            if (!Directory.Exists(stagedPackage.CustomNodeDirectory))
+            {
+                return Enumerable.Empty<Package>();
+            }
+
+            Version stagedVersion;
+            try
+            {
+                stagedVersion = new Version(stagedPackage.VersionName);
+            }
+            catch
+            {
+                // If we cannot parse the staged version we still need a PackageInfo to drive the
+                // name-based conflict check; use a default version.
+                stagedVersion = new Version(0, 0, 0, 0);
+            }
+
+            var newPackageInfo = new Graph.Workspaces.PackageInfo(stagedPackage.Name, stagedVersion);
+
+            var conflictingInfos = customNodeManager
+                .GetConflictingCustomNodeInfos(stagedPackage.CustomNodeDirectory, newPackageInfo, isTestMode)
+                .ToList();
+
+            if (conflictingInfos.Count == 0)
+            {
+                return Enumerable.Empty<Package>();
+            }
+
+            // Map each conflicting CustomNodeInfo back to the local Package that owns it. This
+            // mirrors the lookup done in the existing CustomNodePackageLoadException catch block.
+            var owners = new List<Package>();
+            foreach (var info in conflictingInfos)
+            {
+                if (string.IsNullOrEmpty(info.Path)) continue;
+
+                var infoDir = Path.GetDirectoryName(info.Path);
+                if (string.IsNullOrEmpty(infoDir)) continue;
+
+                var owner = localPackages.FirstOrDefault(x =>
+                    string.Equals(x.CustomNodeDirectory, infoDir, StringComparison.OrdinalIgnoreCase));
+                if (owner != null && !owners.Contains(owner))
+                {
+                    owners.Add(owner);
+                }
+            }
+
+            return owners;
         }
 
         /// <summary>

--- a/test/Libraries/PackageManagerTests/PackageDownloadHandleTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageDownloadHandleTests.cs
@@ -49,72 +49,69 @@ namespace Dynamo.PackageManager.Tests
             return zipPath;
         }
 
-        [Test]
-        public void BuildStagedPackageDoesNotCopyFilesIntoInstallDirectory()
+        private PackageDownloadHandle CreateHandleForPackage(string packageSourceDir, string name)
         {
-            var sourceDir = Path.Combine(TestDirectory, "pkgs", "EvenOdd2");
-            var zipPath = CreateTestPackageZip(sourceDir);
-
-            var installDirectory = Path.Combine(scratchDirectory, "packages");
-            Directory.CreateDirectory(installDirectory);
-
-            var handle = new PackageDownloadHandle
+            var zipPath = CreateTestPackageZip(packageSourceDir);
+            return new PackageDownloadHandle
             {
-                Name = "EvenOdd2",
+                Name = name,
                 DownloadPath = zipPath,
                 VersionName = "1.0.0",
             };
+        }
 
-            var staged = handle.BuildStagedPackage(CurrentDynamoModel, installDirectory);
+        [Test]
+        public void BuildStagedPackageDoesNotCreatePackageInstallDirectory()
+        {
+            var sourceDir = Path.Combine(TestDirectory, "pkgs", "EvenOdd2");
+            var installDirectory = Path.Combine(scratchDirectory, "packages");
+            Directory.CreateDirectory(installDirectory);
 
-            Assert.IsNotNull(staged);
-            Assert.AreEqual("EvenOdd2", staged.Package.Name);
-            Assert.IsTrue(Directory.Exists(staged.StagingPath),
-                "Staging folder should exist immediately after BuildStagedPackage.");
-            Assert.IsFalse(Directory.Exists(staged.InstalledPath),
-                "BuildStagedPackage must not create the final install directory.");
-            Assert.AreEqual(staged.StagingPath, staged.Package.RootDirectory,
-                "Staged package's RootDirectory should still point at the temp staging folder.");
+            var existingEntries = Directory.GetFileSystemEntries(installDirectory);
+            var handle = CreateHandleForPackage(sourceDir, "EvenOdd2");
 
-            PackageDownloadHandle.CleanupStaging(staged);
+            var stagedPkg = handle.BuildStagedPackage(CurrentDynamoModel, installDirectory);
+
+            Assert.IsNotNull(stagedPkg);
+            Assert.AreEqual("EvenOdd2", stagedPkg.Name);
+            Assert.IsTrue(Directory.Exists(stagedPkg.RootDirectory),
+                "Staged package's RootDirectory should point at an existing temp staging folder.");
+            CollectionAssert.AreEqual(existingEntries, Directory.GetFileSystemEntries(installDirectory),
+                "BuildStagedPackage must not write anything into the install directory.");
+
+            handle.CleanupStaging();
         }
 
         [Test]
         public void FinalizeExtractionCopiesFilesAndUpdatesRootDirectory()
         {
             var sourceDir = Path.Combine(TestDirectory, "pkgs", "EvenOdd");
-            var zipPath = CreateTestPackageZip(sourceDir);
-
             var installDirectory = Path.Combine(scratchDirectory, "packages");
             Directory.CreateDirectory(installDirectory);
 
-            var handle = new PackageDownloadHandle
-            {
-                Name = "EvenOdd",
-                DownloadPath = zipPath,
-                VersionName = "1.0.0",
-            };
+            var handle = CreateHandleForPackage(sourceDir, "EvenOdd");
 
-            var staged = handle.BuildStagedPackage(CurrentDynamoModel, installDirectory);
-            Assert.IsNotNull(staged);
+            var stagedPkg = handle.BuildStagedPackage(CurrentDynamoModel, installDirectory);
+            Assert.IsNotNull(stagedPkg);
+            var stagingPath = stagedPkg.RootDirectory;
 
             try
             {
-                PackageDownloadHandle.FinalizeExtraction(staged);
+                handle.FinalizeExtraction(stagedPkg);
 
-                Assert.IsTrue(Directory.Exists(staged.InstalledPath),
-                    "FinalizeExtraction should create the final install directory.");
-                Assert.IsTrue(File.Exists(Path.Combine(staged.InstalledPath, "pkg.json")),
+                Assert.AreNotEqual(stagingPath, stagedPkg.RootDirectory,
+                    "FinalizeExtraction must update the staged package's RootDirectory.");
+                Assert.IsTrue(Directory.Exists(stagedPkg.RootDirectory),
+                    "Final installed directory should exist after FinalizeExtraction.");
+                Assert.IsTrue(File.Exists(Path.Combine(stagedPkg.RootDirectory, "pkg.json")),
                     "FinalizeExtraction should copy pkg.json into the install directory.");
-                Assert.AreEqual(staged.InstalledPath, staged.Package.RootDirectory,
-                    "FinalizeExtraction should update the staged package's RootDirectory.");
             }
             finally
             {
-                PackageDownloadHandle.CleanupStaging(staged);
-                if (Directory.Exists(staged.InstalledPath))
+                handle.CleanupStaging();
+                if (Directory.Exists(stagedPkg.RootDirectory))
                 {
-                    Directory.Delete(staged.InstalledPath, true);
+                    Directory.Delete(stagedPkg.RootDirectory, true);
                 }
             }
         }
@@ -123,41 +120,53 @@ namespace Dynamo.PackageManager.Tests
         public void CleanupStagingDeletesTheStagingDirectory()
         {
             var sourceDir = Path.Combine(TestDirectory, "pkgs", "EvenOdd");
-            var zipPath = CreateTestPackageZip(sourceDir);
-
             var installDirectory = Path.Combine(scratchDirectory, "packages");
             Directory.CreateDirectory(installDirectory);
 
-            var handle = new PackageDownloadHandle
-            {
-                Name = "EvenOdd",
-                DownloadPath = zipPath,
-                VersionName = "1.0.0",
-            };
+            var handle = CreateHandleForPackage(sourceDir, "EvenOdd");
 
-            var staged = handle.BuildStagedPackage(CurrentDynamoModel, installDirectory);
-            Assert.IsNotNull(staged);
-            Assert.IsTrue(Directory.Exists(staged.StagingPath));
+            var stagedPkg = handle.BuildStagedPackage(CurrentDynamoModel, installDirectory);
+            Assert.IsNotNull(stagedPkg);
+            var stagingPath = stagedPkg.RootDirectory;
+            Assert.IsTrue(Directory.Exists(stagingPath));
 
-            PackageDownloadHandle.CleanupStaging(staged);
+            handle.CleanupStaging();
 
-            Assert.IsFalse(Directory.Exists(staged.StagingPath),
+            Assert.IsFalse(Directory.Exists(stagingPath),
                 "CleanupStaging should delete the temporary staging folder.");
-            Assert.IsFalse(Directory.Exists(staged.InstalledPath),
-                "CleanupStaging should not have created the final install directory.");
         }
 
         [Test]
         public void CleanupStagingTolerantOfMissingDirectory()
         {
-            // Calling CleanupStaging twice (or against a non-existent staging path) should not throw.
-            var staged = new StagedPackage(
-                package: null,
-                stagingPath: Path.Combine(scratchDirectory, "does", "not", "exist"),
-                installedPath: Path.Combine(scratchDirectory, "ignored"));
+            // CleanupStaging should be safe to call before BuildStagedPackage and idempotent
+            // when called a second time after the staging folder is already gone.
+            var handle = new PackageDownloadHandle();
+            Assert.DoesNotThrow(() => handle.CleanupStaging());
 
-            Assert.DoesNotThrow(() => PackageDownloadHandle.CleanupStaging(staged));
-            Assert.DoesNotThrow(() => PackageDownloadHandle.CleanupStaging(null));
+            var sourceDir = Path.Combine(TestDirectory, "pkgs", "EvenOdd");
+            var installDirectory = Path.Combine(scratchDirectory, "packages");
+            Directory.CreateDirectory(installDirectory);
+
+            var stagedHandle = CreateHandleForPackage(sourceDir, "EvenOdd");
+            var stagedPkg = stagedHandle.BuildStagedPackage(CurrentDynamoModel, installDirectory);
+            Assert.IsNotNull(stagedPkg);
+
+            stagedHandle.CleanupStaging();
+            Assert.DoesNotThrow(() => stagedHandle.CleanupStaging());
+        }
+
+        [Test]
+        public void FinalizeExtractionWithoutStageThrows()
+        {
+            var handle = new PackageDownloadHandle();
+            // No BuildStagedPackage call — staging state is unset, so FinalizeExtraction must fail
+            // loudly rather than silently doing nothing.
+            Assert.Throws<InvalidOperationException>(() => handle.FinalizeExtraction(new Package(
+                directory: Path.Combine(scratchDirectory, "ignored"),
+                name: "Ignored",
+                versionName: "1.0.0",
+                license: string.Empty)));
         }
     }
 }

--- a/test/Libraries/PackageManagerTests/PackageDownloadHandleTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageDownloadHandleTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using NUnit.Framework;
+
+namespace Dynamo.PackageManager.Tests
+{
+    /// <summary>
+    /// Tests for the staging, finalize, and cleanup phases that
+    /// <see cref="PackageDownloadHandle.Extract"/> is built on top of. These phases are exercised
+    /// by the package install flow in PackageManagerClientViewModel.SetPackageState so that custom
+    /// node guid conflicts can be detected before any files are copied into Dynamo's package
+    /// folder.
+    /// </summary>
+    [TestFixture]
+    class PackageDownloadHandleTests : DynamoModelTestBase
+    {
+        private string scratchDirectory;
+
+        public override void Setup()
+        {
+            base.Setup();
+            scratchDirectory = Path.Combine(Path.GetTempPath(),
+                "PackageDownloadHandleTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(scratchDirectory);
+        }
+
+        public override void Cleanup()
+        {
+            try
+            {
+                if (Directory.Exists(scratchDirectory))
+                {
+                    Directory.Delete(scratchDirectory, true);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup; do not fail the test on filesystem hiccups.
+            }
+
+            base.Cleanup();
+        }
+
+        private string CreateTestPackageZip(string packageSourceDir)
+        {
+            var zipPath = Path.Combine(scratchDirectory, Path.GetFileName(packageSourceDir) + ".zip");
+            ZipFile.CreateFromDirectory(packageSourceDir, zipPath, CompressionLevel.NoCompression, includeBaseDirectory: false);
+            return zipPath;
+        }
+
+        [Test]
+        public void BuildStagedPackageDoesNotCopyFilesIntoInstallDirectory()
+        {
+            var sourceDir = Path.Combine(TestDirectory, "pkgs", "EvenOdd2");
+            var zipPath = CreateTestPackageZip(sourceDir);
+
+            var installDirectory = Path.Combine(scratchDirectory, "packages");
+            Directory.CreateDirectory(installDirectory);
+
+            var handle = new PackageDownloadHandle
+            {
+                Name = "EvenOdd2",
+                DownloadPath = zipPath,
+                VersionName = "1.0.0",
+            };
+
+            var staged = handle.BuildStagedPackage(CurrentDynamoModel, installDirectory);
+
+            Assert.IsNotNull(staged);
+            Assert.AreEqual("EvenOdd2", staged.Package.Name);
+            Assert.IsTrue(Directory.Exists(staged.StagingPath),
+                "Staging folder should exist immediately after BuildStagedPackage.");
+            Assert.IsFalse(Directory.Exists(staged.InstalledPath),
+                "BuildStagedPackage must not create the final install directory.");
+            Assert.AreEqual(staged.StagingPath, staged.Package.RootDirectory,
+                "Staged package's RootDirectory should still point at the temp staging folder.");
+
+            PackageDownloadHandle.CleanupStaging(staged);
+        }
+
+        [Test]
+        public void FinalizeExtractionCopiesFilesAndUpdatesRootDirectory()
+        {
+            var sourceDir = Path.Combine(TestDirectory, "pkgs", "EvenOdd");
+            var zipPath = CreateTestPackageZip(sourceDir);
+
+            var installDirectory = Path.Combine(scratchDirectory, "packages");
+            Directory.CreateDirectory(installDirectory);
+
+            var handle = new PackageDownloadHandle
+            {
+                Name = "EvenOdd",
+                DownloadPath = zipPath,
+                VersionName = "1.0.0",
+            };
+
+            var staged = handle.BuildStagedPackage(CurrentDynamoModel, installDirectory);
+            Assert.IsNotNull(staged);
+
+            try
+            {
+                PackageDownloadHandle.FinalizeExtraction(staged);
+
+                Assert.IsTrue(Directory.Exists(staged.InstalledPath),
+                    "FinalizeExtraction should create the final install directory.");
+                Assert.IsTrue(File.Exists(Path.Combine(staged.InstalledPath, "pkg.json")),
+                    "FinalizeExtraction should copy pkg.json into the install directory.");
+                Assert.AreEqual(staged.InstalledPath, staged.Package.RootDirectory,
+                    "FinalizeExtraction should update the staged package's RootDirectory.");
+            }
+            finally
+            {
+                PackageDownloadHandle.CleanupStaging(staged);
+                if (Directory.Exists(staged.InstalledPath))
+                {
+                    Directory.Delete(staged.InstalledPath, true);
+                }
+            }
+        }
+
+        [Test]
+        public void CleanupStagingDeletesTheStagingDirectory()
+        {
+            var sourceDir = Path.Combine(TestDirectory, "pkgs", "EvenOdd");
+            var zipPath = CreateTestPackageZip(sourceDir);
+
+            var installDirectory = Path.Combine(scratchDirectory, "packages");
+            Directory.CreateDirectory(installDirectory);
+
+            var handle = new PackageDownloadHandle
+            {
+                Name = "EvenOdd",
+                DownloadPath = zipPath,
+                VersionName = "1.0.0",
+            };
+
+            var staged = handle.BuildStagedPackage(CurrentDynamoModel, installDirectory);
+            Assert.IsNotNull(staged);
+            Assert.IsTrue(Directory.Exists(staged.StagingPath));
+
+            PackageDownloadHandle.CleanupStaging(staged);
+
+            Assert.IsFalse(Directory.Exists(staged.StagingPath),
+                "CleanupStaging should delete the temporary staging folder.");
+            Assert.IsFalse(Directory.Exists(staged.InstalledPath),
+                "CleanupStaging should not have created the final install directory.");
+        }
+
+        [Test]
+        public void CleanupStagingTolerantOfMissingDirectory()
+        {
+            // Calling CleanupStaging twice (or against a non-existent staging path) should not throw.
+            var staged = new StagedPackage(
+                package: null,
+                stagingPath: Path.Combine(scratchDirectory, "does", "not", "exist"),
+                installedPath: Path.Combine(scratchDirectory, "ignored"));
+
+            Assert.DoesNotThrow(() => PackageDownloadHandle.CleanupStaging(staged));
+            Assert.DoesNotThrow(() => PackageDownloadHandle.CleanupStaging(null));
+        }
+    }
+}

--- a/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
+++ b/test/Libraries/PackageManagerTests/PackageLoaderTests.cs
@@ -735,6 +735,115 @@ namespace Dynamo.PackageManager.Tests
             loader.RequestLoadNodeLibrary -= libraryLoader.LoadLibraryAndSuppressZTSearchImport;
         }
 
+        [Test]
+        public void GetPackagesConflictingWithStagedPackageReturnsAlreadyLoadedConflictingPackage()
+        {
+            var loader = GetPackageLoader();
+            var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
+
+            loader.PackagesLoaded += libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary += libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+
+            // The "EvenOdd2" package shares a custom node guid with "EvenOdd" but uses a
+            // different package name, which is exactly the conflict case the pre-install
+            // validation must catch before files are copied into the Dynamo packages folder.
+            Func<string, PackageInfo, IEnumerable<CustomNodeInfo>> reqLoadCNDelegate = (dir, pkgInfo) =>
+                CurrentDynamoModel.CustomNodeManager.AddUninitializedCustomNodesInPath(dir, isTestMode: true, packageInfo: pkgInfo);
+            loader.RequestLoadCustomNodeDirectory += reqLoadCNDelegate;
+
+            var packageDirectory = Path.Combine(TestDirectory, "pkgs", "EvenOdd");
+            var stagedDirectory = Path.Combine(TestDirectory, "pkgs", "EvenOdd2");
+
+            var loadedPackage = Package.FromDirectory(packageDirectory, CurrentDynamoModel.Logger);
+            loader.LoadPackages(new[] { loadedPackage });
+
+            var stagedPackage = Package.FromDirectory(stagedDirectory, CurrentDynamoModel.Logger);
+
+            var conflicts = loader
+                .GetPackagesConflictingWithStagedPackage(stagedPackage, CurrentDynamoModel.CustomNodeManager, isTestMode: true)
+                .ToList();
+
+            Assert.AreEqual(1, conflicts.Count);
+            Assert.AreSame(loadedPackage, conflicts[0]);
+
+            loader.PackagesLoaded -= libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary -= libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+            loader.RequestLoadCustomNodeDirectory -= reqLoadCNDelegate;
+        }
+
+        [Test]
+        public void GetPackagesConflictingWithStagedPackageReturnsEmptyWhenSameName()
+        {
+            var loader = GetPackageLoader();
+            var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
+
+            loader.PackagesLoaded += libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary += libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+
+            Func<string, PackageInfo, IEnumerable<CustomNodeInfo>> reqLoadCNDelegate = (dir, pkgInfo) =>
+                CurrentDynamoModel.CustomNodeManager.AddUninitializedCustomNodesInPath(dir, isTestMode: true, packageInfo: pkgInfo);
+            loader.RequestLoadCustomNodeDirectory += reqLoadCNDelegate;
+
+            var packageDirectory = Path.Combine(TestDirectory, "pkgs", "EvenOdd");
+            var loadedPackage = Package.FromDirectory(packageDirectory, CurrentDynamoModel.Logger);
+            loader.LoadPackages(new[] { loadedPackage });
+
+            // Restage the same package: same name and guids should NOT be reported as a conflict;
+            // re-installing/upgrading a package is treated as a same-package overwrite, matching
+            // the existing logic in CustomNodeManager.SetNodeInfo.
+            var restaged = Package.FromDirectory(packageDirectory, CurrentDynamoModel.Logger);
+
+            var conflicts = loader
+                .GetPackagesConflictingWithStagedPackage(restaged, CurrentDynamoModel.CustomNodeManager, isTestMode: true)
+                .ToList();
+
+            Assert.IsEmpty(conflicts);
+
+            loader.PackagesLoaded -= libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary -= libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+            loader.RequestLoadCustomNodeDirectory -= reqLoadCNDelegate;
+        }
+
+        [Test]
+        public void ConflictingCustomNodePackageLoadedEventDoesNotFireWhenInstalledPackageAlreadyMarkedForUninstall()
+        {
+            var pathManager = new Mock<Dynamo.Interfaces.IPathManager>();
+            pathManager.SetupGet(x => x.PackagesDirectories).Returns(
+                () => new List<string> { PackagesDirectory });
+
+            var loader = new PackageLoader(pathManager.Object);
+            var libraryLoader = new ExtensionLibraryLoader(CurrentDynamoModel);
+
+            loader.PackagesLoaded += libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary += libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+            Func<string, PackageInfo, IEnumerable<CustomNodeInfo>> reqLoadCNDelegate = (dir, pkgInfo) =>
+                CurrentDynamoModel.CustomNodeManager.AddUninitializedCustomNodesInPath(dir, isTestMode: false, packageInfo: pkgInfo);
+            loader.RequestLoadCustomNodeDirectory += reqLoadCNDelegate;
+
+            var packageDirectory = Path.Combine(TestDirectory, "pkgs", "EvenOdd");
+            var packageDirectory2 = Path.Combine(TestDirectory, "pkgs", "EvenOdd2");
+            var loadedPackage = Package.FromDirectory(packageDirectory, CurrentDynamoModel.Logger);
+            loader.LoadPackages(new[] { loadedPackage });
+
+            // Simulate the user having already accepted the pre-install conflict prompt: the
+            // older package is marked for uninstall before the new package is loaded.
+            loadedPackage.MarkForUninstall(CurrentDynamoModel.PreferenceSettings);
+
+            var eventFired = false;
+            loader.ConflictingCustomNodePackageLoaded += (installed, conflicting) => eventFired = true;
+
+            var conflictingPackage = Package.FromDirectory(packageDirectory2, CurrentDynamoModel.Logger);
+            loader.LoadPackages(new[] { conflictingPackage });
+
+            Assert.IsFalse(eventFired,
+                "ConflictingCustomNodePackageLoaded must not fire when the installed package " +
+                "is already scheduled for uninstall (the user already chose to proceed).");
+
+            loader.PackagesLoaded -= libraryLoader.LoadPackages;
+            loader.RequestLoadNodeLibrary -= libraryLoader.LoadLibraryAndSuppressZTSearchImport;
+            loader.RequestLoadCustomNodeDirectory -= reqLoadCNDelegate;
+        }
+
         // This can occur when a user copies a custom node from a package into definitions folder.
         // TODO not exactly clear what behavior should be.
         [Test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

Fixes DYN-7587: clicking **No** on the "Cannot Download Package" dialog still left the new package installed on disk in a partially-loaded state.

When installing a package, `PackageManagerClientViewModel.SetPackageState` previously called `PackageDownloadHandle.Extract` (which copies the unzipped package into Dynamo's packages folder) and then called `PackageLoader.LoadPackages`. Custom node guid conflicts only surfaced inside `CustomNodeManager.SetNodeInfo`, which threw `CustomNodePackageLoadException`. By the time the dialog appeared, the package was already extracted, so clicking **No** stranded the new package on disk while leaving the older one untouched.

This PR detects the conflict **before** any files land in the Dynamo packages folder.

#### Implementation summary

- `PackageDownloadHandle` is split into three explicit phases that share private staging state on the handle itself (no extra DTO):
  - `BuildStagedPackage` unzips the download into a temp folder, parses `pkg.json`, and remembers the staging/installed paths as private fields on the handle. Returns the staged `Package` whose `RootDirectory` points at the temp folder.
  - `FinalizeExtraction(Package)` copies the staged contents into the final install folder and updates `Package.RootDirectory`.
  - `CleanupStaging()` deletes the temp staging folder when an install is cancelled. Idempotent and safe to call before any staging has happened.
  - `Extract` is preserved as a thin wrapper around the new methods to keep the public surface unchanged.
- `CustomNodeManager.GetConflictingCustomNodeInfos` reads the staged `.dyf` headers (without registering them) and returns any existing `CustomNodeInfo` entries from a different package that share a function id.
- `PackageLoader.GetPackagesConflictingWithStagedPackage` maps those conflicts back to the local `Package` instances.
- `PackageManagerClientViewModel.SetPackageState` now:
  1. Stages the package.
  2. Asks for any conflicting already-loaded packages.
  3. If conflicts exist, shows the existing "Cannot Download Package" dialog (`MessageUninstallCustomNodeToContinue`).
  4. On **No**: deletes the staging folder, leaves the Dynamo packages folder, the loaded package list, and `PackageDirectoriesToUninstall` untouched, and moves the handle into the `Error` state.
  5. On **Yes**: marks the conflicting loaded package(s) for uninstall (matching the existing handler's behavior) and finalizes the install.
- `PackageLoader.OnConflictingPackageLoaded` skips the `ConflictingCustomNodePackageLoaded` event when the installed package is already scheduled for uninstall/unload, so the load that follows a pre-install **Yes** does not show the same dialog a second time when `CustomNodePackageLoadException` is still raised by the existing in-memory `NodeInfos` entries.

The post-load `ConflictingCustomNodePackageLoaded` path is preserved unchanged for non-download flows (e.g., scanning packages on startup) and as a defense in depth.

### Declarations

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

`PackageDownloadHandle.Extract` keeps the same public signature and behavior; the new staging/finalize/cleanup methods are `internal`. `PackageLoader.GetPackagesConflictingWithStagedPackage` and `CustomNodeManager.GetConflictingCustomNodeInfos` are also `internal`. No public API was added or changed.

### Release Notes

Fixed an issue where clicking "No" on the conflict prompt during package install still left the downloaded package extracted into the Dynamo packages folder; the new package is now never copied to the packages folder when the user declines the conflict prompt, and no stale entries are added to `PackageDirectoriesToUninstall`.

### Tests

New tests in `test/Libraries/PackageManagerTests`:

- `PackageLoaderTests.GetPackagesConflictingWithStagedPackageReturnsAlreadyLoadedConflictingPackage`
- `PackageLoaderTests.GetPackagesConflictingWithStagedPackageReturnsEmptyWhenSameName`
- `PackageLoaderTests.ConflictingCustomNodePackageLoadedEventDoesNotFireWhenInstalledPackageAlreadyMarkedForUninstall`
- `PackageDownloadHandleTests.BuildStagedPackageDoesNotCreatePackageInstallDirectory`
- `PackageDownloadHandleTests.FinalizeExtractionCopiesFilesAndUpdatesRootDirectory`
- `PackageDownloadHandleTests.CleanupStagingDeletesTheStagingDirectory`
- `PackageDownloadHandleTests.CleanupStagingTolerantOfMissingDirectory`
- `PackageDownloadHandleTests.FinalizeExtractionWithoutStageThrows`

All 8 new tests pass on Linux (`dotnet test ... -p:Platform=NET_Linux`). The existing 30 pre-existing failures in `PackageManagerTests` on Linux are unrelated path-separator issues already present on master.

### Reviewers

(FILL ME IN)

### FYIs

(FILL ME IN, Optional)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e642c6f-058e-4066-853b-3bbd782c28f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e642c6f-058e-4066-853b-3bbd782c28f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

