### PR TITLE
DYN-9078: Context menu submenu chevron turns white on hover and when expanded

### DIFF
--- a/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
+++ b/src/DynamoCoreWpf/UI/Themes/Modern/DynamoModern.xaml
@@ -4114,7 +4114,11 @@
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="ContentPresenter" Property="TextBlock.Foreground" Value="White" />
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource GenericMouseOverBackgroundColorBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsSubmenuOpen" Value="True">
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="False">
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackground}" />
@@ -4211,7 +4215,11 @@
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="ContentPresenter" Property="TextBlock.Foreground" Value="White" />
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource GenericMouseOverBackgroundColorBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsSubmenuOpen" Value="True">
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="False">
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource GenericBorderBackgroundColorBrush}" />
@@ -4311,7 +4319,11 @@
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="ContentPresenter" Property="TextBlock.Foreground" Value="White" />
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackgroundHighlight}" />
+                        </Trigger>
+                        <Trigger Property="IsSubmenuOpen" Value="True">
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="False">
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackground}" />
@@ -5745,7 +5757,11 @@
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="ContentPresenter" Property="TextBlock.Foreground" Value="White" />
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackgroundHighlight}" />
+                        </Trigger>
+                        <Trigger Property="IsSubmenuOpen" Value="True">
+                            <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="False">
                             <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackground}" />

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -1989,6 +1989,20 @@ namespace Dynamo.Nodes
             return border;
         }
 
+        private static void ApplySubmenuHighlight(Border border, TextBlock label, TextBlock arrow)
+        {
+            border.Background = _nodeContextMenuBackgroundHighlight;
+            label.Foreground = Brushes.White;
+            arrow.Foreground = Brushes.White;
+        }
+
+        private static void ResetSubmenuHighlight(Border border, TextBlock label, TextBlock arrow)
+        {
+            border.Background = Brushes.Transparent;
+            label.Foreground = _nodeContextMenuForeground;
+            arrow.Foreground = _blue300Brush;
+        }
+
         private Grid CreateSubmenuItem(string label, Func<UIElement> submenuContentFactory, bool isEnabled = true)
         {
             var popup = new Popup
@@ -2005,6 +2019,7 @@ namespace Dynamo.Nodes
                 FontSize = 13,
                 FontFamily = _artifaktElementRegular,
                 Foreground = _blue300Brush,
+                Margin = new Thickness(0, 0, 8, 7),
                 VerticalAlignment = VerticalAlignment.Center,
                 HorizontalAlignment = HorizontalAlignment.Right,
                 RenderTransform = new ScaleTransform(1, 1.5)
@@ -2034,55 +2049,27 @@ namespace Dynamo.Nodes
 
             var border = WrapWithMenuBorder(layoutGrid, isEnabled: isEnabled);
 
-            void SetSubmenuHighlight()
-            {
-                border.Background = _nodeContextMenuBackgroundHighlight;
-                text.Foreground = Brushes.White;
-                arrow.Foreground = Brushes.White;
-            }
-
-            void ResetSubmenuHighlight()
-            {
-                border.Background = Brushes.Transparent;
-                text.Foreground = _nodeContextMenuForeground;
-                arrow.Foreground = _blue300Brush;
-            }
-
             border.MouseEnter += (s, e) =>
             {
                 if (!isEnabled) return;
                 popup.Child = submenuContentFactory.Invoke();
                 popup.PlacementTarget = border;
                 popup.IsOpen = true;
-                SetSubmenuHighlight();
+                ApplySubmenuHighlight(border, text, arrow);
             };
 
             border.MouseLeave += (s, e) =>
             {
                 if (!isEnabled) return;
-                if (!popup.IsMouseOver)
+                // Defer so moving from the row into the flyout is not treated as a leave.
+                border.Dispatcher.BeginInvoke(new Action(() =>
                 {
-                    popup.IsOpen = false;
-                    ResetSubmenuHighlight();
-                }
-            };
-
-            popup.MouseLeave += (s, e) =>
-            {
-                if (!isEnabled) return;
-                if (!border.IsMouseOver)
-                {
-                    popup.IsOpen = false;
-                    ResetSubmenuHighlight();
-                }
-            };
-
-            popup.Closed += (s, e) =>
-            {
-                if (!border.IsMouseOver)
-                {
-                    ResetSubmenuHighlight();
-                }
+                    if (!border.IsMouseOver && !popup.IsMouseOver)
+                    {
+                        popup.IsOpen = false;
+                        ResetSubmenuHighlight(border, text, arrow);
+                    }
+                }), DispatcherPriority.Input);
             };
 
             return new Grid { Children = { border, popup } };

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -2019,9 +2019,10 @@ namespace Dynamo.Nodes
                 FontSize = 13,
                 FontFamily = _artifaktElementRegular,
                 Foreground = _blue300Brush,
