### PR TITLE
DYN-9707: Graph-lock cleanup (L5, L8, L9, L10) + template lock guard

### DIFF
--- a/src/DynamoCore/Graph/Workspaces/Locking/GraphLockInfo.cs
+++ b/src/DynamoCore/Graph/Workspaces/Locking/GraphLockInfo.cs
@@ -11,9 +11,6 @@ namespace Dynamo.Graph.Workspaces.Locking
         [JsonProperty("sessionId")]
         internal Guid SessionId { get; set; }
 
-        [JsonProperty("graphPath")]
-        internal string GraphPath { get; set; }
-
         [JsonProperty("machineName")]
         internal string MachineName { get; set; }
 

--- a/src/DynamoCore/Graph/Workspaces/Locking/GraphLockManager.cs
+++ b/src/DynamoCore/Graph/Workspaces/Locking/GraphLockManager.cs
@@ -376,7 +376,9 @@ namespace Dynamo.Graph.Workspaces.Locking
 
         private void OnWorkspaceAdded(WorkspaceModel workspace)
         {
-            if (workspace == null || string.IsNullOrEmpty(workspace.FileName))
+            // Templates are opened as throwaway copies and may legitimately be open in several
+            // instances at once, so they are never locked.
+            if (workspace == null || workspace.IsTemplate || string.IsNullOrEmpty(workspace.FileName))
             {
                 return;
             }
@@ -385,17 +387,18 @@ namespace Dynamo.Graph.Workspaces.Locking
 
             if (locks.TryGetValue(normalizedPath, out var owned))
             {
+                // The lock was already acquired by the open flow; just associate the workspace.
                 owned.Workspace = workspace;
-                workspace.PropertyChanged += OnWorkspacePropertyChanged;
             }
             else if (!openingPaths.ContainsKey(normalizedPath))
             {
                 // The workspace was added with Save As: acquire and register a lock so the saved
-                // file is protected against being opened by another Dynamo instance
+                // file is protected against being opened by another Dynamo instance.
                 TryAcquireCore(normalizedPath, false, workspace);
             }
 
-            // Track future renames/saves for this workspace. Unsubscribe first to stay idempotent.
+            // Track future renames/saves for this workspace. Unsubscribe before subscribing so the
+            // handler is never attached twice if WorkspaceAdded is raised more than once for it.
             workspace.PropertyChanged -= OnWorkspacePropertyChanged;
             workspace.PropertyChanged += OnWorkspacePropertyChanged;
         }
@@ -410,6 +413,11 @@ namespace Dynamo.Graph.Workspaces.Locking
             if (workspace != null)
             {
                 workspace.PropertyChanged -= OnWorkspacePropertyChanged;
+
+                // Defensive: WorkspaceRemoveStarted normally releases the lock first, but release
+                // again here in case a future or test code path raises WorkspaceRemoved on its own.
+                // Release is idempotent when the lock has already been removed.
+                ReleaseWorkspace(workspace);
             }
         }
 
@@ -426,7 +434,7 @@ namespace Dynamo.Graph.Workspaces.Locking
             }
 
             var workspace = sender as WorkspaceModel;
-            if (workspace == null || string.IsNullOrEmpty(workspace.FileName))
+            if (workspace == null || workspace.IsTemplate || string.IsNullOrEmpty(workspace.FileName))
             {
                 return;
             }
