### PR TITLE
DYN-9707 Show error when graph is open in another Dynamo session

### DIFF
--- a/src/DynamoCore/Exceptions/GraphFileOpenInAnotherSessionException.cs
+++ b/src/DynamoCore/Exceptions/GraphFileOpenInAnotherSessionException.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Dynamo.Exceptions
+{
+    /// <summary>
+    /// Thrown when attempting to open a graph file that is already open in another
+    /// active Dynamo session.
+    /// </summary>
+    internal class GraphFileOpenInAnotherSessionException : Exception
+    {
+        /// <summary>
+        /// Path to the graph file that is already open elsewhere.
+        /// </summary>
+        public string FilePath { get; }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="GraphFileOpenInAnotherSessionException"/>.
+        /// </summary>
+        /// <param name="filePath">Path to the graph file.</param>
+        public GraphFileOpenInAnotherSessionException(string filePath)
+            : base(filePath)
+        {
+            FilePath = filePath;
+        }
+    }
+}

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -3387,7 +3387,12 @@ namespace Dynamo.Models
             }
 
             //don't save the file path
+            var previousFileName = CurrentWorkspace.FileName;
             CurrentWorkspace.FileName = "";
+            if (!string.IsNullOrEmpty(previousFileName))
+            {
+                DynamoGraphFileSessionTracker.UnregisterOpenFile(previousFileName);
+            }
             CurrentWorkspace.HasUnsavedChanges = false;
             EngineController.CurrentWorkspaceVersion = AssemblyHelper.GetDynamoVersion();
 

--- a/src/DynamoCore/Models/DynamoModelCommands.cs
+++ b/src/DynamoCore/Models/DynamoModelCommands.cs
@@ -14,6 +14,8 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Graph.Notes;
 using Dynamo.Graph.Workspaces;
+using Dynamo.Exceptions;
+using Dynamo.Utilities;
 
 namespace Dynamo.Models
 {
@@ -47,7 +49,29 @@ namespace Dynamo.Models
             string filePath = command.FilePath;
             bool forceManualMode = command.ForceManualExecutionMode;
             bool isTemplate = command.IsTemplate;
-            OpenFileFromPath(filePath, forceManualMode);
+
+            if (!isTemplate)
+            {
+                if (DynamoGraphFileSessionTracker.IsOpenInAnotherSession(filePath)
+                    || !DynamoGraphFileSessionTracker.TryRegisterOpenFile(filePath))
+                {
+                    throw new GraphFileOpenInAnotherSessionException(filePath);
+                }
+            }
+
+            try
+            {
+                OpenFileFromPath(filePath, forceManualMode);
+            }
+            catch
+            {
+                if (!isTemplate)
+                {
+                    DynamoGraphFileSessionTracker.UnregisterOpenFile(filePath);
+                }
+
+                throw;
+            }
 
             //clear the clipboard to avoid copying between dyns
             //ClipBoard.Clear();

--- a/src/DynamoCore/Models/DynamoModelEvents.cs
+++ b/src/DynamoCore/Models/DynamoModelEvents.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using Dynamo.Graph;
 using Dynamo.Extensions;
 using Dynamo.Logging;
+using Dynamo.Utilities;
 
 namespace Dynamo.Models
 {
@@ -185,6 +186,11 @@ namespace Dynamo.Models
         public event Action<WorkspaceModel> WorkspaceRemoved;
         protected virtual void OnWorkspaceRemoved(WorkspaceModel obj)
         {
+            if (!string.IsNullOrEmpty(obj.FileName))
+            {
+                DynamoGraphFileSessionTracker.UnregisterOpenFile(obj.FileName);
+            }
+
             var handler = WorkspaceRemoved;
             if (handler != null) handler(obj);
 

--- a/src/DynamoCore/Utilities/DynamoGraphFileSessionTracker.cs
+++ b/src/DynamoCore/Utilities/DynamoGraphFileSessionTracker.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using Dynamo.Models;
+
+namespace Dynamo.Utilities
+{
+    /// <summary>
+    /// Tracks graph files opened in the current Dynamo process and detects when the same
+    /// file is already open in another active Dynamo session.
+    /// </summary>
+    internal static class DynamoGraphFileSessionTracker
+    {
+        private const string MutexNamePrefix = "Dynamo_GraphFile_";
+        private static readonly ConcurrentDictionary<string, Mutex> heldLocks =
+            new ConcurrentDictionary<string, Mutex>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Returns true when the file is a persisted Dynamo graph that should participate in
+        /// cross-session open tracking.
+        /// </summary>
+        internal static bool ShouldTrackFile(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath) || DynamoModel.IsTestMode)
+            {
+                return false;
+            }
+
+            var extension = Path.GetExtension(filePath);
+            return extension.Equals(".dyn", StringComparison.OrdinalIgnoreCase)
+                || extension.Equals(".dyf", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Returns true when another active Dynamo session already has the file open.
+        /// </summary>
+        internal static bool IsOpenInAnotherSession(string filePath)
+        {
+            if (!ShouldTrackFile(filePath))
+            {
+                return false;
+            }
+
+            var normalizedPath = NormalizePath(filePath);
+            if (heldLocks.ContainsKey(normalizedPath))
+            {
+                return false;
+            }
+
+            var mutexName = GetMutexName(normalizedPath);
+            if (!Mutex.TryOpenExisting(mutexName, out Mutex existingMutex))
+            {
+                return false;
+            }
+
+            existingMutex.Dispose();
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to register the current process as having the graph file open.
+        /// Returns false when another active Dynamo session already holds the lock.
+        /// </summary>
+        internal static bool TryRegisterOpenFile(string filePath)
+        {
+            if (!ShouldTrackFile(filePath))
+            {
+                return true;
+            }
+
+            var normalizedPath = NormalizePath(filePath);
+            if (heldLocks.ContainsKey(normalizedPath))
+            {
+                return true;
+            }
+
+            var mutexName = GetMutexName(normalizedPath);
+            var mutex = new Mutex(false, mutexName, out bool createdNew);
+            if (!createdNew)
+            {
+                mutex.Dispose();
+                return false;
+            }
+
+            heldLocks[normalizedPath] = mutex;
+            return true;
+        }
+
+        /// <summary>
+        /// Unregisters the graph file for the current process.
+        /// </summary>
+        internal static void UnregisterOpenFile(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath) || DynamoModel.IsTestMode)
+            {
+                return;
+            }
+
+            var normalizedPath = NormalizePath(filePath);
+            if (!heldLocks.TryRemove(normalizedPath, out Mutex mutex))
+            {
+                return;
+            }
+
+            try
+            {
+                mutex.ReleaseMutex();
+            }
+            catch (ApplicationException)
+            {
+                // Mutex was not owned by this thread.
+            }
+
+            mutex.Dispose();
+        }
+
+        private static string NormalizePath(string filePath)
+        {
+            return Path.GetFullPath(filePath);
+        }
+
+        private static string GetMutexName(string normalizedPath)
+        {
+            using (var sha256 = SHA256.Create())
+            {
+                var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(normalizedPath));
+                return MutexNamePrefix + Convert.ToHexString(hash);
+            }
+        }
+    }
+}

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -1989,8 +1989,22 @@ namespace Dynamo.ViewModels
                 if (AskUserToSaveWorkspaceOrCancel(HomeSpace))
                 {
                     filePath = command.FilePath;
-                    ExecuteCommand(command);
-                    ShowStartPage = false;
+                    try
+                    {
+                        ExecuteCommand(command);
+                        ShowStartPage = false;
+                    }
+                    catch (GraphFileOpenInAnotherSessionException)
+                    {
+                        if (!DynamoModel.IsTestMode)
+                        {
+                            ShowGraphAlreadyOpenInAnotherSessionMessage();
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
                 }
             }
             else
@@ -2128,6 +2142,19 @@ namespace Dynamo.ViewModels
                     FileTrustViewModel.AllowOneTimeTrust = false;
                 }
             }