-                Margin = new Thickness(0, 0, 8, 7),
+                Margin = new Thickness(0, 0, 8, 0),
                 VerticalAlignment = VerticalAlignment.Center,
                 HorizontalAlignment = HorizontalAlignment.Right,
+                RenderTransformOrigin = new Point(0.5, 0.5),
                 RenderTransform = new ScaleTransform(1, 1.5)
             };
 

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -2034,13 +2034,27 @@ namespace Dynamo.Nodes
 
             var border = WrapWithMenuBorder(layoutGrid, isEnabled: isEnabled);
 
+            void SetSubmenuHighlight()
+            {
+                border.Background = _nodeContextMenuBackgroundHighlight;
+                text.Foreground = Brushes.White;
+                arrow.Foreground = Brushes.White;
+            }
+
+            void ResetSubmenuHighlight()
+            {
+                border.Background = Brushes.Transparent;
+                text.Foreground = _nodeContextMenuForeground;
+                arrow.Foreground = _blue300Brush;
+            }
+
             border.MouseEnter += (s, e) =>
             {
                 if (!isEnabled) return;
                 popup.Child = submenuContentFactory.Invoke();
                 popup.PlacementTarget = border;
                 popup.IsOpen = true;
-                border.Background = _nodeContextMenuBackgroundHighlight;
+                SetSubmenuHighlight();
             };
 
             border.MouseLeave += (s, e) =>
@@ -2049,7 +2063,25 @@ namespace Dynamo.Nodes
                 if (!popup.IsMouseOver)
                 {
                     popup.IsOpen = false;
-                    border.Background = Brushes.Transparent;
+                    ResetSubmenuHighlight();
+                }
+            };
+
+            popup.MouseLeave += (s, e) =>
+            {
+                if (!isEnabled) return;
+                if (!border.IsMouseOver)
+                {
+                    popup.IsOpen = false;
+                    ResetSubmenuHighlight();
+                }
+            };
+
+            popup.Closed += (s, e) =>
+            {
+                if (!border.IsMouseOver)
+                {
+                    ResetSubmenuHighlight();
                 }
             };
 

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -2384,7 +2384,15 @@ namespace Dynamo.Controls
                 Value = true
             };
             isMouseOverTrueTrigger.Setters.Add(new Setter(TextBlock.ForegroundProperty, Brushes.White, "ContentPresenter"));
+            isMouseOverTrueTrigger.Setters.Add(new Setter(Label.ForegroundProperty, Brushes.White, "subMenuArrow"));
             isMouseOverTrueTrigger.Setters.Add(new Setter(DockPanel.BackgroundProperty, nodeContextMenuBackgroundHighlight, "dockPanel"));
+
+            var isSubmenuOpenTrigger = new Trigger
+            {
+                Property = MenuItem.IsSubmenuOpenProperty,
+                Value = true
+            };
+            isSubmenuOpenTrigger.Setters.Add(new Setter(Label.ForegroundProperty, Brushes.White, "subMenuArrow"));
 
             // Trigger for IsMouseOver property (false)
             var isMouseOverFalseTrigger = new Trigger

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -2384,7 +2384,15 @@ namespace Dynamo.Controls
                 Value = true
             };
             isMouseOverTrueTrigger.Setters.Add(new Setter(TextBlock.ForegroundProperty, Brushes.White, "ContentPresenter"));
