### PR TITLE
DYN-9707 warn when graph is open in another Dynamo instance

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/GraphLockService.cs
+++ b/src/DynamoCore/Graph/Workspaces/GraphLockService.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using Newtonsoft.Json;
 
@@ -49,38 +48,38 @@ namespace Dynamo.Graph.Workspaces
 
     internal sealed class GraphLockData
     {
-        [JsonProperty("schemaVersion")]
+        [JsonProperty("schemaVersion", Order = 1)]
         internal int SchemaVersion { get; set; }
 
-        [JsonProperty("graphPath")]
+        [JsonProperty("sessionId", Order = 2)]
+        internal Guid SessionId { get; set; }
+
+        [JsonProperty("graphPath", Order = 3)]
         internal string GraphPath { get; set; }
 
-        [JsonProperty("userName")]
+        [JsonProperty("userName", Order = 4)]
         internal string UserName { get; set; }
 
-        [JsonProperty("hostName")]
-        internal string HostName { get; set; }
+        [JsonProperty("machineName", Order = 5)]
+        internal string MachineName { get; set; }
 
-        [JsonProperty("processId")]
+        [JsonProperty("processId", Order = 6)]
         internal int ProcessId { get; set; }
 
-        [JsonProperty("processStartTimeUtc")]
-        internal DateTime ProcessStartTimeUtc { get; set; }
+        [JsonProperty("processStartUtc", Order = 7)]
+        internal DateTime ProcessStartUtc { get; set; }
 
-        [JsonProperty("dynamoVersion")]
+        [JsonProperty("dynamoVersion", Order = 8)]
         internal string DynamoVersion { get; set; }
 
-        [JsonProperty("dynamoMajorMinorVersion")]
-        internal string DynamoMajorMinorVersion { get; set; }
+        [JsonProperty("dynamoMajorMinor", Order = 9)]
+        internal string DynamoMajorMinor { get; set; }
 
-        [JsonProperty("dynamoBuild")]
-        internal string DynamoBuild { get; set; }
+        [JsonProperty("acquiredUtc", Order = 10)]
+        internal DateTime AcquiredUtc { get; set; }
 
-        [JsonProperty("lastHeartbeatUtc")]
+        [JsonProperty("lastHeartbeatUtc", Order = 11)]
         internal DateTime LastHeartbeatUtc { get; set; }
-
-        [JsonProperty("sessionId")]
-        internal Guid SessionId { get; set; }
     }
 
     internal sealed class GraphLockService : IDisposable
@@ -95,10 +94,9 @@ namespace Dynamo.Graph.Workspaces
         private readonly int processId;
         private readonly DateTime processStartTimeUtc;
         private readonly string userName;
-        private readonly string hostName;
+        private readonly string machineName;
         private readonly string dynamoVersion;
-        private readonly string dynamoMajorMinorVersion;
-        private readonly string dynamoBuild;
+        private readonly string dynamoMajorMinor;
         private readonly TimeSpan heartbeatInterval;
         private readonly TimeSpan staleHeartbeatThreshold;
         private readonly bool unregisterProcessExit;
@@ -107,7 +105,6 @@ namespace Dynamo.Graph.Workspaces
 
         internal GraphLockService(
             string dynamoVersion = null,
-            string dynamoBuild = null,
             TimeSpan? heartbeatInterval = null,
             int staleHeartbeatMultiplier = 5,
             bool registerProcessExit = true)
@@ -118,10 +115,9 @@ namespace Dynamo.Graph.Workspaces
             ownedLocks = new Dictionary<string, GraphLockData>(pathComparer);
             sessionId = Guid.NewGuid();
             userName = Environment.UserName;
-            hostName = Environment.MachineName;
+            machineName = Environment.MachineName;
             this.dynamoVersion = string.IsNullOrWhiteSpace(dynamoVersion) ? GetAssemblyVersion() : dynamoVersion;