+            catch (GraphFileOpenInAnotherSessionException)
+            {
+                if (!DynamoModel.IsTestMode)
+                {
+                    ShowGraphAlreadyOpenInAnotherSessionMessage();
+                    this.ShowStartPage = true;
+                }
+                else
+                {
+                    throw;
+                }
+                return;
+            }
             catch (Exception e)
             {
                 if (!DynamoModel.IsTestMode)
@@ -2256,6 +2283,16 @@ namespace Dynamo.ViewModels
         {
             var jsonDynFile = ResourceUtilities.LoadContentFromResources(GuidesManager.OnboardingGuideWorkspaceEmbeededResource, Assembly.GetExecutingAssembly(), false, false);
             OpenFromJson(new Tuple<string, bool>(jsonDynFile, true));
+        }
+
+        private void ShowGraphAlreadyOpenInAnotherSessionMessage()
+        {
+            DynamoMessageBox.Show(
+                Owner,
+                "Already opened",
+                "Error!!!",
+                MessageBoxButton.OKCancel,
+                MessageBoxImage.Error);
         }
 
         private bool CanOpen(object parameters)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

When a user tries to open a `.dyn` or `.dyf` file that is already open in another active Dynamo session, Dynamo now blocks the open and shows a `DynamoMessageBox` with placeholder copy (title **Error!!!**, body **Already opened**) and **OK** / **Cancel** buttons. Both buttons dismiss the dialog for now.

Cross-session detection uses a named mutex keyed by the normalized file path. The lock is acquired before opening the graph and released when the workspace is removed or the home workspace is cleared.

### Declarations

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [x] This PR contains no files larger than 50 MB

### Release Notes

Dynamo shows an error dialog when you try to open a graph file that is already open in another Dynamo session.

### Reviewers

Dynamo team

### FYIs

Placeholder dialog strings are hardcoded per initial scope; localization and button behavior can follow in a subsequent change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34cd2c70-3d80-41ad-9d8a-a5861eca76b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34cd2c70-3d80-41ad-9d8a-a5861eca76b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