+            isMouseOverTrueTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
             isMouseOverTrueTrigger.Setters.Add(new Setter(DockPanel.BackgroundProperty, nodeContextMenuBackgroundHighlight, "dockPanel"));
+
+            var isSubmenuOpenTrigger = new Trigger
+            {
+                Property = MenuItem.IsSubmenuOpenProperty,
+                Value = true
+            };
+            isSubmenuOpenTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
 
             // Trigger for IsMouseOver property (false)
             var isMouseOverFalseTrigger = new Trigger

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -2384,7 +2384,7 @@ namespace Dynamo.Controls
                 Value = true
             };
             isMouseOverTrueTrigger.Setters.Add(new Setter(TextBlock.ForegroundProperty, Brushes.White, "ContentPresenter"));
-            isMouseOverTrueTrigger.Setters.Add(new Setter(Label.ForegroundProperty, Brushes.White, "subMenuArrow"));
+            isMouseOverTrueTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
             isMouseOverTrueTrigger.Setters.Add(new Setter(DockPanel.BackgroundProperty, nodeContextMenuBackgroundHighlight, "dockPanel"));
 
             var isSubmenuOpenTrigger = new Trigger
@@ -2392,7 +2392,7 @@ namespace Dynamo.Controls
                 Property = MenuItem.IsSubmenuOpenProperty,
                 Value = true
             };
-            isSubmenuOpenTrigger.Setters.Add(new Setter(Label.ForegroundProperty, Brushes.White, "subMenuArrow"));
+            isSubmenuOpenTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
 
             // Trigger for IsMouseOver property (false)
             var isMouseOverFalseTrigger = new Trigger

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -2384,15 +2384,7 @@ namespace Dynamo.Controls
                 Value = true
             };
             isMouseOverTrueTrigger.Setters.Add(new Setter(TextBlock.ForegroundProperty, Brushes.White, "ContentPresenter"));
-            isMouseOverTrueTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
             isMouseOverTrueTrigger.Setters.Add(new Setter(DockPanel.BackgroundProperty, nodeContextMenuBackgroundHighlight, "dockPanel"));
-
-            var isSubmenuOpenTrigger = new Trigger
-            {
-                Property = MenuItem.IsSubmenuOpenProperty,
-                Value = true
-            };
-            isSubmenuOpenTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
 
             // Trigger for IsMouseOver property (false)
             var isMouseOverFalseTrigger = new Trigger
@@ -2423,6 +2415,7 @@ namespace Dynamo.Controls
             // Add the triggers to the ControlTemplate
             menuItemTemplate.Triggers.Add(isEnabledTrigger);
             menuItemTemplate.Triggers.Add(isMouseOverTrueTrigger);
+            menuItemTemplate.Triggers.Add(isSubmenuOpenTrigger);
             menuItemTemplate.Triggers.Add(isMouseOverFalseTrigger);
             menuItemTemplate.Triggers.Add(dataTrigger);
             menuItemTemplate.Triggers.Add(isCheckedTrigger);

--- a/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/NodeView.xaml.cs
@@ -2377,22 +2377,15 @@ namespace Dynamo.Controls
             };
             isEnabledTrigger.Setters.Add(new Setter(TextBlock.OpacityProperty, 0.5, "ContentPresenter"));
 
-            // Trigger for IsMouseOver property (true)
-            var isMouseOverTrueTrigger = new Trigger
+            // IsHighlighted tracks hover and open-submenu parent row without outliving mouse leave.
+            var isHighlightedTrigger = new Trigger
             {
-                Property = UIElement.IsMouseOverProperty,
+                Property = MenuItem.IsHighlightedProperty,
                 Value = true
             };