@@ -498,7 +506,6 @@ namespace Dynamo.Graph.Workspaces.Locking
             return new GraphLockInfo
             {
                 SessionId = sessionId,
-                GraphPath = normalizedPath,
                 MachineName = machineName,
                 ProcessId = processId,
                 ProcessStartUtc = processStartTimeUtc,

--- a/src/DynamoCore/Graph/Workspaces/Locking/GraphLockOpenOutcome.cs
+++ b/src/DynamoCore/Graph/Workspaces/Locking/GraphLockOpenOutcome.cs
@@ -1,0 +1,23 @@
+namespace Dynamo.Graph.Workspaces.Locking
+{
+    /// <summary>
+    /// Describes how the most recent file-open attempt interacted with the graph-lock feature.
+    /// </summary>
+    internal enum GraphLockOpenOutcome
+    {
+        /// <summary>
+        /// The file was opened, or the lock could not be evaluated and the open proceeded anyway.
+        /// </summary>
+        Opened,
+
+        /// <summary>
+        /// The user cancelled at the graph-lock conflict prompt; no workspace was opened.
+        /// </summary>
+        Cancelled,
+
+        /// <summary>
+        /// The open was redirected to a Save As copy because the original was locked by another instance.
+        /// </summary>
+        RedirectedToCopy
+    }
+}

--- a/src/DynamoCore/Models/DynamoModel.cs
+++ b/src/DynamoCore/Models/DynamoModel.cs
@@ -166,15 +166,10 @@ namespace Dynamo.Models
         internal GraphLockManager GraphLockManager { get; private set; }
 
         /// <summary>
-        /// Indicates whether the last file open request was cancelled before a workspace was loaded.
+        /// Describes how the most recent file-open attempt interacted with the graph-lock feature
+        /// (opened normally, cancelled at the conflict prompt, or redirected to a Save As copy).
         /// </summary>
-        internal bool LastOpenFileOperationWasCancelled { get; private set; }
-
-        /// <summary>
-        /// Indicates whether the last file open was redirected to a copy because the requested
-        /// graph was already locked by another Dynamo instance (the Save As flow).
-        /// </summary>
-        internal bool LastOpenFileWasGraphLockRedirect { get; private set; }
+        internal GraphLockOpenOutcome LastGraphLockOpenOutcome { get; private set; }
 
         // Get ProgramData folder path (usually C:\ProgramData)
         static readonly string programDataPath = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
@@ -2196,13 +2191,12 @@ namespace Dynamo.Models
         /// execution mode specified in the file and set manual mode</param>
         public void OpenFileFromPath(string filePath, bool forceManualExecutionMode = false)
         {
-            LastOpenFileOperationWasCancelled = false;
-            LastOpenFileWasGraphLockRedirect = false;
+            LastGraphLockOpenOutcome = GraphLockOpenOutcome.Opened;
 
             var graphLockOutcome = GraphLockManager?.TryAcquire(filePath, true) ?? GraphLockAcquireResult.Acquired();
             if (!graphLockOutcome.ShouldOpen)
             {
-                LastOpenFileOperationWasCancelled = true;
+                LastGraphLockOpenOutcome = GraphLockOpenOutcome.Cancelled;
                 GraphLockManager?.CompleteOpen(filePath, false);
                 return;
             }
@@ -2216,13 +2210,13 @@ namespace Dynamo.Models
                 if (!string.IsNullOrEmpty(filePathToOpen) &&
                     !string.Equals(Path.GetFullPath(filePathToOpen), Path.GetFullPath(filePath), StringComparison.OrdinalIgnoreCase))
                 {
-                    LastOpenFileWasGraphLockRedirect = true;
+                    LastGraphLockOpenOutcome = GraphLockOpenOutcome.RedirectedToCopy;
                 }
             }
             catch (Exception pathEx) when (pathEx is ArgumentException || pathEx is NotSupportedException || pathEx is PathTooLongException)
             {
                 // If either path cannot be normalized, treat this as a non-redirect open.
-                LastOpenFileWasGraphLockRedirect = false;
+                LastGraphLockOpenOutcome = GraphLockOpenOutcome.Opened;
             }
 
             var openedSuccessfully = false;
@@ -2273,7 +2267,7 @@ namespace Dynamo.Models
         /// execution mode specified in the file and set manual mode</param>
         public void OpenTemplateFromPath(string filePath, bool forceManualExecutionMode = false)
         {
-            LastOpenFileOperationWasCancelled = false;
+            LastGraphLockOpenOutcome = GraphLockOpenOutcome.Opened;
 
             if (DynamoUtilities.PathHelper.isValidJson(filePath, out string fileContents, out Exception ex))
             {

--- a/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/DynamoViewModel.cs
@@ -24,6 +24,7 @@ using Dynamo.Graph.Connectors;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;
 using Dynamo.Graph.Workspaces;
+using Dynamo.Graph.Workspaces.Locking;
 using Dynamo.Interfaces;
 using Dynamo.Logging;
 using Dynamo.Models;
@@ -2243,7 +2244,7 @@ namespace Dynamo.ViewModels
                 // The file is already open in another Dynamo instance
                 // On cancel: nothing is opened, so undo the run block, make sure no trust warning is shown,
                 // restore the previous start-page state and stop.
-                if (Model.LastOpenFileOperationWasCancelled)
+                if (Model.LastGraphLockOpenOutcome == GraphLockOpenOutcome.Cancelled)
                 {
                     RunSettings.ForceBlockRun = false;
 
@@ -2257,7 +2258,7 @@ namespace Dynamo.ViewModels
 
                 // On Save as: the model is opened as a copy at a different location,
                 // re-evaluate the trust state for that copy.
-                if (Model.LastOpenFileWasGraphLockRedirect)
+                if (Model.LastGraphLockOpenOutcome == GraphLockOpenOutcome.RedirectedToCopy)
                 {
                     var openedPath = Model.CurrentWorkspace?.FileName;
                     if (!string.IsNullOrEmpty(openedPath))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose

Follow-up cleanup for the graph-lock feature (DYN-9707), addressing review findings L5/L8/L9/L10 and fixing a correctness gap (templates getting locked). Branched off the latest `DYN-9707-Warning-when-the-Dyn-file-is-opened-in-another-Dynamo-instance`.

- **L5 — drop unused `GraphLockInfo.GraphPath`.** The field was written in `BuildSelfInfo` but never read; the graph path is already implied by the sidecar's location (`<file>.dynlock`). Removed the property and its assignment. (Old sidecars that still contain `graphPath` are ignored on read.)
- **L8 — consolidate the two `Last*` side-channel flags.** Replaced `LastOpenFileOperationWasCancelled` and `LastOpenFileWasGraphLockRedirect` with a single `GraphLockOpenOutcome` enum (`Opened` / `Cancelled` / `RedirectedToCopy`) on `DynamoModel`, so the open result is a single coherent value that can't hold contradictory states. Updated `OpenFileFromPath`, `OpenTemplateFromPath`, and `DynamoViewModel.Open`. (Kept as an `internal` state property rather than changing the public `OpenFileFromPath` signature; a full return-value/event refactor remains an optional larger follow-up.)
- **L9 — `OnWorkspaceAdded` clarity + correctness.** Clarified the idempotent re-subscribe comment and removed a redundant `+=`. **Also added the missing `IsTemplate` guard** to `OnWorkspaceAdded` and `OnWorkspacePropertyChanged`: without it, opening a template (whose `FileName` is the template path) created a `.dynlock` on the template file, which would block opening the same template in multiple instances. Templates are now never locked.
- **L10 — defensive release in `OnWorkspaceRemoved`.** `WorkspaceRemoveStarted` already releases the lock; this adds an idempotent `ReleaseWorkspace` in `OnWorkspaceRemoved` too, guarding against a future/test path that raises `WorkspaceRemoved` without `WorkspaceRemoveStarted`.

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [x] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

Note on testing: changes were verified against source and for consistent line endings, but could not be compiled in this environment (no .NET 10 SDK). A Windows `Dynamo.All.sln` build is still required (the `DynamoViewModel` change is WPF), and NUnit coverage for `GraphLockManager` remains a recommended follow-up.

### Release Notes

N/A (internal cleanup; fixes a bug where opening a graph template could create a stray lock file that prevented opening the same template in another Dynamo instance).

### Reviewers

@ivaylo-matov

### FYIs

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c3be7ea-240e-4c24-b9f0-8f4e0840f944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c3be7ea-240e-4c24-b9f0-8f4e0840f944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