-            this.dynamoMajorMinorVersion = GetMajorMinorVersion(this.dynamoVersion);
-            this.dynamoBuild = string.IsNullOrWhiteSpace(dynamoBuild) ? GetAssemblyInformationalVersion() : dynamoBuild;
+            dynamoMajorMinor = GetMajorMinorVersion(this.dynamoVersion);
 
             using (var process = Process.GetCurrentProcess())
             {
@@ -299,19 +295,20 @@ namespace Dynamo.Graph.Workspaces
 
         private GraphLockData CreateLockData(string canonicalGraphPath)
         {
+            var acquiredUtc = DateTime.UtcNow;
             return new GraphLockData
             {
                 SchemaVersion = CurrentSchemaVersion,
+                SessionId = sessionId,
                 GraphPath = canonicalGraphPath,
                 UserName = userName,
-                HostName = hostName,
+                MachineName = machineName,
                 ProcessId = processId,
-                ProcessStartTimeUtc = processStartTimeUtc,
+                ProcessStartUtc = processStartTimeUtc,
                 DynamoVersion = dynamoVersion,
-                DynamoMajorMinorVersion = dynamoMajorMinorVersion,
-                DynamoBuild = dynamoBuild,
-                LastHeartbeatUtc = DateTime.UtcNow,
-                SessionId = sessionId
+                DynamoMajorMinor = dynamoMajorMinor,
+                AcquiredUtc = acquiredUtc,
+                LastHeartbeatUtc = acquiredUtc
             };
         }
 
@@ -415,7 +412,7 @@ namespace Dynamo.Graph.Workspaces
 
         private bool IsDeadLocalProcess(GraphLockData lockData)
         {
-            if (!string.Equals(lockData.HostName, hostName, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(lockData.MachineName, machineName, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
@@ -425,7 +422,7 @@ namespace Dynamo.Graph.Workspaces
                 using (var process = Process.GetProcessById(lockData.ProcessId))
                 {
                     var startTimeUtc = GetProcessStartTimeUtc(process);
-                    return startTimeUtc != lockData.ProcessStartTimeUtc;
+                    return startTimeUtc != lockData.ProcessStartUtc;
                 }
             }
             catch (ArgumentException)
@@ -523,12 +520,6 @@ namespace Dynamo.Graph.Workspaces
         private static string GetAssemblyVersion()
         {
             return typeof(GraphLockService).Assembly.GetName().Version?.ToString() ?? string.Empty;
-        }
-
-        private static string GetAssemblyInformationalVersion()
-        {
-            var attribute = typeof(GraphLockService).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-            return attribute?.InformationalVersion ?? GetAssemblyVersion();
         }
 
         private static bool IsWindows()

--- a/src/DynamoCore/Graph/Workspaces/GraphLockService.cs
+++ b/src/DynamoCore/Graph/Workspaces/GraphLockService.cs
@@ -1,0 +1,548 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Newtonsoft.Json;
+
+namespace Dynamo.Graph.Workspaces
+{
+    internal enum GraphLockAcquisitionStatus
+    {
+        Acquired,
+        LockedByLiveSession,
+        StaleLock,
+        LockUnavailable
+    }
+
+    internal sealed class GraphLockAcquisitionResult
+    {
+        internal GraphLockAcquisitionResult(
+            GraphLockAcquisitionStatus status,
+            string graphPath,
+            string lockFilePath,
+            GraphLockData existingLock = null,
+            Exception exception = null)
+        {
+            Status = status;
+            GraphPath = graphPath;
+            LockFilePath = lockFilePath;
+            ExistingLock = existingLock;
+            Exception = exception;
+        }
+
+        internal GraphLockAcquisitionStatus Status { get; }
+
+        internal string GraphPath { get; }
+
+        internal string LockFilePath { get; }
+
+        internal GraphLockData ExistingLock { get; }
+
+        internal Exception Exception { get; }
+
+        internal bool LockAcquired => Status == GraphLockAcquisitionStatus.Acquired;
+    }
+
+    internal sealed class GraphLockData
+    {
+        [JsonProperty("schemaVersion")]
+        internal int SchemaVersion { get; set; }
+
+        [JsonProperty("graphPath")]
+        internal string GraphPath { get; set; }
+
+        [JsonProperty("userName")]
+        internal string UserName { get; set; }
+
+        [JsonProperty("hostName")]
+        internal string HostName { get; set; }
+
+        [JsonProperty("processId")]
+        internal int ProcessId { get; set; }
+
+        [JsonProperty("processStartTimeUtc")]
+        internal DateTime ProcessStartTimeUtc { get; set; }
+
+        [JsonProperty("dynamoVersion")]
+        internal string DynamoVersion { get; set; }
+
+        [JsonProperty("dynamoMajorMinorVersion")]
+        internal string DynamoMajorMinorVersion { get; set; }
+
+        [JsonProperty("dynamoBuild")]
+        internal string DynamoBuild { get; set; }
+
+        [JsonProperty("lastHeartbeatUtc")]
+        internal DateTime LastHeartbeatUtc { get; set; }
+
+        [JsonProperty("sessionId")]
+        internal Guid SessionId { get; set; }
+    }
+
+    internal sealed class GraphLockService : IDisposable
+    {
+        internal const int CurrentSchemaVersion = 1;
+        internal static readonly TimeSpan DefaultHeartbeatInterval = TimeSpan.FromSeconds(30);
+
+        private readonly object lockObject = new object();
+        private readonly Dictionary<string, GraphLockData> ownedLocks;
+        private readonly StringComparer pathComparer;
+        private readonly Guid sessionId;
+        private readonly int processId;
+        private readonly DateTime processStartTimeUtc;
+        private readonly string userName;
+        private readonly string hostName;
+        private readonly string dynamoVersion;
+        private readonly string dynamoMajorMinorVersion;
+        private readonly string dynamoBuild;
+        private readonly TimeSpan heartbeatInterval;
+        private readonly TimeSpan staleHeartbeatThreshold;
+        private readonly bool unregisterProcessExit;
+        private Timer heartbeatTimer;
+        private bool disposed;
+
+        internal GraphLockService(
+            string dynamoVersion = null,
+            string dynamoBuild = null,
+            TimeSpan? heartbeatInterval = null,
+            int staleHeartbeatMultiplier = 5,
+            bool registerProcessExit = true)
+        {
+            this.heartbeatInterval = heartbeatInterval ?? DefaultHeartbeatInterval;
+            staleHeartbeatThreshold = TimeSpan.FromTicks(this.heartbeatInterval.Ticks * Math.Max(1, staleHeartbeatMultiplier));
+            pathComparer = IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            ownedLocks = new Dictionary<string, GraphLockData>(pathComparer);
+            sessionId = Guid.NewGuid();
+            userName = Environment.UserName;
+            hostName = Environment.MachineName;
+            this.dynamoVersion = string.IsNullOrWhiteSpace(dynamoVersion) ? GetAssemblyVersion() : dynamoVersion;
+            this.dynamoMajorMinorVersion = GetMajorMinorVersion(this.dynamoVersion);
+            this.dynamoBuild = string.IsNullOrWhiteSpace(dynamoBuild) ? GetAssemblyInformationalVersion() : dynamoBuild;
+
+            using (var process = Process.GetCurrentProcess())
+            {
+                processId = process.Id;
+                processStartTimeUtc = GetProcessStartTimeUtc(process);
+            }
+
+            if (registerProcessExit)
+            {
+                AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
+                unregisterProcessExit = true;
+            }
+        }
+
+        internal GraphLockAcquisitionResult TryAcquireLock(string graphPath, bool force = false)
+        {
+            if (string.IsNullOrWhiteSpace(graphPath))
+            {
+                return new GraphLockAcquisitionResult(GraphLockAcquisitionStatus.LockUnavailable, graphPath, null);
+            }
+
+            var canonicalGraphPath = GetCanonicalGraphPath(graphPath);
+            var lockFilePath = GetLockFilePath(canonicalGraphPath);
+
+            lock (lockObject)
+            {
+                if (ownedLocks.ContainsKey(canonicalGraphPath))
+                {
+                    return new GraphLockAcquisitionResult(GraphLockAcquisitionStatus.Acquired, canonicalGraphPath, lockFilePath);
+                }
+            }
+
+            if (force)
+            {
+                return CreateOrOverwriteLock(canonicalGraphPath, lockFilePath);
+            }
+
+            try
+            {
+                var lockData = CreateLockData(canonicalGraphPath);
+                using (var fileStream = new FileStream(lockFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+                using (var streamWriter = new StreamWriter(fileStream))
+                using (var jsonWriter = new JsonTextWriter(streamWriter))
+                {
+                    CreateSerializer().Serialize(jsonWriter, lockData);
+                }
+
+                AddOwnedLock(canonicalGraphPath, lockData);
+                return new GraphLockAcquisitionResult(GraphLockAcquisitionStatus.Acquired, canonicalGraphPath, lockFilePath);
+            }
+            catch (IOException)
+            {
+                if (!File.Exists(lockFilePath))
+                {
+                    return new GraphLockAcquisitionResult(GraphLockAcquisitionStatus.LockUnavailable, canonicalGraphPath, lockFilePath);
+                }
+
+                return EvaluateExistingLock(canonicalGraphPath, lockFilePath);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return new GraphLockAcquisitionResult(GraphLockAcquisitionStatus.LockUnavailable, canonicalGraphPath, lockFilePath, exception: ex);
+            }
+            catch (Exception ex) when (ex is NotSupportedException || ex is DirectoryNotFoundException)
+            {
+                return new GraphLockAcquisitionResult(GraphLockAcquisitionStatus.LockUnavailable, canonicalGraphPath, lockFilePath, exception: ex);
+            }
+        }
+
+        internal void ReleaseLock(string graphPath)
+        {
+            if (string.IsNullOrWhiteSpace(graphPath))
+            {
+                return;
+            }
+
+            GraphLockData lockData;
+            var canonicalGraphPath = GetCanonicalGraphPath(graphPath);
+
+            lock (lockObject)
+            {
+                if (!ownedLocks.TryGetValue(canonicalGraphPath, out lockData))
+                {
+                    return;
+                }
+
+                ownedLocks.Remove(canonicalGraphPath);
+                StopHeartbeatTimerIfNeeded();
+            }
+
+            DeleteLockFileIfOwned(lockData);
+        }
+
+        internal void ReleaseAllLocks()
+        {
+            List<GraphLockData> locksToRelease;
+            lock (lockObject)
+            {
+                locksToRelease = ownedLocks.Values.ToList();
+                ownedLocks.Clear();
+                StopHeartbeatTimerIfNeeded();
+            }
+
+            foreach (var lockData in locksToRelease)
+            {
+                DeleteLockFileIfOwned(lockData);
+            }
+        }
+
+        internal static string GetLockFilePath(string graphPath)
+        {
+            var directory = Path.GetDirectoryName(graphPath);
+            var fileName = Path.GetFileName(graphPath);
+            return Path.Combine(directory, "." + fileName + ".lock");
+        }
+
+        internal static string GetCanonicalGraphPath(string graphPath)
+        {
+            return Path.GetFullPath(graphPath);
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (unregisterProcessExit)
+            {
+                AppDomain.CurrentDomain.ProcessExit -= CurrentDomain_ProcessExit;
+            }
+
+            ReleaseAllLocks();
+            heartbeatTimer?.Dispose();
+            disposed = true;
+        }
+
+        private GraphLockAcquisitionResult CreateOrOverwriteLock(string canonicalGraphPath, string lockFilePath)
+        {
+            try
+            {
+                var lockData = CreateLockData(canonicalGraphPath);
+                WriteLockData(lockFilePath, lockData);
+                AddOwnedLock(canonicalGraphPath, lockData);
+                return new GraphLockAcquisitionResult(GraphLockAcquisitionStatus.Acquired, canonicalGraphPath, lockFilePath);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is NotSupportedException || ex is DirectoryNotFoundException)
+            {
+                return new GraphLockAcquisitionResult(GraphLockAcquisitionStatus.LockUnavailable, canonicalGraphPath, lockFilePath, exception: ex);
+            }
+        }
+
+        private GraphLockAcquisitionResult EvaluateExistingLock(string canonicalGraphPath, string lockFilePath)
+        {
+            var existingLock = ReadLockData(lockFilePath);
+            if (existingLock == null)
+            {
+                return new GraphLockAcquisitionResult(GraphLockAcquisitionStatus.StaleLock, canonicalGraphPath, lockFilePath);
+            }
+
+            if (existingLock.SessionId == sessionId)
+            {
+                AddOwnedLock(canonicalGraphPath, existingLock);
+                return new GraphLockAcquisitionResult(GraphLockAcquisitionStatus.Acquired, canonicalGraphPath, lockFilePath);
+            }
+
+            if (IsStale(existingLock) || IsDeadLocalProcess(existingLock))
+            {
+                return new GraphLockAcquisitionResult(GraphLockAcquisitionStatus.StaleLock, canonicalGraphPath, lockFilePath, existingLock);
+            }
+
+            return new GraphLockAcquisitionResult(GraphLockAcquisitionStatus.LockedByLiveSession, canonicalGraphPath, lockFilePath, existingLock);
+        }
+
+        private GraphLockData CreateLockData(string canonicalGraphPath)
+        {
+            return new GraphLockData
+            {
+                SchemaVersion = CurrentSchemaVersion,
+                GraphPath = canonicalGraphPath,
+                UserName = userName,
+                HostName = hostName,
+                ProcessId = processId,
+                ProcessStartTimeUtc = processStartTimeUtc,
+                DynamoVersion = dynamoVersion,
+                DynamoMajorMinorVersion = dynamoMajorMinorVersion,
+                DynamoBuild = dynamoBuild,
+                LastHeartbeatUtc = DateTime.UtcNow,
+                SessionId = sessionId
+            };
+        }
+
+        private void AddOwnedLock(string canonicalGraphPath, GraphLockData lockData)
+        {
+            lock (lockObject)
+            {
+                ownedLocks[canonicalGraphPath] = lockData;
+                EnsureHeartbeatTimer();
+            }
+        }
+
+        private void EnsureHeartbeatTimer()
+        {
+            if (heartbeatTimer == null)
+            {
+                heartbeatTimer = new Timer(OnHeartbeat, null, heartbeatInterval, heartbeatInterval);
+            }
+            else
+            {
+                heartbeatTimer.Change(heartbeatInterval, heartbeatInterval);
+            }
+        }
+
+        private void StopHeartbeatTimerIfNeeded()
+        {
+            if (ownedLocks.Count == 0 && heartbeatTimer != null)
+            {
+                heartbeatTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            }
+        }
+
+        private void OnHeartbeat(object state)
+        {
+            List<KeyValuePair<string, GraphLockData>> locksToUpdate;
+            lock (lockObject)
+            {
+                locksToUpdate = ownedLocks.ToList();
+            }
+
+            foreach (var lockEntry in locksToUpdate)
+            {
+                var lockFilePath = GetLockFilePath(lockEntry.Key);
+                var existingLock = ReadLockData(lockFilePath);
+                if (existingLock == null || existingLock.SessionId != sessionId)
+                {
+                    lock (lockObject)
+                    {
+                        ownedLocks.Remove(lockEntry.Key);
+                        StopHeartbeatTimerIfNeeded();
+                    }
+                    continue;
+                }
+
+                existingLock.LastHeartbeatUtc = DateTime.UtcNow;
+                try
+                {
+                    WriteLockData(lockFilePath, existingLock);
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    Debug.WriteLine(ex.Message);
+                    continue;
+                }
+
+                lock (lockObject)
+                {
+                    if (ownedLocks.ContainsKey(lockEntry.Key))
+                    {
+                        ownedLocks[lockEntry.Key] = existingLock;
+                    }
+                }
+            }
+        }
+
+        private void DeleteLockFileIfOwned(GraphLockData lockData)
+        {
+            try
+            {
+                var lockFilePath = GetLockFilePath(lockData.GraphPath);
+                var existingLock = ReadLockData(lockFilePath);
+                if (existingLock?.SessionId == sessionId && File.Exists(lockFilePath))
+                {
+                    File.Delete(lockFilePath);
+                }
+            }
+            catch (IOException ex)
+            {
+                Debug.WriteLine(ex.Message);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                Debug.WriteLine(ex.Message);
+            }
+        }
+
+        private bool IsStale(GraphLockData lockData)
+        {
+            return DateTime.UtcNow - lockData.LastHeartbeatUtc > staleHeartbeatThreshold;
+        }
+
+        private bool IsDeadLocalProcess(GraphLockData lockData)
+        {
+            if (!string.Equals(lockData.HostName, hostName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            try
+            {
+                using (var process = Process.GetProcessById(lockData.ProcessId))
+                {
+                    var startTimeUtc = GetProcessStartTimeUtc(process);
+                    return startTimeUtc != lockData.ProcessStartTimeUtc;
+                }
+            }
+            catch (ArgumentException)
+            {
+                return true;
+            }
+            catch (InvalidOperationException)
+            {
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.Message);
+                return false;
+            }
+        }
+
+        private static GraphLockData ReadLockData(string lockFilePath)
+        {
+            const int maxAttempts = 2;
+            for (var attempt = 0; attempt < maxAttempts; attempt++)
+            {
+                try
+                {
+                    using (var fileStream = new FileStream(lockFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    using (var streamReader = new StreamReader(fileStream))
+                    using (var jsonReader = new JsonTextReader(streamReader))
+                    {
+                        return CreateSerializer().Deserialize<GraphLockData>(jsonReader);
+                    }
+                }
+                catch (Exception ex) when (ex is IOException || ex is JsonException)
+                {
+                    if (attempt == maxAttempts - 1)
+                    {
+                        return null;
+                    }
+
+                    Thread.Sleep(50);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    return null;
+                }
+            }
+
+            return null;
+        }
+
+        private static void WriteLockData(string lockFilePath, GraphLockData lockData)
+        {
+            using (var fileStream = new FileStream(lockFilePath, FileMode.Create, FileAccess.Write, FileShare.Read))
+            using (var streamWriter = new StreamWriter(fileStream))
+            using (var jsonWriter = new JsonTextWriter(streamWriter))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+                CreateSerializer().Serialize(jsonWriter, lockData);
+            }
+        }
+
+        private static JsonSerializer CreateSerializer()
+        {
+            return JsonSerializer.Create(new JsonSerializerSettings
+            {
+                Culture = CultureInfo.InvariantCulture,
+                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                TypeNameHandling = TypeNameHandling.None,
+                MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
+                MissingMemberHandling = MissingMemberHandling.Ignore,
+                NullValueHandling = NullValueHandling.Ignore
+            });
+        }
+
+        private static DateTime GetProcessStartTimeUtc(Process process)
+        {
+            try
+            {
+                return process.StartTime.ToUniversalTime();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.Message);
+                return DateTime.MinValue;
+            }
+        }
+
+        private static string GetMajorMinorVersion(string version)
+        {
+            Version parsedVersion;
+            return Version.TryParse(version, out parsedVersion)
+                ? parsedVersion.ToString(2)
+                : version;
+        }
+
+        private static string GetAssemblyVersion()
+        {
+            return typeof(GraphLockService).Assembly.GetName().Version?.ToString() ?? string.Empty;
+        }
+
+        private static string GetAssemblyInformationalVersion()
+        {
+            var attribute = typeof(GraphLockService).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            return attribute?.InformationalVersion ?? GetAssemblyVersion();
+        }
+
+        private static bool IsWindows()
+        {
+            var platform = Environment.OSVersion.Platform;
+            return platform == PlatformID.Win32NT ||
+                   platform == PlatformID.Win32S ||
+                   platform == PlatformID.Win32Windows ||
+                   platform == PlatformID.WinCE;
+        }
+
+        private void CurrentDomain_ProcessExit(object sender, EventArgs e)
+        {
+            ReleaseAllLocks();
+        }
+    }
+}

--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -4654,6 +4654,159 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Graph already open.
+        /// </summary>
+        public static string GraphLockMessageBoxTitle {
+            get {
+                return ResourceManager.GetString("GraphLockMessageBoxTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This graph is already open in Dynamo {0} on this machine. You can open a read-only copy or cancel..
+        /// </summary>
+        public static string GraphLockLocalMessage {
+            get {
+                return ResourceManager.GetString("GraphLockLocalMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This graph is currently open by {0} in Dynamo {1} (last activity {2}). You can open a read-only copy, cancel, or force open the graph..
+        /// </summary>
+        public static string GraphLockRemoteMessage {
+            get {
+                return ResourceManager.GetString("GraphLockRemoteMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This graph appears to have been left locked by a previous Dynamo session from {0} in Dynamo {1} (last activity {2}). You can take over the lock, open a read-only copy, or cancel..
+        /// </summary>
+        public static string GraphLockStaleMessage {
+            get {
+                return ResourceManager.GetString("GraphLockStaleMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This graph appears to have been left locked by a previous Dynamo session, but the lock details could not be read. You can take over the lock, open a read-only copy, or cancel..
+        /// </summary>
+        public static string GraphLockUnreadableStaleMessage {
+            get {
+                return ResourceManager.GetString("GraphLockUnreadableStaleMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open read-only.
+        /// </summary>
+        public static string GraphLockOpenReadOnlyButton {
+            get {
+                return ResourceManager.GetString("GraphLockOpenReadOnlyButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Force open.
+        /// </summary>
+        public static string GraphLockForceOpenButton {
+            get {
+                return ResourceManager.GetString("GraphLockForceOpenButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Take over lock.
+        /// </summary>
+        public static string GraphLockTakeOverButton {
+            get {
+                return ResourceManager.GetString("GraphLockTakeOverButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dynamo could not force open this graph because the lock file could not be updated. {0}.
+        /// </summary>
+        public static string GraphLockForceOpenFailureMessage {
+            get {
+                return ResourceManager.GetString("GraphLockForceOpenFailureMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dynamo could not take over this graph because the lock file could not be updated. {0}.
+        /// </summary>
+        public static string GraphLockTakeOverFailureMessage {
+            get {
+                return ResourceManager.GetString("GraphLockTakeOverFailureMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}@{1}.
+        /// </summary>
+        public static string GraphLockOwnerFormat {
+            get {
+                return ResourceManager.GetString("GraphLockOwnerFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to another user.
+        /// </summary>
+        public static string GraphLockUnknownOwner {
+            get {
+                return ResourceManager.GetString("GraphLockUnknownOwner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to an unknown version.
+        /// </summary>
+        public static string GraphLockUnknownVersion {
+            get {
+                return ResourceManager.GetString("GraphLockUnknownVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to unknown.
+        /// </summary>
+        public static string GraphLockUnknownLastActivity {
+            get {
+                return ResourceManager.GetString("GraphLockUnknownLastActivity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} seconds ago.
+        /// </summary>
+        public static string GraphLockSecondsAgo {
+            get {
+                return ResourceManager.GetString("GraphLockSecondsAgo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} minutes ago.
+        /// </summary>
+        public static string GraphLockMinutesAgo {
+            get {
+                return ResourceManager.GetString("GraphLockMinutesAgo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} hours ago.
+        /// </summary>
+        public static string GraphLockHoursAgo {
+            get {
+                return ResourceManager.GetString("GraphLockHoursAgo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid file path provided. In case the file is archived, please make sure to extract it before opening.\n{0}.
         /// </summary>
         public static string MessageErrorOpeningInvalidPath {

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -2508,6 +2508,57 @@ Next assemblies were loaded several times:
     <value>Error Opening File</value>
     <comment>Notification Center Title</comment>
   </data>
+  <data name="GraphLockMessageBoxTitle" xml:space="preserve">
+    <value>Graph already open</value>
+  </data>
+  <data name="GraphLockLocalMessage" xml:space="preserve">
+    <value>This graph is already open in Dynamo {0} on this machine. You can open a read-only copy or cancel.</value>
+  </data>
+  <data name="GraphLockRemoteMessage" xml:space="preserve">
+    <value>This graph is currently open by {0} in Dynamo {1} (last activity {2}). You can open a read-only copy, cancel, or force open the graph.</value>
+  </data>
+  <data name="GraphLockStaleMessage" xml:space="preserve">
+    <value>This graph appears to have been left locked by a previous Dynamo session from {0} in Dynamo {1} (last activity {2}). You can take over the lock, open a read-only copy, or cancel.</value>
+  </data>
+  <data name="GraphLockUnreadableStaleMessage" xml:space="preserve">
+    <value>This graph appears to have been left locked by a previous Dynamo session, but the lock details could not be read. You can take over the lock, open a read-only copy, or cancel.</value>
+  </data>
+  <data name="GraphLockOpenReadOnlyButton" xml:space="preserve">
+    <value>Open read-only</value>
+  </data>
+  <data name="GraphLockForceOpenButton" xml:space="preserve">
+    <value>Force open</value>
+  </data>
+  <data name="GraphLockTakeOverButton" xml:space="preserve">
+    <value>Take over lock</value>
+  </data>
+  <data name="GraphLockForceOpenFailureMessage" xml:space="preserve">
+    <value>Dynamo could not force open this graph because the lock file could not be updated. {0}</value>
+  </data>
+  <data name="GraphLockTakeOverFailureMessage" xml:space="preserve">
+    <value>Dynamo could not take over this graph because the lock file could not be updated. {0}</value>
+  </data>
+  <data name="GraphLockOwnerFormat" xml:space="preserve">
+    <value>{0}@{1}</value>
+  </data>
+  <data name="GraphLockUnknownOwner" xml:space="preserve">
+    <value>another user</value>
+  </data>
+  <data name="GraphLockUnknownVersion" xml:space="preserve">
+    <value>an unknown version</value>
+  </data>
+  <data name="GraphLockUnknownLastActivity" xml:space="preserve">
+    <value>unknown</value>
+  </data>
+  <data name="GraphLockSecondsAgo" xml:space="preserve">
+    <value>{0} seconds ago</value>
+  </data>
+  <data name="GraphLockMinutesAgo" xml:space="preserve">
+    <value>{0} minutes ago</value>
+  </data>
+  <data name="GraphLockHoursAgo" xml:space="preserve">
+    <value>{0} hours ago</value>
+  </data>
   <data name="DynamoViewSettingsMenuChangeScaleFactor" xml:space="preserve">
     <value>Geometry Scaling...</value>
     <comment>Settings menu | Geometry Scaling</comment>

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -70,6 +70,7 @@ namespace Dynamo.ViewModels
         public Window Owner { get; set; }
         private readonly DynamoModel model;
         private readonly GraphLockService graphLockService;
+        private readonly Dictionary<Guid, string> graphLockPathsByWorkspace = new Dictionary<Guid, string>();
         private Point transformOrigin;
         private bool showStartPage = false;
         private PreferencesViewModel preferencesViewModel;
@@ -1917,7 +1918,7 @@ namespace Dynamo.ViewModels
 
         private void WorkspaceRemoved(WorkspaceModel item)
         {
-            graphLockService.ReleaseLock(item.FileName);
+            ReleaseTrackedGraphLock(item);
             var viewModel = workspaces.First(x => x.Model == item);
             if (currentWorkspaceViewModel == viewModel)
                 if(currentWorkspaceViewModel != null)
@@ -2259,6 +2260,10 @@ namespace Dynamo.ViewModels
                 {
                     CurrentSpace.IsReadOnly = true;
                 }
+                else if (ownsGraphLock && CurrentSpace != null)
+                {
+                    TrackGraphLock(CurrentSpace, filePath);
+                }
 
                 // Apply annotation updates based on the preference setting
                 RefreshAnnotationDescriptions();
@@ -2512,6 +2517,61 @@ namespace Dynamo.ViewModels
             var assembly = typeof(DynamoModel).Assembly;
             var attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
             return attribute?.InformationalVersion ?? assembly.GetName().Version?.ToString();
+        }
+
+        private void TrackGraphLock(WorkspaceModel workspace, string graphPath)
+        {
+            graphLockPathsByWorkspace[workspace.Guid] = GraphLockService.GetCanonicalGraphPath(graphPath);
+            workspace.PropertyChanged -= WorkspaceGraphLockPropertyChanged;
+            workspace.PropertyChanged += WorkspaceGraphLockPropertyChanged;
+        }
+
+        private void ReleaseTrackedGraphLock(WorkspaceModel workspace)
+        {
+            string graphPath;
+            if (graphLockPathsByWorkspace.TryGetValue(workspace.Guid, out graphPath))
+            {
+                graphLockService.ReleaseLock(graphPath);
+                graphLockPathsByWorkspace.Remove(workspace.Guid);
+            }
+            else
+            {
+                graphLockService.ReleaseLock(workspace.FileName);
+            }
+
+            workspace.PropertyChanged -= WorkspaceGraphLockPropertyChanged;
+        }
+
+        private void WorkspaceGraphLockPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != nameof(WorkspaceModel.FileName))
+            {
+                return;
+            }
+
+            var workspace = sender as WorkspaceModel;
+            if (workspace == null)
+            {
+                return;
+            }
+
+            string graphPath;
+            if (!graphLockPathsByWorkspace.TryGetValue(workspace.Guid, out graphPath))
+            {
+                return;
+            }
+
+            var newGraphPath = string.IsNullOrWhiteSpace(workspace.FileName)
+                ? string.Empty
+                : GraphLockService.GetCanonicalGraphPath(workspace.FileName);
+            if (string.Equals(graphPath, newGraphPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            graphLockService.ReleaseLock(graphPath);
+            graphLockPathsByWorkspace.Remove(workspace.Guid);
+            workspace.PropertyChanged -= WorkspaceGraphLockPropertyChanged;
         }
 
         /// <summary>
@@ -4893,6 +4953,7 @@ namespace Dynamo.ViewModels
             ToastManager?.CloseRealTimeInfoWindow();
 
             graphLockService.Dispose();
+            graphLockPathsByWorkspace.Clear();
             model.ShutDown(shutdownParams.ShutdownHost);
             UsageReportingManager.DestroyInstance();
 

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -69,6 +69,7 @@ namespace Dynamo.ViewModels
         #region properties
         public Window Owner { get; set; }
         private readonly DynamoModel model;
+        private readonly GraphLockService graphLockService;
         private Point transformOrigin;
         private bool showStartPage = false;
         private PreferencesViewModel preferencesViewModel;
@@ -843,6 +844,7 @@ namespace Dynamo.ViewModels
 
             // initialize core data structures
             this.model = startConfiguration.DynamoModel;
+            graphLockService = new GraphLockService(DynamoModel.Version, GetDynamoBuildVersion());
             this.model.CommandStarting += OnModelCommandStarting;
             this.model.CommandCompleted += OnModelCommandCompleted;
             this.model.RequestsCrashPrompt += CrashReportTool.ShowCrashWindow;
@@ -1915,6 +1917,7 @@ namespace Dynamo.ViewModels
 
         private void WorkspaceRemoved(WorkspaceModel item)
         {
+            graphLockService.ReleaseLock(item.FileName);
             var viewModel = workspaces.First(x => x.Model == item);
             if (currentWorkspaceViewModel == viewModel)
                 if(currentWorkspaceViewModel != null)
@@ -2203,6 +2206,8 @@ namespace Dynamo.ViewModels
             fileContents = string.Empty;
             bool forceManualMode = false;
             bool isTemplate = false;
+            bool openReadOnly = false;
+            bool ownsGraphLock = false;
             try
             {
                 if (parameters is Tuple<string, bool> packedParams)
@@ -2223,6 +2228,24 @@ namespace Dynamo.ViewModels
 
                 var directoryName = Path.GetDirectoryName(filePath);
 
+                if (ShouldUseGraphLock(filePath, isTemplate))
+                {
+                    var lockAction = ResolveGraphLockAction(filePath);
+                    if (lockAction == GraphLockOpenAction.Cancel)
+                    {
+                        return;
+                    }
+
+                    if (lockAction == GraphLockOpenAction.OpenReadOnly)
+                    {
+                        openReadOnly = true;
+                    }
+                    else
+                    {
+                        ownsGraphLock = lockAction == GraphLockOpenAction.OpenWithLock;
+                    }
+                }
+
                 // Display trust warning when file is not among trust location and warning feature is on
                 bool displayTrustWarning = !PreferenceSettings.IsTrustedLocation(directoryName)
                     && !filePath.EndsWith("dyf")
@@ -2232,6 +2255,10 @@ namespace Dynamo.ViewModels
                 RunSettings.ForceBlockRun = displayTrustWarning;
                 // Execute graph open command
                 ExecuteCommand(new DynamoModel.OpenFileCommand(filePath, forceManualMode, isTemplate));
+                if (openReadOnly && CurrentSpace != null)
+                {
+                    CurrentSpace.IsReadOnly = true;
+                }
 
                 // Apply annotation updates based on the preference setting
                 RefreshAnnotationDescriptions();
@@ -2248,6 +2275,11 @@ namespace Dynamo.ViewModels
             }
             catch (Exception e)
             {
+                if (ownsGraphLock)
+                {
+                    graphLockService.ReleaseLock(filePath);
+                }
+
                 if (!DynamoModel.IsTestMode)
                 {
                     string commandString = String.Format(Resources.MessageErrorOpeningFileGeneral);
@@ -2284,6 +2316,202 @@ namespace Dynamo.ViewModels
                 return;
             }
             this.ShowStartPage = false; // Hide start page if there's one.
+        }
+
+        private enum GraphLockOpenAction
+        {
+            OpenWithLock,
+            OpenReadOnly,
+            Cancel
+        }
+
+        private bool ShouldUseGraphLock(string graphPath, bool isTemplate)
+        {
+            return !isTemplate
+                && !string.IsNullOrWhiteSpace(graphPath)
+                && string.Equals(Path.GetExtension(graphPath), ".dyn", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private GraphLockOpenAction ResolveGraphLockAction(string graphPath)
+        {
+            var acquisitionResult = graphLockService.TryAcquireLock(graphPath);
+            switch (acquisitionResult.Status)
+            {
+                case GraphLockAcquisitionStatus.Acquired:
+                    return GraphLockOpenAction.OpenWithLock;
+                case GraphLockAcquisitionStatus.LockUnavailable:
+                    model.Logger.Log(string.Format(
+                        "Graph lock file could not be created for {0}: {1}",
+                        graphPath,
+                        acquisitionResult.Exception?.Message));
+                    return GraphLockOpenAction.OpenReadOnly;
+                case GraphLockAcquisitionStatus.StaleLock:
+                    return ResolveStaleGraphLock(graphPath, acquisitionResult);
+                case GraphLockAcquisitionStatus.LockedByLiveSession:
+                    return ResolveLiveGraphLock(graphPath, acquisitionResult);
+                default:
+                    return GraphLockOpenAction.Cancel;
+            }
+        }
+
+        private GraphLockOpenAction ResolveLiveGraphLock(string graphPath, GraphLockAcquisitionResult acquisitionResult)
+        {
+            var existingLock = acquisitionResult.ExistingLock;
+            var isLocalUserLock = IsLocalUserLock(existingLock);
+            var message = isLocalUserLock
+                ? string.Format(Resources.GraphLockLocalMessage, GetLockDynamoVersion(existingLock))
+                : string.Format(
+                    Resources.GraphLockRemoteMessage,
+                    GetLockOwner(existingLock),
+                    GetLockDynamoVersion(existingLock),
+                    GetLastHeartbeatDescription(existingLock));
+
+            if (isLocalUserLock)
+            {
+                var localResult = MessageBoxService.Show(
+                    Owner,
+                    message,
+                    Resources.GraphLockMessageBoxTitle,
+                    MessageBoxButton.OKCancel,
+                    new[] { Resources.GraphLockOpenReadOnlyButton, Resources.CancelButton },
+                    MessageBoxImage.Warning);
+
+                return localResult == MessageBoxResult.OK
+                    ? GraphLockOpenAction.OpenReadOnly
+                    : GraphLockOpenAction.Cancel;
+            }
+
+            var result = MessageBoxService.Show(
+                Owner,
+                message,
+                Resources.GraphLockMessageBoxTitle,
+                MessageBoxButton.YesNoCancel,
+                new[] { Resources.GraphLockOpenReadOnlyButton, Resources.CancelButton, Resources.GraphLockForceOpenButton },
+                MessageBoxImage.Warning);
+
+            if (result == MessageBoxResult.Yes)
+            {
+                return GraphLockOpenAction.OpenReadOnly;
+            }
+
+            if (result == MessageBoxResult.Cancel)
+            {
+                return ForceAcquireGraphLock(graphPath, Resources.GraphLockForceOpenFailureMessage);
+            }
+
+            return GraphLockOpenAction.Cancel;
+        }
+
+        private GraphLockOpenAction ResolveStaleGraphLock(string graphPath, GraphLockAcquisitionResult acquisitionResult)
+        {
+            var existingLock = acquisitionResult.ExistingLock;
+            var message = existingLock == null
+                ? Resources.GraphLockUnreadableStaleMessage
+                : string.Format(
+                    Resources.GraphLockStaleMessage,
+                    GetLockOwner(existingLock),
+                    GetLockDynamoVersion(existingLock),
+                    GetLastHeartbeatDescription(existingLock));
+
+            var result = MessageBoxService.Show(
+                Owner,
+                message,
+                Resources.GraphLockMessageBoxTitle,
+                MessageBoxButton.YesNoCancel,
+                new[] { Resources.GraphLockTakeOverButton, Resources.GraphLockOpenReadOnlyButton, Resources.CancelButton },
+                MessageBoxImage.Warning);
+
+            if (result == MessageBoxResult.Yes)
+            {
+                return ForceAcquireGraphLock(graphPath, Resources.GraphLockTakeOverFailureMessage);
+            }
+
+            if (result == MessageBoxResult.No)
+            {
+                return GraphLockOpenAction.OpenReadOnly;
+            }
+
+            return GraphLockOpenAction.Cancel;
+        }
+
+        private GraphLockOpenAction ForceAcquireGraphLock(string graphPath, string failureMessage)
+        {
+            var forcedResult = graphLockService.TryAcquireLock(graphPath, true);
+            if (forcedResult.LockAcquired)
+            {
+                return GraphLockOpenAction.OpenWithLock;
+            }
+
+            MessageBoxService.Show(
+                Owner,
+                string.Format(failureMessage, forcedResult.Exception?.Message ?? graphPath),
+                Resources.GraphLockMessageBoxTitle,
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+
+            return GraphLockOpenAction.Cancel;
+        }
+
+        private static bool IsLocalUserLock(GraphLockData lockData)
+        {
+            return lockData != null
+                && string.Equals(lockData.HostName, Environment.MachineName, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(lockData.UserName, Environment.UserName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string GetLockOwner(GraphLockData lockData)
+        {
+            if (lockData == null)
+            {
+                return Resources.GraphLockUnknownOwner;
+            }
+
+            return string.Format(Resources.GraphLockOwnerFormat, lockData.UserName, lockData.HostName);
+        }
+
+        private static string GetLockDynamoVersion(GraphLockData lockData)
+        {
+            if (!string.IsNullOrWhiteSpace(lockData?.DynamoMajorMinorVersion))
+            {
+                return lockData.DynamoMajorMinorVersion;
+            }
+
+            return string.IsNullOrWhiteSpace(lockData?.DynamoVersion)
+                ? Resources.GraphLockUnknownVersion
+                : lockData.DynamoVersion;
+        }
+
+        private static string GetLastHeartbeatDescription(GraphLockData lockData)
+        {
+            if (lockData == null || lockData.LastHeartbeatUtc == DateTime.MinValue)
+            {
+                return Resources.GraphLockUnknownLastActivity;
+            }
+
+            var elapsed = DateTime.UtcNow - lockData.LastHeartbeatUtc;
+            if (elapsed < TimeSpan.Zero)
+            {
+                elapsed = TimeSpan.Zero;
+            }
+
+            if (elapsed.TotalSeconds < 60)
+            {
+                return string.Format(Resources.GraphLockSecondsAgo, Math.Max(0, (int)Math.Round(elapsed.TotalSeconds)));
+            }
+
+            if (elapsed.TotalMinutes < 60)
+            {
+                return string.Format(Resources.GraphLockMinutesAgo, Math.Max(1, (int)Math.Round(elapsed.TotalMinutes)));
+            }
+
+            return string.Format(Resources.GraphLockHoursAgo, Math.Max(1, (int)Math.Round(elapsed.TotalHours)));
+        }
+
+        private static string GetDynamoBuildVersion()
+        {
+            var assembly = typeof(DynamoModel).Assembly;
+            var attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            return attribute?.InformationalVersion ?? assembly.GetName().Version?.ToString();
         }
 
         /// <summary>
@@ -4664,6 +4892,7 @@ namespace Dynamo.ViewModels
             }
             ToastManager?.CloseRealTimeInfoWindow();
 
+            graphLockService.Dispose();
             model.ShutDown(shutdownParams.ShutdownHost);
             UsageReportingManager.DestroyInstance();
 

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -845,7 +845,7 @@ namespace Dynamo.ViewModels
 
             // initialize core data structures
             this.model = startConfiguration.DynamoModel;
-            graphLockService = new GraphLockService(DynamoModel.Version, GetDynamoBuildVersion());
+            graphLockService = new GraphLockService(DynamoModel.Version);
             this.model.CommandStarting += OnModelCommandStarting;
             this.model.CommandCompleted += OnModelCommandCompleted;
             this.model.RequestsCrashPrompt += CrashReportTool.ShowCrashWindow;
@@ -2460,7 +2460,7 @@ namespace Dynamo.ViewModels
         private static bool IsLocalUserLock(GraphLockData lockData)
         {
             return lockData != null
-                && string.Equals(lockData.HostName, Environment.MachineName, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(lockData.MachineName, Environment.MachineName, StringComparison.OrdinalIgnoreCase)
                 && string.Equals(lockData.UserName, Environment.UserName, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -2471,14 +2471,14 @@ namespace Dynamo.ViewModels
                 return Resources.GraphLockUnknownOwner;
             }
 
-            return string.Format(Resources.GraphLockOwnerFormat, lockData.UserName, lockData.HostName);
+            return string.Format(Resources.GraphLockOwnerFormat, lockData.UserName, lockData.MachineName);
         }
 
         private static string GetLockDynamoVersion(GraphLockData lockData)
         {
-            if (!string.IsNullOrWhiteSpace(lockData?.DynamoMajorMinorVersion))
+            if (!string.IsNullOrWhiteSpace(lockData?.DynamoMajorMinor))
             {
-                return lockData.DynamoMajorMinorVersion;
+                return lockData.DynamoMajorMinor;
             }
 
             return string.IsNullOrWhiteSpace(lockData?.DynamoVersion)
@@ -2510,13 +2510,6 @@ namespace Dynamo.ViewModels
             }
 
             return string.Format(Resources.GraphLockHoursAgo, Math.Max(1, (int)Math.Round(elapsed.TotalHours)));
-        }
-
-        private static string GetDynamoBuildVersion()
-        {
-            var assembly = typeof(DynamoModel).Assembly;
-            var attribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-            return attribute?.InformationalVersion ?? assembly.GetName().Version?.ToString();
         }
 
         private void TrackGraphLock(WorkspaceModel workspace, string graphPath)

--- a/test/DynamoCoreTests/Graph/Workspaces/GraphLockServiceTests.cs
+++ b/test/DynamoCoreTests/Graph/Workspaces/GraphLockServiceTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.IO;
+using Dynamo.Graph.Workspaces;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Dynamo.Tests.Graph.Workspaces
+{
+    [TestFixture]
+    internal class GraphLockServiceTests : UnitTestBase
+    {
+        [Test]
+        [Category("UnitTests")]
+        public void WhenLockDoesNotExistThenAcquireCreatesSidecar()
+        {
+            var graphPath = GetNewFileNameOnTempPath();
+            File.WriteAllText(graphPath, "{}");
+
+            using (var lockService = CreateLockService())
+            {
+                var result = lockService.TryAcquireLock(graphPath);
+
+                Assert.AreEqual(GraphLockAcquisitionStatus.Acquired, result.Status);
+                Assert.IsTrue(File.Exists(GraphLockService.GetLockFilePath(result.GraphPath)));
+
+                var lockData = ReadLockData(result.GraphPath);
+                Assert.AreEqual(GraphLockService.CurrentSchemaVersion, lockData.SchemaVersion);
+                Assert.AreEqual(GraphLockService.GetCanonicalGraphPath(graphPath), lockData.GraphPath);
+                Assert.AreEqual("3.6.1", lockData.DynamoVersion);
+                Assert.AreEqual("3.6", lockData.DynamoMajorMinorVersion);
+                Assert.AreEqual("build-123", lockData.DynamoBuild);
+                Assert.AreNotEqual(Guid.Empty, lockData.SessionId);
+            }
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenExistingLockHasLiveHeartbeatThenAcquireReportsLiveLock()
+        {
+            var graphPath = GetNewFileNameOnTempPath();
+            File.WriteAllText(graphPath, "{}");
+
+            using (var owningLockService = CreateLockService())
+            using (var secondLockService = CreateLockService())
+            {
+                owningLockService.TryAcquireLock(graphPath);
+
+                var result = secondLockService.TryAcquireLock(graphPath);
+
+                Assert.AreEqual(GraphLockAcquisitionStatus.LockedByLiveSession, result.Status);
+                Assert.IsNotNull(result.ExistingLock);
+                Assert.AreEqual(Environment.UserName, result.ExistingLock.UserName);
+                Assert.AreEqual(Environment.MachineName, result.ExistingLock.HostName);
+            }
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenExistingLockIsStaleThenAcquireReportsStaleLock()
+        {
+            var graphPath = GetNewFileNameOnTempPath();
+            File.WriteAllText(graphPath, "{}");
+            WriteStaleLock(graphPath);
+
+            using (var lockService = CreateLockService())
+            {
+                var result = lockService.TryAcquireLock(graphPath);
+
+                Assert.AreEqual(GraphLockAcquisitionStatus.StaleLock, result.Status);
+                Assert.IsNotNull(result.ExistingLock);
+            }
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenForceAcquireStaleLockThenSidecarIsOverwritten()
+        {
+            var graphPath = GetNewFileNameOnTempPath();
+            File.WriteAllText(graphPath, "{}");
+            WriteStaleLock(graphPath);
+
+            using (var lockService = CreateLockService())
+            {
+                var result = lockService.TryAcquireLock(graphPath, true);
+
+                Assert.AreEqual(GraphLockAcquisitionStatus.Acquired, result.Status);
+
+                var lockData = ReadLockData(result.GraphPath);
+                Assert.AreEqual(Environment.UserName, lockData.UserName);
+                Assert.AreEqual(Environment.MachineName, lockData.HostName);
+                Assert.AreEqual("3.6.1", lockData.DynamoVersion);
+            }
+        }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WhenLockIsReleasedThenOwnedSidecarIsDeleted()
+        {
+            var graphPath = GetNewFileNameOnTempPath();
+            File.WriteAllText(graphPath, "{}");
+
+            using (var lockService = CreateLockService())
+            {
+                var result = lockService.TryAcquireLock(graphPath);
+                Assert.IsTrue(File.Exists(GraphLockService.GetLockFilePath(result.GraphPath)));
+
+                lockService.ReleaseLock(graphPath);
+
+                Assert.IsFalse(File.Exists(GraphLockService.GetLockFilePath(result.GraphPath)));
+            }
+        }
+
+        private static GraphLockService CreateLockService()
+        {
+            return new GraphLockService(
+                "3.6.1",
+                "build-123",
+                TimeSpan.FromMilliseconds(100),
+                registerProcessExit: false);
+        }
+
+        private static GraphLockData ReadLockData(string graphPath)
+        {
+            return JsonConvert.DeserializeObject<GraphLockData>(
+                File.ReadAllText(GraphLockService.GetLockFilePath(graphPath)));
+        }
+
+        private static void WriteStaleLock(string graphPath)
+        {
+            var canonicalGraphPath = GraphLockService.GetCanonicalGraphPath(graphPath);
+            var lockData = new GraphLockData
+            {
+                SchemaVersion = GraphLockService.CurrentSchemaVersion,
+                GraphPath = canonicalGraphPath,
+                UserName = "stale-user",
+                HostName = "stale-host",
+                ProcessId = 123,
+                ProcessStartTimeUtc = DateTime.UtcNow.AddHours(-2),
+                DynamoVersion = "3.5.0",
+                DynamoMajorMinorVersion = "3.5",
+                DynamoBuild = "stale-build",
+                LastHeartbeatUtc = DateTime.UtcNow.AddHours(-1),
+                SessionId = Guid.NewGuid()
+            };
+
+            File.WriteAllText(
+                GraphLockService.GetLockFilePath(canonicalGraphPath),
+                JsonConvert.SerializeObject(lockData));
+        }
+    }
+}

--- a/test/DynamoCoreTests/Graph/Workspaces/GraphLockServiceTests.cs
+++ b/test/DynamoCoreTests/Graph/Workspaces/GraphLockServiceTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.IO;
+using System.Linq;
 using Dynamo.Graph.Workspaces;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
 namespace Dynamo.Tests.Graph.Workspaces
@@ -25,11 +27,17 @@ namespace Dynamo.Tests.Graph.Workspaces
 
                 var lockData = ReadLockData(result.GraphPath);
                 Assert.AreEqual(GraphLockService.CurrentSchemaVersion, lockData.SchemaVersion);
-                Assert.AreEqual(GraphLockService.GetCanonicalGraphPath(graphPath), lockData.GraphPath);
-                Assert.AreEqual("3.6.1", lockData.DynamoVersion);
-                Assert.AreEqual("3.6", lockData.DynamoMajorMinorVersion);
-                Assert.AreEqual("build-123", lockData.DynamoBuild);
                 Assert.AreNotEqual(Guid.Empty, lockData.SessionId);
+                Assert.AreEqual(GraphLockService.GetCanonicalGraphPath(graphPath), lockData.GraphPath);
+                Assert.AreEqual(Environment.UserName, lockData.UserName);
+                Assert.AreEqual(Environment.MachineName, lockData.MachineName);
+                Assert.Greater(lockData.ProcessId, 0);
+                Assert.AreNotEqual(DateTime.MinValue, lockData.ProcessStartUtc);
+                Assert.AreEqual("3.6.1", lockData.DynamoVersion);
+                Assert.AreEqual("3.6", lockData.DynamoMajorMinor);
+                Assert.AreNotEqual(DateTime.MinValue, lockData.AcquiredUtc);
+                Assert.AreEqual(lockData.AcquiredUtc, lockData.LastHeartbeatUtc);
+                CollectionAssert.AreEqual(GetExpectedLockPropertyNames(), ReadLockPropertyNames(result.GraphPath));
             }
         }
 
@@ -50,7 +58,7 @@ namespace Dynamo.Tests.Graph.Workspaces
                 Assert.AreEqual(GraphLockAcquisitionStatus.LockedByLiveSession, result.Status);
                 Assert.IsNotNull(result.ExistingLock);
                 Assert.AreEqual(Environment.UserName, result.ExistingLock.UserName);
-                Assert.AreEqual(Environment.MachineName, result.ExistingLock.HostName);
+                Assert.AreEqual(Environment.MachineName, result.ExistingLock.MachineName);
             }
         }
 
@@ -87,7 +95,7 @@ namespace Dynamo.Tests.Graph.Workspaces
 
                 var lockData = ReadLockData(result.GraphPath);
                 Assert.AreEqual(Environment.UserName, lockData.UserName);
-                Assert.AreEqual(Environment.MachineName, lockData.HostName);
+                Assert.AreEqual(Environment.MachineName, lockData.MachineName);
                 Assert.AreEqual("3.6.1", lockData.DynamoVersion);
             }
         }
@@ -114,8 +122,7 @@ namespace Dynamo.Tests.Graph.Workspaces
         {
             return new GraphLockService(
                 "3.6.1",
-                "build-123",
-                TimeSpan.FromMilliseconds(100),
+                heartbeatInterval: TimeSpan.FromMilliseconds(100),
                 registerProcessExit: false);
         }
 
@@ -131,21 +138,47 @@ namespace Dynamo.Tests.Graph.Workspaces
             var lockData = new GraphLockData
             {
                 SchemaVersion = GraphLockService.CurrentSchemaVersion,
+                SessionId = Guid.NewGuid(),
                 GraphPath = canonicalGraphPath,
                 UserName = "stale-user",
-                HostName = "stale-host",
+                MachineName = "stale-host",
                 ProcessId = 123,
-                ProcessStartTimeUtc = DateTime.UtcNow.AddHours(-2),
+                ProcessStartUtc = DateTime.UtcNow.AddHours(-2),
                 DynamoVersion = "3.5.0",
-                DynamoMajorMinorVersion = "3.5",
-                DynamoBuild = "stale-build",
-                LastHeartbeatUtc = DateTime.UtcNow.AddHours(-1),
-                SessionId = Guid.NewGuid()
+                DynamoMajorMinor = "3.5",
+                AcquiredUtc = DateTime.UtcNow.AddHours(-2),
+                LastHeartbeatUtc = DateTime.UtcNow.AddHours(-1)
             };
 
             File.WriteAllText(
                 GraphLockService.GetLockFilePath(canonicalGraphPath),
                 JsonConvert.SerializeObject(lockData));
+        }
+
+        private static string[] ReadLockPropertyNames(string graphPath)
+        {
+            return JObject.Parse(File.ReadAllText(GraphLockService.GetLockFilePath(graphPath)))
+                .Properties()
+                .Select(property => property.Name)
+                .ToArray();
+        }
+
+        private static string[] GetExpectedLockPropertyNames()
+        {
+            return new[]
+            {
+                "schemaVersion",
+                "sessionId",
+                "graphPath",
+                "userName",
+                "machineName",
+                "processId",
+                "processStartUtc",
+                "dynamoVersion",
+                "dynamoMajorMinor",
+                "acquiredUtc",
+                "lastHeartbeatUtc"
+            };
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

Adds sidecar graph lock detection for `.dyn` files so Dynamo warns when a graph is already open in another Dynamo instance. The lock file is versioned JSON next to the graph and contains exactly the agreed schema fields: schema/session IDs, normalized graph path, user/machine, process ID/start time, Dynamo version/major-minor, acquired time, and heartbeat time.

The WPF open flow now prompts users to open read-only, cancel, force open a live remote lock, or take over a stale lock depending on heartbeat and local process liveness. Lock ownership is tracked per workspace and released when the workspace closes, changes file path, or Dynamo shuts down.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Release Notes

Dynamo now warns before opening a graph already open elsewhere.

### Reviewers

Dynamo team

Focused test class added: `GraphLockServiceTests`, including an assertion that the serialized lock contains only the requested field names. `git diff --check HEAD~1 HEAD` passed. The focused `dotnet test` command could not run in this cloud image because `dotnet` is not installed (`dotnet: command not found`).

### FYIs

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04f07c7f-1ae3-436e-82e3-9f77bfe659e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04f07c7f-1ae3-436e-82e3-9f77bfe659e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