-            isMouseOverTrueTrigger.Setters.Add(new Setter(TextBlock.ForegroundProperty, Brushes.White, "ContentPresenter"));
-            isMouseOverTrueTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
-            isMouseOverTrueTrigger.Setters.Add(new Setter(DockPanel.BackgroundProperty, nodeContextMenuBackgroundHighlight, "dockPanel"));
-
-            var isSubmenuOpenTrigger = new Trigger
-            {
-                Property = MenuItem.IsSubmenuOpenProperty,
-                Value = true
-            };
-            isSubmenuOpenTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
+            isHighlightedTrigger.Setters.Add(new Setter(TextBlock.ForegroundProperty, Brushes.White, "ContentPresenter"));
+            isHighlightedTrigger.Setters.Add(new Setter(Control.ForegroundProperty, Brushes.White, "subMenuArrow"));
+            isHighlightedTrigger.Setters.Add(new Setter(DockPanel.BackgroundProperty, nodeContextMenuBackgroundHighlight, "dockPanel"));
 
             // Trigger for IsMouseOver property (false)
             var isMouseOverFalseTrigger = new Trigger
@@ -2422,8 +2415,7 @@ namespace Dynamo.Controls
 
             // Add the triggers to the ControlTemplate
             menuItemTemplate.Triggers.Add(isEnabledTrigger);
-            menuItemTemplate.Triggers.Add(isMouseOverTrueTrigger);
-            menuItemTemplate.Triggers.Add(isSubmenuOpenTrigger);
+            menuItemTemplate.Triggers.Add(isHighlightedTrigger);
             menuItemTemplate.Triggers.Add(isMouseOverFalseTrigger);
             menuItemTemplate.Triggers.Add(dataTrigger);
             menuItemTemplate.Triggers.Add(isCheckedTrigger);

--- a/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/WorkspaceView.xaml
@@ -507,7 +507,11 @@
                                     </Trigger>
                                     <Trigger Property="IsMouseOver" Value="True">
                                         <Setter TargetName="ContentPresenter" Property="TextBlock.Foreground" Value="White" />
+                                        <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                                         <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackgroundHighlight}" />
+                                    </Trigger>
+                                    <Trigger Property="IsSubmenuOpen" Value="True">
+                                        <Setter TargetName="subMenuArrow" Property="Foreground" Value="White" />
                                     </Trigger>
                                     <Trigger Property="IsMouseOver" Value="False">
                                         <Setter TargetName="dockPanel" Property="Background" Value="{StaticResource NodeContextMenuBackground}" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

Fixes **DYN-9078**.

In node, workspace, and group context menus, items that open a submenu show a small blue `>` on the right. When you hover those items or open the submenu, the label text turns white, but the arrow stayed blue. That made the menu feel inconsistent.

This PR updates styling so the arrow turns white in the same situations, including group (annotation) context menus, with chevron alignment fixed for groups.

**Node context menu (latest):** Uses `MenuItem.IsHighlighted` for white label, arrow, and row highlight—matching other Dynamo menus. This replaces separate `IsMouseOver` + `IsSubmenuOpen` triggers, which left the arrow white for ~1s after the pointer left because `IsSubmenuOpen` stayed true while the flyout closed.

### Declarations

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Context menu items with submenus now show a white chevron when hovered or expanded, matching the menu label. Applies to node, workspace, and group context menus.

### Reviewers

(FILL ME IN)

### FYIs

**Suggested title:** `DYN-9078: Context menu submenu chevron turns white on hover and when expanded`

**What to try (Windows):**
- Right-click a **node** → hover items with submenus (e.g. Lacing); move the pointer off—the `>` should return to blue promptly (no ~1s delay).
- Open a submenu and move into the flyout—the parent row chevron should stay white while that row is still highlighted.
- Repeat for **workspace** and **group** menus (Group Style, Color, Font Size).

**Files touched:**
- `DynamoModern.xaml` — shared context menu styles
- `WorkspaceView.xaml` — in-canvas workspace menu
- `NodeView.xaml.cs` — programmatic node menu (`IsHighlighted` trigger)
- `AnnotationView.xaml.cs` — group menu hover + chevron alignment

No public API changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-504373c7-9f38-4ad0-958f-ea6c06b9e155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-504373c7-9f38-4ad0-958f-ea6c06b9e155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

